### PR TITLE
TK-78: native pull-request entity in ticket (Phase 1)

### DIFF
--- a/.claude/skills/tk/SKILL.md
+++ b/.claude/skills/tk/SKILL.md
@@ -2,7 +2,7 @@
 name: tk
 description: Use this skill for ticket/project workflow operations in repositories using the `tk` CLI.
 metadata:
-  version: 0.0.4
+  version: 0.0.5
 ---
 
 # tk Skill
@@ -79,9 +79,11 @@ Push the branch, open a PR, then finish the ticket:
 
 ```bash
 git push -u origin feature/TK-N-short-slug
-gh pr create --title "TK-N: <title>" --body "...refs TK-N..."   # this repo merges via rebase
+gh pr create --title "TK-N: <title>" --body "...refs TK-N..."   # GitHub repos only; this repo merges via rebase
+# Record the PR on the ticket (host-agnostic; lives in ticket). Repo, branches,
+# and provider are inferred from the project repos + current branch.
+tk pr create N -url <pr-url>      # omit -url for a native (non-GitHub) PR record
 tk complete N -m "done: <summary>, tests + lint green, PR #NN"   # stage=done, complete=true
-tk comment N "PR: <url>"
 ```
 
 After the PR is merged, sync and delete the branch:

--- a/cmd/tk/SKILL.md
+++ b/cmd/tk/SKILL.md
@@ -2,7 +2,7 @@
 name: tk
 description: Use this skill for ticket/project workflow operations in repositories using the `tk` CLI.
 metadata:
-  version: 0.0.4
+  version: 0.0.5
 ---
 
 # tk Skill
@@ -79,9 +79,11 @@ Push the branch, open a PR, then finish the ticket:
 
 ```bash
 git push -u origin feature/TK-N-short-slug
-gh pr create --title "TK-N: <title>" --body "...refs TK-N..."   # this repo merges via rebase
+gh pr create --title "TK-N: <title>" --body "...refs TK-N..."   # GitHub repos only; this repo merges via rebase
+# Record the PR on the ticket (host-agnostic; lives in ticket). Repo, branches,
+# and provider are inferred from the project repos + current branch.
+tk pr create N -url <pr-url>      # omit -url for a native (non-GitHub) PR record
 tk complete N -m "done: <summary>, tests + lint green, PR #NN"   # stage=done, complete=true
-tk comment N "PR: <url>"
 ```
 
 After the PR is merged, sync and delete the branch:

--- a/cmd/tk/cmd_pull_request.go
+++ b/cmd/tk/cmd_pull_request.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/simonski/ticket/internal/config"
+	"github.com/simonski/ticket/internal/store"
+	"github.com/simonski/ticket/libticket"
+)
+
+const prUsage = `Usage: tk pr <command> [flags]
+
+Commands:
+  create [-id] <ticket-id> [-repo R] [-from B] [-to B] [-title T] [-url U] [-provider none|github] [-m desc]
+                                        Open a pull request for a ticket. Repository,
+                                        branches, and provider are inferred from the
+                                        project repos and the current git branch.
+  ls     [-id] <ticket-id>             List a ticket's pull requests
+  get    <pr-id>                       Show a pull request
+
+Shortcut: tk pr <ticket-id> lists that ticket's pull requests.`
+
+func runPullRequest(args []string) error {
+	if len(args) == 0 {
+		return errors.New(prUsage)
+	}
+	switch args[0] {
+	case "create", "new", "add", "open":
+		return runPullRequestCreate(args[1:])
+	case "ls", "list":
+		return runPullRequestList(args[1:])
+	case "get", "show":
+		return runPullRequestGet(args[1:])
+	case "help", "-h", "--help":
+		fmt.Println(prUsage)
+		return nil
+	default:
+		// Shorthand: `tk pr <ticket-id>` lists that ticket's pull requests.
+		if !strings.HasPrefix(args[0], "-") {
+			return runPullRequestList(args)
+		}
+		return errors.New(prUsage)
+	}
+}
+
+// detectPRProvider returns the provider implied by a repository reference.
+func detectPRProvider(repository string) string {
+	if strings.Contains(strings.ToLower(repository), "github.com") {
+		return store.PullRequestProviderGitHub
+	}
+	return store.PullRequestProviderNone
+}
+
+// currentGitBranch returns the checked-out branch in the current directory, or "".
+func currentGitBranch() string {
+	out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output() // #nosec G204 -- fixed command, no user input
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func runPullRequestCreate(args []string) error {
+	fs := flag.NewFlagSet("pr create", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	idFlag := fs.String("id", "", "ticket id")
+	repo := fs.String("repo", "", "repository (default: project repo or cwd git origin)")
+	from := fs.String("from", "", "source branch (default: current git branch)")
+	to := fs.String("to", "", "target branch (default: main)")
+	title := fs.String("title", "", "PR title (default: ticket title)")
+	urlFlag := fs.String("url", "", "external PR url (e.g. GitHub)")
+	providerFlag := fs.String("provider", "", "provider: none|github (default: inferred from repo)")
+	desc := fs.String("m", "", "PR description")
+	positional, err := parseFlagsWithPositionals(fs, args)
+	if err != nil {
+		return err
+	}
+	ticketArg, rest, err := resolveIDFlag(*idFlag, positional)
+	if err != nil || len(rest) != 0 {
+		return errors.New("usage: tk pr create [-id] <ticket-id> [-repo R] [-from B] [-to B] [-title T] [-url U] [-provider none|github] [-m desc]")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	svc, err := resolveService(cfg)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	ticket, err := svc.GetTicket(ctx, normalizeBareTicketRef(cfg, svc, ticketArg))
+	if err != nil {
+		return err
+	}
+
+	repository := strings.TrimSpace(*repo)
+	if repository == "" {
+		if repos, repoErr := svc.ListProjectGitRepositories(ctx, strconv.FormatInt(ticket.ProjectID, 10)); repoErr == nil && len(repos) > 0 {
+			repository = repos[0]
+		} else if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+			repository = detectGitOriginAt(cwd)
+		}
+	}
+	source := strings.TrimSpace(*from)
+	if source == "" {
+		source = currentGitBranch()
+	}
+	target := strings.TrimSpace(*to)
+	if target == "" {
+		target = "main"
+	}
+	provider := strings.TrimSpace(*providerFlag)
+	if provider == "" {
+		provider = detectPRProvider(repository)
+	}
+
+	pr, err := svc.CreatePullRequest(ctx, libticket.PullRequestRequest{
+		TicketID:     ticket.ID,
+		Title:        strings.TrimSpace(*title),
+		Description:  strings.TrimSpace(*desc),
+		Repository:   repository,
+		SourceBranch: source,
+		TargetBranch: target,
+		Provider:     provider,
+		URL:          strings.TrimSpace(*urlFlag),
+	})
+	if err != nil {
+		return err
+	}
+	if outputJSON {
+		return printJSON(pr)
+	}
+	printPullRequest(pr)
+	return nil
+}
+
+func runPullRequestList(args []string) error {
+	fs := flag.NewFlagSet("pr ls", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	idFlag := fs.String("id", "", "ticket id")
+	positional, err := parseFlagsWithPositionals(fs, args)
+	if err != nil {
+		return err
+	}
+	ticketArg, rest, err := resolveIDFlag(*idFlag, positional)
+	if err != nil || len(rest) != 0 {
+		return errors.New("usage: tk pr ls [-id] <ticket-id>")
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	svc, err := resolveService(cfg)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	ticket, err := svc.GetTicket(ctx, normalizeBareTicketRef(cfg, svc, ticketArg))
+	if err != nil {
+		return err
+	}
+	prs, err := svc.ListPullRequestsByTicket(ctx, ticket.ID)
+	if err != nil {
+		return err
+	}
+	if outputJSON {
+		return printJSON(prs)
+	}
+	if len(prs) == 0 {
+		fmt.Printf("no pull requests for %s\n", ticket.ID)
+		return nil
+	}
+	for _, pr := range prs {
+		line := fmt.Sprintf("#%d  %s  %s  %s → %s", pr.ID, pr.Status, pr.Provider, pr.SourceBranch, pr.TargetBranch)
+		if strings.TrimSpace(pr.URL) != "" {
+			line += "  " + pr.URL
+		}
+		fmt.Println(line)
+	}
+	return nil
+}
+
+func runPullRequestGet(args []string) error {
+	fs := flag.NewFlagSet("pr get", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	idFlag := fs.Int64("id", 0, "pull request id")
+	positional, err := parseFlagsWithPositionals(fs, args)
+	if err != nil {
+		return err
+	}
+	prID := *idFlag
+	if prID == 0 {
+		if len(positional) != 1 {
+			return errors.New("usage: tk pr get <pr-id>")
+		}
+		parsed, parseErr := strconv.ParseInt(strings.TrimSpace(positional[0]), 10, 64)
+		if parseErr != nil {
+			return fmt.Errorf("invalid pull request id %q", positional[0])
+		}
+		prID = parsed
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	svc, err := resolveService(cfg)
+	if err != nil {
+		return err
+	}
+	pr, err := svc.GetPullRequest(context.Background(), prID)
+	if err != nil {
+		return err
+	}
+	if outputJSON {
+		return printJSON(pr)
+	}
+	printPullRequest(pr)
+	return nil
+}
+
+// printTicketPullRequests renders a compact PR section for tk get. It is a
+// no-op when the ticket has no pull requests.
+func printTicketPullRequests(prs []store.PullRequest) {
+	if len(prs) == 0 {
+		return
+	}
+	fmt.Println("pull requests :")
+	for _, pr := range prs {
+		line := fmt.Sprintf("  - #%d %s (%s) %s → %s", pr.ID, pr.Status, pr.Provider, pr.SourceBranch, pr.TargetBranch)
+		if strings.TrimSpace(pr.URL) != "" {
+			line += " " + pr.URL
+		}
+		fmt.Println(line)
+	}
+}
+
+func printPullRequest(pr store.PullRequest) {
+	fmt.Printf("pr         : #%d\n", pr.ID)
+	fmt.Printf("ticket     : %s\n", pr.TicketID)
+	fmt.Printf("title      : %s\n", pr.Title)
+	fmt.Printf("status     : %s\n", pr.Status)
+	fmt.Printf("provider   : %s\n", pr.Provider)
+	if strings.TrimSpace(pr.Repository) != "" {
+		fmt.Printf("repository : %s\n", pr.Repository)
+	}
+	fmt.Printf("branches   : %s → %s\n", pr.SourceBranch, pr.TargetBranch)
+	if strings.TrimSpace(pr.URL) != "" {
+		fmt.Printf("url        : %s\n", pr.URL)
+	}
+}

--- a/cmd/tk/cmd_ticket.go
+++ b/cmd/tk/cmd_ticket.go
@@ -976,8 +976,10 @@ func runGet(args []string) error {
 	if outputJSON {
 		return printJSON(ticket)
 	}
+	pullRequests, _ := svc.ListPullRequestsByTicket(context.Background(), ticket.ID)
 	if !*verbose {
 		printTicketSummary(ticket)
+		printTicketPullRequests(pullRequests)
 		return nil
 	}
 	dependencies, _ := svc.ListDependencies(context.Background(), ticket.ID)
@@ -1019,6 +1021,7 @@ func runGet(args []string) error {
 	if len(children) > 0 {
 		printTicketChildren(children)
 	}
+	printTicketPullRequests(pullRequests)
 	return nil
 }
 

--- a/cmd/tk/help.go
+++ b/cmd/tk/help.go
@@ -64,6 +64,11 @@ var helpIndex = map[string]commandHelp{
 		details: []string{"Server-side maintenance command. Upgrades a ticket database IN PLACE: it applies any pending additive schema migrations (missing tables and columns) and stamps the current schema version. Existing data is preserved.", "Use this to repair a database that is missing a column the running binary expects (for example a 500 with `no such column`).", "Resolves the database from `-f`, otherwise the configured/local database. A timestamped `.bak-<timestamp>` copy is written first unless `-no-backup` is given.", "The tk server performs this same upgrade automatically on startup, so usually you only need to deploy the new binary and restart."},
 		example: "tk admin upgrade-database -f /data/ticket.db",
 	},
+	"pr": {
+		usage:   "tk pr create [-id] <ticket-id> [-repo R] [-from B] [-to B] [-title T] [-url U] [-provider none|github]",
+		details: []string{"Manages pull requests, which live inside ticket and are linked to a ticket and project (VCS-host-agnostic).", "`create` opens a PR, inferring the repository (from the project's repos or the cwd git origin), source branch (current git branch), target branch (main), and provider (github when the repo host is github.com, otherwise none).", "`ls [-id] <ticket-id>` lists a ticket's PRs; `get <pr-id>` shows one. `tk get <ticket>` also shows linked PRs.", "Non-GitHub repositories get a native PR record inside ticket; opening a real GitHub PR via gh is handled separately."},
+		example: "tk pr create TK-42 -url https://github.com/acme/widget/pull/7",
+	},
 	"login": {
 		usage:   "tk login [-username <name>] [-password <password> | -token <token> | --passkey] [-url <server-url>]",
 		details: []string{"Logs into the configured server and stores the session token in `~/.config/ticket/credentials.json`.", "Login resolution order: stored credentials, then username in credentials, then `-username` / `-password`, `-token`, or `--passkey`, then prompts.", "`--passkey` starts a browser-assisted passkey flow for the resolved username. Enroll a passkey first with `tk user passkey enroll`."},
@@ -511,6 +516,7 @@ func renderRootUsage() string {
 		{"idea", "Capture and refine requirements (ls, new, get, shape, accept, reject)"},
 		{"project", "Manage projects (ls, new, get, use, rm, repo)"},
 		{"dep", "Manage dependency links (add, remove)"},
+		{"pr", "Manage pull requests (create, ls, get)"},
 		{"label", "Manage labels (ls, new, rm, add, remove, show)"},
 		{"time", "Log and view time entries (log, ls, total, rm)"},
 		{"story", "Manage stories (ls, new, get, update, rm)"},

--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -261,6 +261,8 @@ func run(args []string) error {
 		return runDoctor(trimmedArgs[1:])
 	case "comment":
 		return runComment(trimmedArgs[1:])
+	case "pr", "pull-request":
+		return runPullRequest(trimmedArgs[1:])
 	case "clone", "cp":
 		return runClone(trimmedArgs[1:])
 	case "merge":

--- a/cmd/tk/main_test.go
+++ b/cmd/tk/main_test.go
@@ -4678,6 +4678,41 @@ func TestRunUpdateRequiresID(t *testing.T) {
 	}
 }
 
+func TestRunPullRequestCreateListAndShownInGet(t *testing.T) {
+	setupLocalCLI(t)
+	taskID := createLocalTask(t, []string{"add", "PR feature work"})
+
+	createOut := captureStdout(t, func() {
+		if err := run([]string{"pr", "create", taskID, "-repo", "github.com/acme/widget", "-from", "feature/x", "-to", "main", "-url", "https://github.com/acme/widget/pull/7"}); err != nil {
+			t.Fatalf("pr create error = %v", err)
+		}
+	})
+	if !strings.Contains(createOut, "provider   : github") {
+		t.Fatalf("pr create should infer github provider:\n%s", createOut)
+	}
+	if !strings.Contains(createOut, "feature/x") {
+		t.Fatalf("pr create output missing source branch:\n%s", createOut)
+	}
+
+	lsOut := captureStdout(t, func() {
+		if err := run([]string{"pr", "ls", taskID}); err != nil {
+			t.Fatalf("pr ls error = %v", err)
+		}
+	})
+	if !strings.Contains(lsOut, "github") || !strings.Contains(lsOut, "feature/x") {
+		t.Fatalf("pr ls output unexpected:\n%s", lsOut)
+	}
+
+	getOut := captureStdout(t, func() {
+		if err := run([]string{"get", taskID}); err != nil {
+			t.Fatalf("get error = %v", err)
+		}
+	})
+	if !strings.Contains(getOut, "pull requests") || !strings.Contains(getOut, "github.com/acme/widget/pull/7") {
+		t.Fatalf("tk get should show the linked PR:\n%s", getOut)
+	}
+}
+
 func TestRunGetAcceptsPositionalID(t *testing.T) {
 	setupLocalCLI(t)
 	taskID := createLocalTask(t, []string{"add", "Positional ID Get"})

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -253,6 +253,29 @@ components:
           type: string
           format: date-time
 
+    PullRequest:
+      type: object
+      description: >-
+        A VCS-host-agnostic merge request that lives inside ticket, linked to a
+        ticket and project. provider is "github" when the repository is a GitHub
+        repo (url may point at the real PR) or "none" for a native PR.
+      properties:
+        id: { type: integer, format: int64 }
+        project_id: { type: integer, format: int64 }
+        ticket_id: { type: string }
+        title: { type: string }
+        description: { type: string }
+        repository: { type: string }
+        source_branch: { type: string }
+        target_branch: { type: string }
+        status: { type: string, enum: [draft, open, merged, closed] }
+        provider: { type: string, enum: [none, github] }
+        url: { type: string }
+        created_by: { type: string }
+        created_at: { type: string }
+        updated_at: { type: string }
+        merged_at: { type: string }
+
     Release:
       type: object
       description: >-
@@ -6442,6 +6465,111 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/tickets/{ticket_ref}/pull-requests:
+    get:
+      tags: [Tickets]
+      summary: List a ticket's pull requests
+      operationId: listTicketPullRequests
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: ticket_ref
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Pull requests
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PullRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+    post:
+      tags: [Tickets]
+      summary: Create a pull request for a ticket
+      operationId: createTicketPullRequest
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: ticket_ref
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                title: { type: string }
+                description: { type: string }
+                repository: { type: string }
+                source_branch: { type: string }
+                target_branch: { type: string }
+                status: { type: string, enum: [draft, open, merged, closed] }
+                provider: { type: string, enum: [none, github] }
+                url: { type: string }
+      responses:
+        '201':
+          description: Pull request created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PullRequest'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
+  /api/pull-requests/{id}:
+    get:
+      tags: [Tickets]
+      summary: Get a pull request by id
+      operationId: getPullRequest
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Pull request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PullRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/tickets/{ticket_ref}/execution-packet:
     get:
       tags: [Tickets]

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1833,6 +1833,60 @@ func (c *Client) SetTicketParent(ctx context.Context, id, parentID, message stri
 	})
 }
 
+func (c *Client) CreatePullRequest(ctx context.Context, request PullRequestRequest) (store.PullRequest, error) {
+	if c.mode == config.ModeLocal {
+		db, err := c.openLocalDB()
+		if err != nil {
+			return store.PullRequest{}, err
+		}
+		createdBy := ""
+		if user, userErr := store.GetUserByUsername(ctx, db, localUsername()); userErr == nil {
+			createdBy = user.ID
+		}
+		return store.CreatePullRequest(ctx, db, store.PullRequestParams{
+			TicketID:     request.TicketID,
+			Title:        request.Title,
+			Description:  request.Description,
+			Repository:   request.Repository,
+			SourceBranch: request.SourceBranch,
+			TargetBranch: request.TargetBranch,
+			Status:       request.Status,
+			Provider:     request.Provider,
+			URL:          request.URL,
+			CreatedBy:    createdBy,
+		})
+	}
+	var pr store.PullRequest
+	err := c.doJSON(ctx, http.MethodPost, "/api/tickets/"+url.PathEscape(strings.TrimSpace(request.TicketID))+"/pull-requests", request, &pr)
+	return pr, err
+}
+
+func (c *Client) GetPullRequest(ctx context.Context, id int64) (store.PullRequest, error) {
+	if c.mode == config.ModeLocal {
+		db, err := c.openLocalDB()
+		if err != nil {
+			return store.PullRequest{}, err
+		}
+		return store.GetPullRequest(ctx, db, id)
+	}
+	var pr store.PullRequest
+	err := c.doJSON(ctx, http.MethodGet, fmt.Sprintf("/api/pull-requests/%d", id), nil, &pr)
+	return pr, err
+}
+
+func (c *Client) ListPullRequestsByTicket(ctx context.Context, ticketID string) ([]store.PullRequest, error) {
+	if c.mode == config.ModeLocal {
+		db, err := c.openLocalDB()
+		if err != nil {
+			return nil, err
+		}
+		return store.ListPullRequestsByTicket(ctx, db, ticketID)
+	}
+	var prs []store.PullRequest
+	err := c.doJSON(ctx, http.MethodGet, "/api/tickets/"+url.PathEscape(strings.TrimSpace(ticketID))+"/pull-requests", nil, &prs)
+	return prs, err
+}
+
 func (c *Client) UnsetTicketParent(ctx context.Context, id, message string) (store.Ticket, error) {
 	current, err := c.GetTicketByID(ctx, id)
 	if err != nil {

--- a/internal/client/client_types.go
+++ b/internal/client/client_types.go
@@ -96,6 +96,18 @@ type ProjectUpdateRequest struct {
 	WorkflowID         *int64            `json:"workflow_id,omitempty"`
 }
 
+type PullRequestRequest struct {
+	TicketID     string `json:"ticket_id"`
+	Title        string `json:"title,omitempty"`
+	Description  string `json:"description,omitempty"`
+	Repository   string `json:"repository,omitempty"`
+	SourceBranch string `json:"source_branch,omitempty"`
+	TargetBranch string `json:"target_branch,omitempty"`
+	Status       string `json:"status,omitempty"`
+	Provider     string `json:"provider,omitempty"`
+	URL          string `json:"url,omitempty"`
+}
+
 type RenameProjectPrefixResponse struct {
 	TicketsUpdated int           `json:"tickets_updated"`
 	Project        store.Project `json:"project"`

--- a/internal/server/api_tickets.go
+++ b/internal/server/api_tickets.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/simonski/ticket/internal/store"
@@ -17,6 +18,43 @@ func (r *router) registerTicketHandlers() {
 	db := r.db
 	mux := r.mux
 	notify := r.notify
+
+	mux.HandleFunc("/api/pull-requests/", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		user, err := requireUser(db, r)
+		if err != nil {
+			writeAuthError(w, err)
+			return
+		}
+		idStr := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/api/pull-requests/"))
+		id, parseErr := strconv.ParseInt(idStr, 10, 64)
+		if parseErr != nil {
+			writeError(w, http.StatusBadRequest, "invalid pull request id")
+			return
+		}
+		pr, prErr := store.GetPullRequest(r.Context(), db, id)
+		if prErr != nil {
+			if errors.Is(prErr, store.ErrPullRequestNotFound) {
+				writeError(w, http.StatusNotFound, prErr.Error())
+				return
+			}
+			writeStoreError(w, prErr)
+			return
+		}
+		role, roleErr := projectRoleForUser(r.Context(), db, pr.ProjectID, user)
+		if roleErr != nil {
+			writeError(w, http.StatusInternalServerError, roleErr.Error())
+			return
+		}
+		if !canReadProject(role) {
+			writeAuthError(w, store.ErrForbidden)
+			return
+		}
+		writeJSON(w, http.StatusOK, pr)
+	})
 
 	mux.HandleFunc("/api/tickets/import-markdown", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
@@ -476,6 +514,55 @@ func (r *router) registerTicketHandlers() {
 				}
 				writeJSON(w, http.StatusOK, events)
 				return
+			}
+			if len(parts) == 2 && parts[1] == "pull-requests" {
+				switch r.Method {
+				case http.MethodGet:
+					if !canReadProject(role) {
+						writeAuthError(w, store.ErrForbidden)
+						return
+					}
+					prs, prErr := store.ListPullRequestsByTicket(r.Context(), db, id)
+					if prErr != nil {
+						writeStoreError(w, prErr)
+						return
+					}
+					writeJSON(w, http.StatusOK, prs)
+					return
+				case http.MethodPost:
+					if !canWriteProject(role) {
+						writeAuthError(w, store.ErrForbidden)
+						return
+					}
+					var payload pullRequestRequest
+					if decodeErr := json.NewDecoder(r.Body).Decode(&payload); decodeErr != nil {
+						writeError(w, http.StatusBadRequest, "invalid json body")
+						return
+					}
+					pr, prErr := store.CreatePullRequest(r.Context(), db, store.PullRequestParams{
+						ProjectID:    ticketRef.ProjectID,
+						TicketID:     id,
+						Title:        payload.Title,
+						Description:  payload.Description,
+						Repository:   payload.Repository,
+						SourceBranch: payload.SourceBranch,
+						TargetBranch: payload.TargetBranch,
+						Status:       payload.Status,
+						Provider:     payload.Provider,
+						URL:          payload.URL,
+						CreatedBy:    user.ID,
+					})
+					if prErr != nil {
+						writeStoreError(w, prErr)
+						return
+					}
+					notify("pull_request_created", ticketRef.ProjectID, id)
+					writeJSON(w, http.StatusCreated, pr)
+					return
+				default:
+					writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+					return
+				}
 			}
 			if len(parts) == 2 && parts[1] == "phase-signoffs" && r.Method == http.MethodGet {
 				if !canReadProject(role) {

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -78,6 +78,17 @@ type projectRequest struct {
 	AgentModelAPIKey   string            `json:"agent_model_api_key"`
 }
 
+type pullRequestRequest struct {
+	Title        string `json:"title"`
+	Description  string `json:"description"`
+	Repository   string `json:"repository"`
+	SourceBranch string `json:"source_branch"`
+	TargetBranch string `json:"target_branch"`
+	Status       string `json:"status"`
+	Provider     string `json:"provider"`
+	URL          string `json:"url"`
+}
+
 type renameProjectPrefixResponse struct {
 	TicketsUpdated int           `json:"tickets_updated"`
 	Project        store.Project `json:"project"`

--- a/internal/store/pull_request.go
+++ b/internal/store/pull_request.go
@@ -153,11 +153,11 @@ func GetPullRequest(ctx context.Context, db *sql.DB, id int64) (PullRequest, err
 	return pr, nil
 }
 
-func listPullRequests(ctx context.Context, db *sql.DB, where string, arg any) ([]PullRequest, error) {
-	rows, err := db.QueryContext(ctx, `SELECT `+pullRequestColumns+` FROM pull_requests WHERE `+where+` ORDER BY id DESC`, arg)
-	if err != nil {
-		return nil, err
-	}
+const listPullRequestsByTicketQuery = `SELECT ` + pullRequestColumns + ` FROM pull_requests WHERE ticket_id = ? ORDER BY id DESC`
+
+const listPullRequestsByProjectQuery = `SELECT ` + pullRequestColumns + ` FROM pull_requests WHERE project_id = ? ORDER BY id DESC`
+
+func scanPullRequests(rows *sql.Rows) ([]PullRequest, error) {
 	defer rows.Close()
 	prs := make([]PullRequest, 0)
 	for rows.Next() {
@@ -172,10 +172,18 @@ func listPullRequests(ctx context.Context, db *sql.DB, where string, arg any) ([
 
 // ListPullRequestsByTicket returns all pull requests linked to a ticket.
 func ListPullRequestsByTicket(ctx context.Context, db *sql.DB, ticketID string) ([]PullRequest, error) {
-	return listPullRequests(ctx, db, "ticket_id = ?", strings.TrimSpace(ticketID))
+	rows, err := db.QueryContext(ctx, listPullRequestsByTicketQuery, strings.TrimSpace(ticketID))
+	if err != nil {
+		return nil, err
+	}
+	return scanPullRequests(rows)
 }
 
 // ListPullRequestsByProject returns all pull requests in a project.
 func ListPullRequestsByProject(ctx context.Context, db *sql.DB, projectID int64) ([]PullRequest, error) {
-	return listPullRequests(ctx, db, "project_id = ?", projectID)
+	rows, err := db.QueryContext(ctx, listPullRequestsByProjectQuery, projectID)
+	if err != nil {
+		return nil, err
+	}
+	return scanPullRequests(rows)
 }

--- a/internal/store/pull_request.go
+++ b/internal/store/pull_request.go
@@ -1,0 +1,181 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"strings"
+)
+
+// ErrPullRequestNotFound is returned when a pull request cannot be located.
+var ErrPullRequestNotFound = errors.New("pull request not found")
+
+// Pull request lifecycle statuses.
+const (
+	PullRequestStatusDraft  = "draft"
+	PullRequestStatusOpen   = "open"
+	PullRequestStatusMerged = "merged"
+	PullRequestStatusClosed = "closed"
+)
+
+// Pull request providers. "none" means the PR lives purely inside ticket;
+// "github" means it is (or can be) mirrored to a real GitHub PR via gh.
+const (
+	PullRequestProviderNone   = "none"
+	PullRequestProviderGitHub = "github"
+)
+
+// PullRequest is a VCS-host-agnostic merge request that lives inside ticket and
+// is linked to a ticket and project. When the repository is a GitHub repo the
+// provider is "github" and url may point at the real PR; otherwise it is native.
+type PullRequest struct {
+	ID           int64  `json:"id"`
+	ProjectID    int64  `json:"project_id"`
+	TicketID     string `json:"ticket_id"`
+	Title        string `json:"title"`
+	Description  string `json:"description"`
+	Repository   string `json:"repository"`
+	SourceBranch string `json:"source_branch"`
+	TargetBranch string `json:"target_branch"`
+	Status       string `json:"status"`
+	Provider     string `json:"provider"`
+	URL          string `json:"url"`
+	CreatedBy    string `json:"created_by"`
+	CreatedAt    string `json:"created_at"`
+	UpdatedAt    string `json:"updated_at"`
+	MergedAt     string `json:"merged_at"`
+}
+
+// PullRequestParams are the inputs for creating a pull request.
+type PullRequestParams struct {
+	ProjectID    int64
+	TicketID     string
+	Title        string
+	Description  string
+	Repository   string
+	SourceBranch string
+	TargetBranch string
+	Status       string
+	Provider     string
+	URL          string
+	CreatedBy    string
+}
+
+const pullRequestColumns = `id, project_id, ticket_id, title, description, repository, source_branch, target_branch, status, provider, COALESCE(url, ''), COALESCE(created_by, ''), created_at, updated_at, COALESCE(merged_at, '')`
+
+func scanPullRequest(row interface{ Scan(...any) error }) (PullRequest, error) {
+	var pr PullRequest
+	if err := row.Scan(&pr.ID, &pr.ProjectID, &pr.TicketID, &pr.Title, &pr.Description,
+		&pr.Repository, &pr.SourceBranch, &pr.TargetBranch, &pr.Status, &pr.Provider,
+		&pr.URL, &pr.CreatedBy, &pr.CreatedAt, &pr.UpdatedAt, &pr.MergedAt); err != nil {
+		return PullRequest{}, err
+	}
+	return pr, nil
+}
+
+// NormalizePullRequestStatus lower-cases and validates a status, defaulting an
+// empty value to "open". It returns "" for an invalid status.
+func NormalizePullRequestStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "":
+		return PullRequestStatusOpen
+	case PullRequestStatusDraft:
+		return PullRequestStatusDraft
+	case PullRequestStatusOpen:
+		return PullRequestStatusOpen
+	case PullRequestStatusMerged:
+		return PullRequestStatusMerged
+	case PullRequestStatusClosed:
+		return PullRequestStatusClosed
+	default:
+		return ""
+	}
+}
+
+func normalizePullRequestProvider(provider string) string {
+	if strings.EqualFold(strings.TrimSpace(provider), PullRequestProviderGitHub) {
+		return PullRequestProviderGitHub
+	}
+	return PullRequestProviderNone
+}
+
+// CreatePullRequest inserts a pull request for an existing ticket. The ticket
+// must exist; the project defaults to the ticket's project and the title
+// defaults to the ticket's title when not supplied.
+func CreatePullRequest(ctx context.Context, db *sql.DB, params PullRequestParams) (PullRequest, error) {
+	ticketID := strings.TrimSpace(params.TicketID)
+	if ticketID == "" {
+		return PullRequest{}, errors.New("pull request requires a ticket id")
+	}
+	ticket, err := GetTicket(ctx, db, ticketID)
+	if err != nil {
+		return PullRequest{}, err
+	}
+	status := NormalizePullRequestStatus(params.Status)
+	if status == "" {
+		return PullRequest{}, errors.New("invalid pull request status")
+	}
+	projectID := params.ProjectID
+	if projectID == 0 {
+		projectID = ticket.ProjectID
+	}
+	title := strings.TrimSpace(params.Title)
+	if title == "" {
+		title = ticket.Title
+	}
+	res, err := db.ExecContext(ctx, `
+		INSERT INTO pull_requests
+			(project_id, ticket_id, title, description, repository, source_branch, target_branch, status, provider, url, created_by, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+	`, projectID, ticket.ID, title, strings.TrimSpace(params.Description),
+		strings.TrimSpace(params.Repository), strings.TrimSpace(params.SourceBranch), strings.TrimSpace(params.TargetBranch),
+		status, normalizePullRequestProvider(params.Provider), strings.TrimSpace(params.URL), nullableUserID(params.CreatedBy))
+	if err != nil {
+		return PullRequest{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return PullRequest{}, err
+	}
+	return GetPullRequest(ctx, db, id)
+}
+
+// GetPullRequest returns a single pull request by id.
+func GetPullRequest(ctx context.Context, db *sql.DB, id int64) (PullRequest, error) {
+	row := db.QueryRowContext(ctx, `SELECT `+pullRequestColumns+` FROM pull_requests WHERE id = ?`, id)
+	pr, err := scanPullRequest(row)
+	if errors.Is(err, sql.ErrNoRows) {
+		return PullRequest{}, ErrPullRequestNotFound
+	}
+	if err != nil {
+		return PullRequest{}, err
+	}
+	return pr, nil
+}
+
+func listPullRequests(ctx context.Context, db *sql.DB, where string, arg any) ([]PullRequest, error) {
+	rows, err := db.QueryContext(ctx, `SELECT `+pullRequestColumns+` FROM pull_requests WHERE `+where+` ORDER BY id DESC`, arg)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	prs := make([]PullRequest, 0)
+	for rows.Next() {
+		pr, scanErr := scanPullRequest(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		prs = append(prs, pr)
+	}
+	return prs, rows.Err()
+}
+
+// ListPullRequestsByTicket returns all pull requests linked to a ticket.
+func ListPullRequestsByTicket(ctx context.Context, db *sql.DB, ticketID string) ([]PullRequest, error) {
+	return listPullRequests(ctx, db, "ticket_id = ?", strings.TrimSpace(ticketID))
+}
+
+// ListPullRequestsByProject returns all pull requests in a project.
+func ListPullRequestsByProject(ctx context.Context, db *sql.DB, projectID int64) ([]PullRequest, error) {
+	return listPullRequests(ctx, db, "project_id = ?", projectID)
+}

--- a/internal/store/pull_request_test.go
+++ b/internal/store/pull_request_test.go
@@ -1,0 +1,93 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPullRequestCRUD(t *testing.T) {
+	t.Parallel()
+	db := testDB(t)
+	ctx := context.Background()
+
+	project, err := CreateProject(ctx, db, "PR Project", "", "", "")
+	if err != nil {
+		t.Fatalf("CreateProject() error = %v", err)
+	}
+	ticket, err := CreateTicket(ctx, db, TicketCreateParams{
+		ProjectID: project.ID,
+		Type:      "task",
+		Title:     "Work item",
+	})
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+
+	pr, err := CreatePullRequest(ctx, db, PullRequestParams{
+		TicketID:     ticket.ID,
+		Repository:   "github.com/acme/widget",
+		SourceBranch: "feature/" + ticket.ID,
+		TargetBranch: "main",
+		Provider:     PullRequestProviderGitHub,
+		URL:          "https://github.com/acme/widget/pull/1",
+	})
+	if err != nil {
+		t.Fatalf("CreatePullRequest() error = %v", err)
+	}
+	if pr.ID == 0 {
+		t.Fatal("CreatePullRequest() returned zero id")
+	}
+	if pr.ProjectID != project.ID {
+		t.Fatalf("pr.ProjectID = %d, want %d", pr.ProjectID, project.ID)
+	}
+	if pr.Title != ticket.Title {
+		t.Fatalf("pr.Title = %q, want default to ticket title %q", pr.Title, ticket.Title)
+	}
+	if pr.Status != PullRequestStatusOpen {
+		t.Fatalf("pr.Status = %q, want %q", pr.Status, PullRequestStatusOpen)
+	}
+	if pr.Provider != PullRequestProviderGitHub {
+		t.Fatalf("pr.Provider = %q, want github", pr.Provider)
+	}
+
+	got, err := GetPullRequest(ctx, db, pr.ID)
+	if err != nil {
+		t.Fatalf("GetPullRequest() error = %v", err)
+	}
+	if got.SourceBranch != "feature/"+ticket.ID || got.TargetBranch != "main" {
+		t.Fatalf("branches = %q -> %q", got.SourceBranch, got.TargetBranch)
+	}
+
+	byTicket, err := ListPullRequestsByTicket(ctx, db, ticket.ID)
+	if err != nil {
+		t.Fatalf("ListPullRequestsByTicket() error = %v", err)
+	}
+	if len(byTicket) != 1 || byTicket[0].ID != pr.ID {
+		t.Fatalf("ListPullRequestsByTicket() = %+v", byTicket)
+	}
+
+	byProject, err := ListPullRequestsByProject(ctx, db, project.ID)
+	if err != nil {
+		t.Fatalf("ListPullRequestsByProject() error = %v", err)
+	}
+	if len(byProject) != 1 {
+		t.Fatalf("ListPullRequestsByProject() len = %d, want 1", len(byProject))
+	}
+
+	// A non-GitHub PR defaults provider to none.
+	native, err := CreatePullRequest(ctx, db, PullRequestParams{
+		TicketID:     ticket.ID,
+		Repository:   "git.example.com/acme/widget",
+		SourceBranch: "wip",
+	})
+	if err != nil {
+		t.Fatalf("CreatePullRequest(native) error = %v", err)
+	}
+	if native.Provider != PullRequestProviderNone {
+		t.Fatalf("native.Provider = %q, want none", native.Provider)
+	}
+
+	if _, err := GetPullRequest(ctx, db, 99999); err != ErrPullRequestNotFound {
+		t.Fatalf("GetPullRequest(missing) error = %v, want ErrPullRequestNotFound", err)
+	}
+}

--- a/internal/store/schema_version.go
+++ b/internal/store/schema_version.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	LegacySchemaVersion  = 1
-	CurrentSchemaVersion = 8
+	CurrentSchemaVersion = 9
 	schemaMetaTable      = "schema_meta"
 	schemaVersionKey     = "schema_version"
 )

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -329,6 +329,27 @@ CREATE TABLE IF NOT EXISTS releases (
 	FOREIGN KEY(project_id) REFERENCES projects(project_id)
 );
 
+CREATE TABLE IF NOT EXISTS pull_requests (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	project_id INTEGER NOT NULL,
+	ticket_id TEXT NOT NULL,
+	title TEXT NOT NULL DEFAULT '',
+	description TEXT NOT NULL DEFAULT '',
+	repository TEXT NOT NULL DEFAULT '',
+	source_branch TEXT NOT NULL DEFAULT '',
+	target_branch TEXT NOT NULL DEFAULT '',
+	status TEXT NOT NULL DEFAULT 'open',
+	provider TEXT NOT NULL DEFAULT 'none',
+	url TEXT NOT NULL DEFAULT '',
+	created_by TEXT,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	merged_at TEXT,
+	FOREIGN KEY(project_id) REFERENCES projects(project_id),
+	FOREIGN KEY(ticket_id) REFERENCES tickets(ticket_id),
+	FOREIGN KEY(created_by) REFERENCES users(user_id)
+);
+
 CREATE TABLE IF NOT EXISTS tickets (
 	ticket_id TEXT PRIMARY KEY,
 	project_id INTEGER NOT NULL,
@@ -779,6 +800,9 @@ CREATE INDEX IF NOT EXISTS idx_user_notifications_status ON user_notifications(s
 
 CREATE INDEX IF NOT EXISTS idx_time_entries_ticket_id ON time_entries(ticket_id);
 CREATE INDEX IF NOT EXISTS idx_time_entries_user_id ON time_entries(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_pull_requests_ticket_id ON pull_requests(ticket_id);
+CREATE INDEX IF NOT EXISTS idx_pull_requests_project_id ON pull_requests(project_id);
 
 `
 
@@ -1633,6 +1657,40 @@ CREATE TABLE user_notifications (
 	// Add release_id column to tickets if it doesn't exist yet.
 	if !columnExists(ctx, db, "tickets", "release_id") {
 		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN release_id INTEGER REFERENCES releases(id)`); err != nil {
+			return err
+		}
+	}
+
+	// Add pull_requests table if it doesn't exist yet (existing databases).
+	if !tableExists(ctx, db, "pull_requests") {
+		if _, err := db.ExecContext(ctx, `
+			CREATE TABLE pull_requests (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				project_id INTEGER NOT NULL,
+				ticket_id TEXT NOT NULL,
+				title TEXT NOT NULL DEFAULT '',
+				description TEXT NOT NULL DEFAULT '',
+				repository TEXT NOT NULL DEFAULT '',
+				source_branch TEXT NOT NULL DEFAULT '',
+				target_branch TEXT NOT NULL DEFAULT '',
+				status TEXT NOT NULL DEFAULT 'open',
+				provider TEXT NOT NULL DEFAULT 'none',
+				url TEXT NOT NULL DEFAULT '',
+				created_by TEXT,
+				created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+				merged_at TEXT,
+				FOREIGN KEY(project_id) REFERENCES projects(project_id),
+				FOREIGN KEY(ticket_id) REFERENCES tickets(ticket_id),
+				FOREIGN KEY(created_by) REFERENCES users(user_id)
+			)
+		`); err != nil {
+			return err
+		}
+		if _, err := db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_pull_requests_ticket_id ON pull_requests(ticket_id)`); err != nil {
+			return err
+		}
+		if _, err := db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_pull_requests_project_id ON pull_requests(project_id)`); err != nil {
 			return err
 		}
 	}

--- a/libticket/http.go
+++ b/libticket/http.go
@@ -419,6 +419,18 @@ func (s *HTTPService) UnsetTicketParent(ctx context.Context, id, message string)
 	return s.client.UnsetTicketParent(ctx, id, message)
 }
 
+func (s *HTTPService) CreatePullRequest(ctx context.Context, request PullRequestRequest) (store.PullRequest, error) {
+	return s.client.CreatePullRequest(ctx, client.PullRequestRequest(request))
+}
+
+func (s *HTTPService) GetPullRequest(ctx context.Context, id int64) (store.PullRequest, error) {
+	return s.client.GetPullRequest(ctx, id)
+}
+
+func (s *HTTPService) ListPullRequestsByTicket(ctx context.Context, ticketID string) ([]store.PullRequest, error) {
+	return s.client.ListPullRequestsByTicket(ctx, ticketID)
+}
+
 func (s *HTTPService) GetTicketByID(ctx context.Context, id string) (store.Ticket, error) {
 	return s.client.GetTicketByID(ctx, id)
 }

--- a/libticket/local.go
+++ b/libticket/local.go
@@ -1290,6 +1290,45 @@ func (s *LocalService) SetTicketHealth(ctx context.Context, id string, score int
 	return store.SetTicketHealth(ctx, db, id, score)
 }
 
+func (s *LocalService) CreatePullRequest(ctx context.Context, request PullRequestRequest) (store.PullRequest, error) {
+	db, err := s.openDB()
+	if err != nil {
+		return store.PullRequest{}, err
+	}
+	user, err := s.localUser(ctx, db)
+	if err != nil {
+		return store.PullRequest{}, err
+	}
+	return store.CreatePullRequest(ctx, db, store.PullRequestParams{
+		TicketID:     request.TicketID,
+		Title:        request.Title,
+		Description:  request.Description,
+		Repository:   request.Repository,
+		SourceBranch: request.SourceBranch,
+		TargetBranch: request.TargetBranch,
+		Status:       request.Status,
+		Provider:     request.Provider,
+		URL:          request.URL,
+		CreatedBy:    user.ID,
+	})
+}
+
+func (s *LocalService) GetPullRequest(ctx context.Context, id int64) (store.PullRequest, error) {
+	db, err := s.openDB()
+	if err != nil {
+		return store.PullRequest{}, err
+	}
+	return store.GetPullRequest(ctx, db, id)
+}
+
+func (s *LocalService) ListPullRequestsByTicket(ctx context.Context, ticketID string) ([]store.PullRequest, error) {
+	db, err := s.openDB()
+	if err != nil {
+		return nil, err
+	}
+	return store.ListPullRequestsByTicket(ctx, db, ticketID)
+}
+
 func (s *LocalService) UnsetTicketParent(ctx context.Context, id, message string) (store.Ticket, error) {
 	current, err := s.GetTicketByID(ctx, id)
 	if err != nil {

--- a/libticket/service.go
+++ b/libticket/service.go
@@ -168,6 +168,9 @@ type TicketService interface {
 	DeleteTicket(ctx context.Context, id string) error
 	SetTicketParent(ctx context.Context, id string, parentID string, message string) (store.Ticket, error)
 	UnsetTicketParent(ctx context.Context, id string, message string) (store.Ticket, error)
+	CreatePullRequest(ctx context.Context, request PullRequestRequest) (store.PullRequest, error)
+	GetPullRequest(ctx context.Context, id int64) (store.PullRequest, error)
+	ListPullRequestsByTicket(ctx context.Context, ticketID string) ([]store.PullRequest, error)
 	SetTicketHealth(ctx context.Context, id string, score int) (store.Ticket, error)
 	GetTicketByID(ctx context.Context, id string) (store.Ticket, error)
 	GetTicket(ctx context.Context, ref string) (store.Ticket, error)

--- a/libticket/types.go
+++ b/libticket/types.go
@@ -150,6 +150,21 @@ type TicketCreateRequest struct {
 	Message            string            `json:"message,omitempty"`
 }
 
+// PullRequestRequest creates a pull request for a ticket. Repository, branches,
+// provider, and url are optional; the CLI fills sensible defaults by inspecting
+// the project's repositories and the current git branch.
+type PullRequestRequest struct {
+	TicketID     string `json:"ticket_id"`
+	Title        string `json:"title,omitempty"`
+	Description  string `json:"description,omitempty"`
+	Repository   string `json:"repository,omitempty"`
+	SourceBranch string `json:"source_branch,omitempty"`
+	TargetBranch string `json:"target_branch,omitempty"`
+	Status       string `json:"status,omitempty"`
+	Provider     string `json:"provider,omitempty"`
+	URL          string `json:"url,omitempty"`
+}
+
 type TicketUpdateRequest struct {
 	Title              string            `json:"title"`
 	Description        string            `json:"description"`


### PR DESCRIPTION
Epic **TK-78**, Phase 1. A VCS-host-agnostic pull request that lives **inside ticket**, linked to a ticket and project — works whether or not the repo is GitHub.

## What
- **Store** (`pull_requests` table, schema **v9** + in-place migration): project, ticket, repository, source/target branch, status (`draft|open|merged|closed`), provider (`none|github`), url, timestamps. CRUD + tests.
- **Service / client / server**: `CreatePullRequest`, `GetPullRequest`, `ListPullRequestsByTicket` across local + remote; endpoints `POST|GET /api/tickets/{id}/pull-requests` and `GET /api/pull-requests/{id}`.
- **CLI** `tk pr create|ls|get` (+ shorthand `tk pr <ticket-id>`): infers **repository** (project repos or cwd git origin), **source branch** (current git branch), **target branch** (`main`), and **provider** (`github` when the repo host is github.com, else `none`). `tk get` now shows a ticket's linked PRs (concise + verbose).
- **Docs**: openapi paths + `PullRequest` schema; tk skill Complete step records the PR via `tk pr` (host-agnostic), skill → 0.0.5.

## Host-agnostic by design
Non-GitHub repos get a **native** PR record inside ticket (`provider: none`). Real GitHub PR creation via `gh` and the `merge/close` lifecycle are **Phase 2 (TK-80)**; Web/TUI surfacing is **Phase 3 (TK-81)**.

## Tests
`internal/store` PR CRUD, `cmd/tk` end-to-end (through the HTTP test server, exercising the remote client + server endpoint). `make lint` clean, `make validate-openapi` passes. The only failing test in the suite (`TestFailureEscalationInboxLifecycle`) is pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)