### PR TITLE
TK-65: comprehensive agent prompt (VCS + execution steps)

### DIFF
--- a/cmd/tk/cmd_prompt.go
+++ b/cmd/tk/cmd_prompt.go
@@ -155,9 +155,46 @@ func buildPromptForTicket(ctx context.Context, svc promptService, ticketRef stri
 	b.WriteString("Name: " + stageName + "\n")
 	b.WriteString("Definition of Ready: " + stageDOR + "\n")
 	b.WriteString("Definition of Done: " + stageDOD + "\n")
-	b.WriteString("Acceptance Criteria: " + stageAC + "\n")
+	b.WriteString("Acceptance Criteria: " + stageAC + "\n\n")
+
+	repo, baseBranch, workBranch := resolveTicketVCS(ticket, project.GitRepository)
+	b.WriteString("VCS\n")
+	b.WriteString("Ticket: " + promptValue(ticket.ID) + "\n")
+	b.WriteString("Repository: " + repo + "\n")
+	b.WriteString("Branch to take from (base): " + baseBranch + "\n")
+	b.WriteString("Branch to commit to (work): " + workBranch + "\n\n")
+
+	b.WriteString("EXECUTION STEPS\n")
+	b.WriteString("1. Set up the agent: load its skills, sub-agents, and this codebase.\n")
+	b.WriteString("2. Build the project first to confirm a green baseline before changing anything.\n")
+	b.WriteString("3. Set up the environment (dependencies, config, env vars).\n")
+	b.WriteString("4. Clone the repository " + repo + " (skip if already present).\n")
+	b.WriteString("5. Create and check out the work branch " + workBranch + " from " + baseBranch + ".\n")
+	b.WriteString("6. Do the work for " + promptValue(ticket.ID) + " to satisfy the acceptance criteria above.\n")
+	b.WriteString("7. Run the tests (and linters); fix until green.\n")
+	b.WriteString("8. Commit and push " + workBranch + ", then stop for review.\n")
 
 	return b.String(), nil
+}
+
+// resolveTicketVCS derives the repository and the base/work branches for a
+// ticket's work. The repository falls back from the ticket to the project; the
+// work branch defaults to feature/<ticket-id> when the ticket has no branch set;
+// the base branch defaults to main.
+func resolveTicketVCS(ticket store.Ticket, projectRepo string) (repo, baseBranch, workBranch string) {
+	repo = strings.TrimSpace(ticket.GitRepository)
+	if repo == "" {
+		repo = strings.TrimSpace(projectRepo)
+	}
+	if repo == "" {
+		repo = "N/A"
+	}
+	baseBranch = "main"
+	workBranch = strings.TrimSpace(ticket.GitBranch)
+	if workBranch == "" {
+		workBranch = "feature/" + ticket.ID
+	}
+	return repo, baseBranch, workBranch
 }
 
 type promptService interface {

--- a/cmd/tk/main_test.go
+++ b/cmd/tk/main_test.go
@@ -2535,6 +2535,8 @@ func TestPrintTaskDetailsIncludesAcceptanceCriteria(t *testing.T) {
 		{label: "Priority", value: "1"},
 		{label: "Created", value: "2026-03-01 12:00:00"},
 		{label: "LastModified", value: "2026-03-02 09:30:00"},
+		{label: "Branch from", value: "main"},
+		{label: "Branch to", value: "feature/TK-42"},
 	} {
 		if !hasDetailField(output, tc.label, tc.value) {
 			t.Fatalf("printTicketDetails() missing %s field:\n%s", tc.label, output)
@@ -3351,6 +3353,12 @@ func TestRunPromptBuildsPlaintextSections(t *testing.T) {
 		"STAGE",
 		"Definition of Ready: Stage acceptance criteria",
 		"Acceptance Criteria: Stage acceptance criteria",
+		"VCS",
+		"Branch to take from (base): main",
+		"Branch to commit to (work): feature/" + taskID,
+		"EXECUTION STEPS",
+		"Run the tests",
+		"push feature/" + taskID,
 	} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("prompt output missing %q:\n%s", want, output)

--- a/cmd/tk/printer.go
+++ b/cmd/tk/printer.go
@@ -460,6 +460,15 @@ func printTicketDetails(ticket store.Ticket, dependencies []store.Dependency, hi
 		ticketField{label: "LastModified", value: ticket.UpdatedAt},
 		ticketField{label: "Acceptance Criteria", value: ticket.AcceptanceCriteria},
 	)
+	// VCS context so the ticket reads as an executable prompt (TK-65).
+	repo, baseBranch, workBranch := resolveTicketVCS(ticket, "")
+	if strings.TrimSpace(ticket.GitRepository) != "" {
+		fields = append(fields, ticketField{label: "Repository", value: repo})
+	}
+	fields = append(fields,
+		ticketField{label: "Branch from", value: baseBranch},
+		ticketField{label: "Branch to", value: workBranch},
+	)
 	maxLabelWidth := 0
 	for _, field := range fields {
 		if len(field.label) > maxLabelWidth {


### PR DESCRIPTION
`tk prompt` and `tk get` now read as an executable agent prompt.

## What
- **`tk prompt`** gains two sections after the existing PROJECT/EPIC/STORY/TICKET/ROLE/STAGE guidance:
  - **VCS** — ticket id, repository (ticket → project fallback), *branch to take from* (base = `main`), *branch to commit to* (work = the ticket's branch or `feature/<id>`).
  - **EXECUTION STEPS** — the staged sequence from the ticket: set up agent → build (green baseline) → set up environment → clone repo → create/checkout work branch → do the work → run tests → commit/push & stop.
- **`tk get -v`** shows the same `Branch from` / `Branch to` (and `Repository` when the ticket has one); the ticket id (`Key`) was already shown.
- Shared `resolveTicketVCS` helper keeps both surfaces consistent.

## Tests
Extended `TestRunPromptBuildsPlaintextSections` (asserts VCS + execution steps + `feature/<id>`) and the `printTicketDetails` test (Branch from/to). `make lint` clean; full `cmd/tk` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)