### PR TITLE
TK-81: surface pull requests in Web UI + TUI (Phase 3)

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -54,6 +54,10 @@ type ticketCreatedMsg store.Ticket
 type updateAvailableMsg string
 type errMsg struct{ err error }
 type projectsLoadedMsg []store.Project
+type pullRequestsLoadedMsg struct {
+	ticketID string
+	prs      []store.PullRequest
+}
 type workflowLoadedMsg []store.WorkflowWithStages
 type rolesLoadedMsg []store.Role
 type onboardingLoadedMsg struct {
@@ -109,10 +113,11 @@ type Model struct {
 	offset   int
 
 	// detail / edit
-	selected    *store.Ticket
-	form        editForm
-	newForm     *newTicketForm
-	projectForm *projectEditForm
+	selected             *store.Ticket
+	selectedPullRequests []store.PullRequest
+	form                 editForm
+	newForm              *newTicketForm
+	projectForm          *projectEditForm
 
 	// settings / theme picker
 	settingsCursor int
@@ -276,6 +281,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.projectCursor = i
 				break
 			}
+		}
+
+	case pullRequestsLoadedMsg:
+		// Only apply if it still matches the selected ticket (avoid stale results).
+		if m.selected != nil && m.selected.ID == msg.ticketID {
+			m.selectedPullRequests = msg.prs
 		}
 
 	case workflowLoadedMsg:
@@ -537,7 +548,9 @@ func (m Model) handleKeyList(key string) (tea.Model, tea.Cmd) {
 		if m.cursor < len(m.items) {
 			t := m.items[m.cursor].ticket
 			m.selected = &t
+			m.selectedPullRequests = nil
 			m.mode = modeDetail
+			return m, loadPullRequests(m.svc, t.ID)
 		}
 	case "e":
 		if m.cursor < len(m.items) {
@@ -572,12 +585,16 @@ func (m Model) handleKeyDetail(key string) (tea.Model, tea.Cmd) {
 			m.cursor--
 			t := m.items[m.cursor].ticket
 			m.selected = &t
+			m.selectedPullRequests = nil
+			return m, loadPullRequests(m.svc, t.ID)
 		}
 	case "down", "j", "s":
 		if m.cursor < len(m.items)-1 {
 			m.cursor++
 			t := m.items[m.cursor].ticket
 			m.selected = &t
+			m.selectedPullRequests = nil
+			return m, loadPullRequests(m.svc, t.ID)
 		}
 	}
 	return m, nil
@@ -1389,6 +1406,18 @@ func (m Model) viewDetail() []string {
 		addBlock("ticket guidance", guidanceText)
 	}
 
+	if len(m.selectedPullRequests) > 0 {
+		lines = append(lines, labelStyle.Render(padRight(" pull requests", inner)))
+		for _, pr := range m.selectedPullRequests {
+			line := fmt.Sprintf("  #%d %s (%s) %s → %s", pr.ID, pr.Status, pr.Provider, pr.SourceBranch, pr.TargetBranch)
+			if strings.TrimSpace(pr.URL) != "" {
+				line += "  " + pr.URL
+			}
+			lines = append(lines, valStyle.Render(padRight(truncate(line, inner-2), inner)))
+		}
+		lines = append(lines, "")
+	}
+
 	for len(lines) < m.height-3 {
 		lines = append(lines, lipgloss.NewStyle().Background(th.Bg).Render(strings.Repeat(" ", inner)))
 	}
@@ -2005,6 +2034,20 @@ func tickCmd() tea.Cmd {
 func loadTickets(svc libticket.Service, cfg config.Config) tea.Cmd {
 	return func() tea.Msg {
 		return loadTicketsSync(svc, cfg)
+	}
+}
+
+// loadPullRequests fetches a ticket's pull requests for the detail view.
+func loadPullRequests(svc libticket.Service, ticketID string) tea.Cmd {
+	return func() tea.Msg {
+		if strings.TrimSpace(ticketID) == "" {
+			return pullRequestsLoadedMsg{ticketID: ticketID}
+		}
+		prs, err := svc.ListPullRequestsByTicket(context.Background(), ticketID)
+		if err != nil {
+			return pullRequestsLoadedMsg{ticketID: ticketID}
+		}
+		return pullRequestsLoadedMsg{ticketID: ticketID, prs: prs}
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -120,6 +120,26 @@ func TestViewDetailShowsExtendedTicketContext(t *testing.T) {
 	}
 }
 
+func TestViewDetailShowsPullRequests(t *testing.T) {
+	m := newModel(nil, config.Config{}, Themes[ThemeTheGrey])
+	m.width = 100
+	m.height = 30
+	m.project = store.Project{ID: 1, Prefix: "PRJ", Title: "Alpha", Status: "open"}
+	selected := store.Ticket{ID: "PRJ-2", Type: "task", Title: "Work", Stage: store.StageDevelop, State: store.StateActive, Status: "develop/active"}
+	m.selected = &selected
+	m.selectedPullRequests = []store.PullRequest{{
+		ID: 5, TicketID: "PRJ-2", Status: "open", Provider: "github",
+		SourceBranch: "feature/PRJ-2", TargetBranch: "main", URL: "https://github.com/acme/w/pull/5",
+	}}
+
+	out := strings.Join(m.viewDetail(), "\n")
+	for _, needle := range []string{"pull requests", "#5", "feature/PRJ-2", "github", "https://github.com/acme/w/pull/5"} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("detail view missing %q:\n%s", needle, out)
+		}
+	}
+}
+
 func TestProjectEditAndNewTicketViewsShowLifecycleFields(t *testing.T) {
 	projectWorkflowID := int64(3)
 	ticketWorkflowID := int64(5)

--- a/web/default/index.html
+++ b/web/default/index.html
@@ -1000,6 +1000,10 @@
                     <button id="ticket-mark-ready-btn" class="btn btn-primary btn-sm" type="button">Mark Ready</button>
                 </div>
                 <div id="ticket-pr-url" class="hidden" style="font-size:0.85rem;margin-bottom:0.5rem;"></div>
+                <div id="ticket-pull-requests-section" class="modal-section hidden" style="margin-bottom:0.5rem;">
+                    <div class="section-heading">Pull Requests</div>
+                    <div id="ticket-pull-requests" class="history-list"></div>
+                </div>
                 <div class="field" style="margin-bottom:10px">
                     <label for="ticket-title">Title</label>
                     <input id="ticket-title" required>

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -244,6 +244,7 @@
             workflowRoleBank: document.getElementById("workflow-role-bank"),
             workflowValidationSummary: document.getElementById("workflow-validation-summary"),
             ticketModal: document.getElementById("ticket-modal"),
+            ticketPullRequests: document.getElementById("ticket-pull-requests"),
             ticketHistory: document.getElementById("ticket-history"),
             ticketComments: document.getElementById("ticket-comments"),
             ticketCommentInput: document.getElementById("ticket-comment-input"),
@@ -7169,6 +7170,9 @@
                 }
             }
             els.ticketModal.classList.add("open");
+            loadTicketPullRequests(ticket.id).catch((error) => {
+                if (els.ticketPullRequests) els.ticketPullRequests.innerHTML = "<div class=\"empty\">" + escapeHTML(error.message) + "</div>";
+            });
             loadTicketHistory(ticket.id).catch((error) => {
                 els.ticketHistory.innerHTML = "<div class=\"empty\">" + escapeHTML(error.message) + "</div>";
             });
@@ -7195,6 +7199,35 @@
             // Always open on the Details panel first; the Refinement tab is one click
             // away for stories in refinement.
             switchTicketTab("details");
+        }
+
+        // loadTicketPullRequests fetches and renders a ticket's pull requests
+        // (repo, branches, status, provider, url). The section hides when empty.
+        async function loadTicketPullRequests(ticketID) {
+            const section = document.getElementById("ticket-pull-requests-section");
+            const list = els.ticketPullRequests;
+            if (!list) return;
+            if (!ticketID) {
+                if (section) section.classList.add("hidden");
+                list.innerHTML = "";
+                return;
+            }
+            const prs = await api("/api/tickets/" + ticketID + "/pull-requests");
+            if (!Array.isArray(prs) || !prs.length) {
+                if (section) section.classList.add("hidden");
+                list.innerHTML = "";
+                return;
+            }
+            if (section) section.classList.remove("hidden");
+            list.innerHTML = prs.map((pr) => {
+                const branches = escapeHTML((pr.source_branch || "?") + " → " + (pr.target_branch || "?"));
+                const meta = escapeHTML("#" + pr.id + " · " + (pr.status || "open") + " · " + (pr.provider || "none"));
+                const repo = pr.repository ? "<div class=\"meta\">" + escapeHTML(pr.repository) + "</div>" : "";
+                const link = pr.url
+                    ? "<a href=\"" + escapeHTML(pr.url) + "\" target=\"_blank\" rel=\"noopener\">" + escapeHTML(pr.url) + "</a>"
+                    : "";
+                return "<div class=\"history-item\"><div>" + meta + " — " + branches + "</div>" + repo + (link ? "<div>" + link + "</div>" : "") + "</div>";
+            }).join("");
         }
 
         // loadTicketPrompt fetches and renders the agent prompt preview for a ticket.


### PR DESCRIPTION
Epic TK-78, Phase 3 (final).

## What
- **Web UI:** the ticket modal fetches `/api/tickets/{id}/pull-requests` and renders a **Pull Requests** section (id · status · provider, source → target branch, repository, and a url link when set). Hidden when the ticket has no PRs.
- **TUI:** the detail view loads the selected ticket's PRs (on enter and up/down navigation) and renders a `pull requests` block (id, status, provider, branches, url).

## Tests
TUI `viewDetail` PR-rendering test; full `internal/tui` suite green; `make lint` clean. (Web JS verified by reasoning + the existing API tests cover the endpoint; the Playwright browser job is environment-broken here, unrelated to this change.)

Completes epic **TK-78** (native PR entity: Phase 1 #10, filters #11, lifecycle+gh #12, this UI phase).

🤖 Generated with [Claude Code](https://claude.com/claude-code)