### PR TITLE
TK-82: tk pr ls project-wide listing + -open/-closed/-all filters

### DIFF
--- a/cmd/tk/cmd_pull_request.go
+++ b/cmd/tk/cmd_pull_request.go
@@ -22,7 +22,10 @@ Commands:
                                         Open a pull request for a ticket. Repository,
                                         branches, and provider are inferred from the
                                         project repos and the current git branch.
-  ls     [-id] <ticket-id>             List a ticket's pull requests
+  ls     [[-id] <ticket-id>] [-open|-closed|-all]
+                                        List pull requests. With no ticket, lists the
+                                        current project's PRs (open by default; -closed
+                                        or -all to widen). With a ticket, lists its PRs.
   get    <pr-id>                       Show a pull request
 
 Shortcut: tk pr <ticket-id> lists that ticket's pull requests.`
@@ -145,15 +148,21 @@ func runPullRequestCreate(args []string) error {
 func runPullRequestList(args []string) error {
 	fs := flag.NewFlagSet("pr ls", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
-	idFlag := fs.String("id", "", "ticket id")
+	idFlag := fs.String("id", "", "ticket id (list this ticket's PRs)")
+	openFlag := fs.Bool("open", false, "only open/draft pull requests")
+	closedFlag := fs.Bool("closed", false, "only merged/closed pull requests")
+	allFlag := fs.Bool("all", false, "all pull requests regardless of status")
 	positional, err := parseFlagsWithPositionals(fs, args)
 	if err != nil {
 		return err
 	}
-	ticketArg, rest, err := resolveIDFlag(*idFlag, positional)
-	if err != nil || len(rest) != 0 {
-		return errors.New("usage: tk pr ls [-id] <ticket-id>")
+	ticketArg := strings.TrimSpace(*idFlag)
+	if ticketArg == "" && len(positional) == 1 {
+		ticketArg = strings.TrimSpace(positional[0])
+	} else if (ticketArg != "" && len(positional) > 0) || len(positional) > 1 {
+		return errors.New("usage: tk pr ls [[-id] <ticket-id>] [-open|-closed|-all]")
 	}
+
 	cfg, err := config.Load()
 	if err != nil {
 		return err
@@ -163,29 +172,82 @@ func runPullRequestList(args []string) error {
 		return err
 	}
 	ctx := context.Background()
-	ticket, err := svc.GetTicket(ctx, normalizeBareTicketRef(cfg, svc, ticketArg))
+
+	var (
+		prs   []store.PullRequest
+		scope string
+		// Project-wide listing defaults to open; a single ticket defaults to all.
+		defaultClosed = false
+		showAll       = *allFlag
+	)
+	if ticketArg != "" {
+		ticket, ticketErr := svc.GetTicket(ctx, normalizeBareTicketRef(cfg, svc, ticketArg))
+		if ticketErr != nil {
+			return ticketErr
+		}
+		prs, err = svc.ListPullRequestsByTicket(ctx, ticket.ID)
+		scope = ticket.ID
+		if !*openFlag && !*closedFlag {
+			showAll = true // a specific ticket shows all of its PRs by default
+		}
+	} else {
+		_, projectSvc, project, projErr := resolveCurrentProjectClient()
+		if projErr != nil {
+			return projErr
+		}
+		prs, err = projectSvc.ListPullRequestsByProject(ctx, strconv.FormatInt(project.ID, 10))
+		scope = project.Prefix
+	}
 	if err != nil {
 		return err
 	}
-	prs, err := svc.ListPullRequestsByTicket(ctx, ticket.ID)
-	if err != nil {
-		return err
+
+	if *closedFlag {
+		defaultClosed = true
 	}
+	filtered := filterPullRequestsByStatus(prs, defaultClosed, showAll)
+
 	if outputJSON {
-		return printJSON(prs)
+		return printJSON(filtered)
 	}
-	if len(prs) == 0 {
-		fmt.Printf("no pull requests for %s\n", ticket.ID)
+	if len(filtered) == 0 {
+		fmt.Printf("no pull requests for %s\n", scope)
 		return nil
 	}
-	for _, pr := range prs {
-		line := fmt.Sprintf("#%d  %s  %s  %s → %s", pr.ID, pr.Status, pr.Provider, pr.SourceBranch, pr.TargetBranch)
+	for _, pr := range filtered {
+		line := fmt.Sprintf("#%d  %s  %s  %s  %s → %s", pr.ID, pr.TicketID, pr.Status, pr.Provider, pr.SourceBranch, pr.TargetBranch)
 		if strings.TrimSpace(pr.URL) != "" {
 			line += "  " + pr.URL
 		}
 		fmt.Println(line)
 	}
 	return nil
+}
+
+// pullRequestIsClosed reports whether a PR status is in the closed set
+// (merged or closed) versus the open set (draft or open).
+func pullRequestIsClosed(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case store.PullRequestStatusMerged, store.PullRequestStatusClosed:
+		return true
+	default:
+		return false
+	}
+}
+
+// filterPullRequestsByStatus returns all PRs when all is true, otherwise the
+// closed set when wantClosed is true, otherwise the open set.
+func filterPullRequestsByStatus(prs []store.PullRequest, wantClosed, all bool) []store.PullRequest {
+	if all {
+		return prs
+	}
+	out := make([]store.PullRequest, 0, len(prs))
+	for _, pr := range prs {
+		if pullRequestIsClosed(pr.Status) == wantClosed {
+			out = append(out, pr)
+		}
+	}
+	return out
 }
 
 func runPullRequestGet(args []string) error {

--- a/cmd/tk/main_test.go
+++ b/cmd/tk/main_test.go
@@ -4713,6 +4713,53 @@ func TestRunPullRequestCreateListAndShownInGet(t *testing.T) {
 	}
 }
 
+func TestRunPullRequestListProjectWideWithStatusFilters(t *testing.T) {
+	setupLocalCLI(t)
+	svc := localCLIService(t)
+
+	openTicket := createLocalTask(t, []string{"add", "Open PR ticket"})
+	mergedTicket := createLocalTask(t, []string{"add", "Merged PR ticket"})
+
+	if _, err := svc.CreatePullRequest(context.Background(), libticket.PullRequestRequest{
+		TicketID: openTicket, Repository: "github.com/acme/w", SourceBranch: "f-open",
+	}); err != nil {
+		t.Fatalf("CreatePullRequest(open) error = %v", err)
+	}
+	if _, err := svc.CreatePullRequest(context.Background(), libticket.PullRequestRequest{
+		TicketID: mergedTicket, Repository: "github.com/acme/w", SourceBranch: "f-merged", Status: "merged",
+	}); err != nil {
+		t.Fatalf("CreatePullRequest(merged) error = %v", err)
+	}
+
+	// Project-wide default: open only.
+	defaultOut := captureStdout(t, func() {
+		if err := run([]string{"pr", "ls"}); err != nil {
+			t.Fatalf("pr ls error = %v", err)
+		}
+	})
+	if !strings.Contains(defaultOut, openTicket) || strings.Contains(defaultOut, mergedTicket) {
+		t.Fatalf("pr ls (default) should show only open PRs:\n%s", defaultOut)
+	}
+
+	closedOut := captureStdout(t, func() {
+		if err := run([]string{"pr", "ls", "-closed"}); err != nil {
+			t.Fatalf("pr ls -closed error = %v", err)
+		}
+	})
+	if !strings.Contains(closedOut, mergedTicket) || strings.Contains(closedOut, openTicket) {
+		t.Fatalf("pr ls -closed should show only merged/closed PRs:\n%s", closedOut)
+	}
+
+	allOut := captureStdout(t, func() {
+		if err := run([]string{"pr", "ls", "-all"}); err != nil {
+			t.Fatalf("pr ls -all error = %v", err)
+		}
+	})
+	if !strings.Contains(allOut, openTicket) || !strings.Contains(allOut, mergedTicket) {
+		t.Fatalf("pr ls -all should show every PR:\n%s", allOut)
+	}
+}
+
 func TestRunGetAcceptsPositionalID(t *testing.T) {
 	setupLocalCLI(t)
 	taskID := createLocalTask(t, []string{"add", "Positional ID Get"})

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Ticket API
-  version: 0.1.1099
+  version: 0.1.1100
   description: |
     RESTful API for the Ticket project and issue management system.
     All endpoints are under `/api/`. Authentication uses Bearer tokens
@@ -5119,6 +5119,37 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /api/projects/{project_id}/pull-requests:
+    get:
+      tags: [Projects]
+      summary: List a project's pull requests
+      operationId: listProjectPullRequests
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: project_id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Pull requests
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PullRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+
   /api/projects/{project_id}/tickets:
     get:
       tags: [Projects]

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1887,6 +1887,23 @@ func (c *Client) ListPullRequestsByTicket(ctx context.Context, ticketID string) 
 	return prs, err
 }
 
+func (c *Client) ListPullRequestsByProject(ctx context.Context, projectRef string) ([]store.PullRequest, error) {
+	if c.mode == config.ModeLocal {
+		db, err := c.openLocalDB()
+		if err != nil {
+			return nil, err
+		}
+		project, err := store.GetProject(ctx, db, projectRef)
+		if err != nil {
+			return nil, err
+		}
+		return store.ListPullRequestsByProject(ctx, db, project.ID)
+	}
+	var prs []store.PullRequest
+	err := c.doJSON(ctx, http.MethodGet, "/api/projects/"+url.PathEscape(strings.TrimSpace(projectRef))+"/pull-requests", nil, &prs)
+	return prs, err
+}
+
 func (c *Client) UnsetTicketParent(ctx context.Context, id, message string) (store.Ticket, error) {
 	current, err := c.GetTicketByID(ctx, id)
 	if err != nil {

--- a/internal/server/api_projects.go
+++ b/internal/server/api_projects.go
@@ -395,6 +395,38 @@ func (r *router) registerProjectHandlers() {
 			writeJSON(w, http.StatusOK, tasks)
 			return
 		}
+		if len(parts) == 2 && parts[1] == "pull-requests" && r.Method == http.MethodGet {
+			project, err := store.GetProject(r.Context(), db, parts[0])
+			if err != nil {
+				if errors.Is(err, store.ErrProjectNotFound) {
+					writeError(w, http.StatusNotFound, err.Error())
+					return
+				}
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			user, err := requireUser(db, r)
+			if err != nil {
+				writeAuthError(w, err)
+				return
+			}
+			role, err := projectRoleForUser(r.Context(), db, project.ID, user)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, err.Error())
+				return
+			}
+			if !canReadProject(role) {
+				writeAuthError(w, store.ErrForbidden)
+				return
+			}
+			prs, prErr := store.ListPullRequestsByProject(r.Context(), db, project.ID)
+			if prErr != nil {
+				writeStoreError(w, prErr)
+				return
+			}
+			writeJSON(w, http.StatusOK, prs)
+			return
+		}
 		if len(parts) == 2 && parts[1] == "interventions" && r.Method == http.MethodGet {
 			project, err := store.GetProject(r.Context(), db, parts[0])
 			if err != nil {

--- a/libticket/http.go
+++ b/libticket/http.go
@@ -431,6 +431,10 @@ func (s *HTTPService) ListPullRequestsByTicket(ctx context.Context, ticketID str
 	return s.client.ListPullRequestsByTicket(ctx, ticketID)
 }
 
+func (s *HTTPService) ListPullRequestsByProject(ctx context.Context, projectRef string) ([]store.PullRequest, error) {
+	return s.client.ListPullRequestsByProject(ctx, projectRef)
+}
+
 func (s *HTTPService) GetTicketByID(ctx context.Context, id string) (store.Ticket, error) {
 	return s.client.GetTicketByID(ctx, id)
 }

--- a/libticket/local.go
+++ b/libticket/local.go
@@ -1329,6 +1329,18 @@ func (s *LocalService) ListPullRequestsByTicket(ctx context.Context, ticketID st
 	return store.ListPullRequestsByTicket(ctx, db, ticketID)
 }
 
+func (s *LocalService) ListPullRequestsByProject(ctx context.Context, projectRef string) ([]store.PullRequest, error) {
+	db, err := s.openDB()
+	if err != nil {
+		return nil, err
+	}
+	project, err := store.GetProject(ctx, db, projectRef)
+	if err != nil {
+		return nil, err
+	}
+	return store.ListPullRequestsByProject(ctx, db, project.ID)
+}
+
 func (s *LocalService) UnsetTicketParent(ctx context.Context, id, message string) (store.Ticket, error) {
 	current, err := s.GetTicketByID(ctx, id)
 	if err != nil {

--- a/libticket/service.go
+++ b/libticket/service.go
@@ -171,6 +171,7 @@ type TicketService interface {
 	CreatePullRequest(ctx context.Context, request PullRequestRequest) (store.PullRequest, error)
 	GetPullRequest(ctx context.Context, id int64) (store.PullRequest, error)
 	ListPullRequestsByTicket(ctx context.Context, ticketID string) ([]store.PullRequest, error)
+	ListPullRequestsByProject(ctx context.Context, projectRef string) ([]store.PullRequest, error)
 	SetTicketHealth(ctx context.Context, id string, score int) (store.Ticket, error)
 	GetTicketByID(ctx context.Context, id string) (store.Ticket, error)
 	GetTicket(ctx context.Context, ref string) (store.Ticket, error)


### PR DESCRIPTION
Builds on the Phase 1 PR entity (TK-78).

## What
- `tk pr ls` (no ticket) now lists the **current project's** pull requests — **open by default**, with `-closed` and `-all` to widen.
- `tk pr ls <ticket>` still lists a ticket's PRs (all of them by default).
- Status sets: open = `draft|open`, closed = `merged|closed`.
- Plumbing: `Service.ListPullRequestsByProject` (local + remote), `GET /api/projects/{id}/pull-requests`, openapi, tests.

## Tests
`cmd/tk` end-to-end (through the HTTP test server) covering default/`-closed`/`-all`; `make lint` clean; `make validate-openapi` passes.

Part of epic TK-78. (Pre-existing unrelated `TestFailureEscalationInboxLifecycle` still fails on main.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)