### PR TITLE
TK-57: show in-progress + start time on tk get

### DIFF
--- a/cmd/tk/main_test.go
+++ b/cmd/tk/main_test.go
@@ -2492,6 +2492,34 @@ func TestRunListIndentsTitlesByTreeDepth(t *testing.T) {
 	}
 }
 
+func TestPrintTicketDetailsShowsInProgressWithStartTime(t *testing.T) {
+	output := captureStdout(t, func() {
+		printTicketDetails(store.Ticket{
+			ID: "TK-9", Title: "Active work", Type: "task",
+			Status: "develop/active", Stage: "develop", State: "active", Assignee: "admin",
+		}, nil, []store.HistoryEvent{
+			{EventType: "ticket_created", CreatedAt: "2026-03-01 12:00:00", Payload: `{"status":"design/idle"}`},
+			{EventType: "ticket_updated", CreatedAt: "2026-03-02 09:00:00", Payload: `{"status":"develop/active"}`},
+		}, nil, nil, 0, "", "", 0, 0, 0)
+	})
+	if !hasDetailLabel(output, "In Progress") {
+		t.Fatalf("expected In Progress field:\n%s", output)
+	}
+	if !strings.Contains(output, "active since 2026-03-02 09:00:00") {
+		t.Fatalf("expected active-since timestamp:\n%s", output)
+	}
+
+	// An idle ticket has no In Progress line.
+	idleOut := captureStdout(t, func() {
+		printTicketDetails(store.Ticket{
+			ID: "TK-10", Title: "Idle", Type: "task", Status: "design/idle", Stage: "design", State: "idle",
+		}, nil, nil, nil, nil, 0, "", "", 0, 0, 0)
+	})
+	if hasDetailLabel(idleOut, "In Progress") {
+		t.Fatalf("idle ticket should not show In Progress:\n%s", idleOut)
+	}
+}
+
 func TestPrintTaskDetailsIncludesAcceptanceCriteria(t *testing.T) {
 	output := captureStdout(t, func() {
 		printTicketDetails(store.Ticket{

--- a/cmd/tk/printer.go
+++ b/cmd/tk/printer.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"text/tabwriter"
+	"time"
 	"unicode/utf8"
 
 	"golang.org/x/term"
@@ -417,6 +418,64 @@ func printRequestContext(resp libticket.TicketRequestResponse) {
 	}
 }
 
+// stateFromHistoryPayload extracts the lifecycle state recorded in a history
+// event payload (e.g. {"status":"develop/active"}), if present.
+func stateFromHistoryPayload(payload string) (string, bool) {
+	var p struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal([]byte(payload), &p); err != nil || strings.TrimSpace(p.Status) == "" {
+		return "", false
+	}
+	_, state, err := store.ParseLifecycleStatus(p.Status)
+	if err != nil {
+		return "", false
+	}
+	return state, true
+}
+
+// activeSinceFromHistory returns the timestamp at which the ticket entered its
+// current active streak (oldest-first history), or "" if it is not active or no
+// transition is recorded. Events without a status are ignored.
+func activeSinceFromHistory(history []store.HistoryEvent) string {
+	activeSince := ""
+	prevActive := false
+	for _, e := range history {
+		state, ok := stateFromHistoryPayload(e.Payload)
+		if !ok {
+			continue
+		}
+		isActive := state == store.StateActive
+		switch {
+		case isActive && !prevActive:
+			activeSince = e.CreatedAt
+		case !isActive:
+			activeSince = ""
+		}
+		prevActive = isActive
+	}
+	return activeSince
+}
+
+// humanizeSince renders a coarse elapsed time since a stored UTC timestamp.
+func humanizeSince(ts string) string {
+	t, err := time.Parse("2006-01-02 15:04:05", strings.TrimSpace(ts))
+	if err != nil {
+		return ""
+	}
+	d := time.Since(t.UTC())
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
+}
+
 func printTicketDetails(ticket store.Ticket, dependencies []store.Dependency, history []store.HistoryEvent, workflowStages []store.WorkflowStage, labels []store.Label, totalMinutes int, parentKey, cloneKey string, childTotal, childOpen, childClosed int) {
 	dependsOn := formatDependsOn(dependencies)
 
@@ -460,6 +519,21 @@ func printTicketDetails(ticket store.Ticket, dependencies []store.Dependency, hi
 		ticketField{label: "LastModified", value: ticket.UpdatedAt},
 		ticketField{label: "Acceptance Criteria", value: ticket.AcceptanceCriteria},
 	)
+	// In-progress indicator with start time + elapsed (TK-57). Derived from the
+	// already-loaded history so there is no extra query.
+	if strings.EqualFold(strings.TrimSpace(ticket.State), store.StateActive) {
+		val := "active"
+		if since := activeSinceFromHistory(history); since != "" {
+			val = "active since " + since
+			if elapsed := humanizeSince(since); elapsed != "" {
+				val += " (" + elapsed + ")"
+			}
+		}
+		if owner := strings.TrimSpace(ticket.Assignee); owner != "" {
+			val += " — " + owner
+		}
+		fields = append(fields, ticketField{label: "In Progress", value: val})
+	}
 	// VCS context so the ticket reads as an executable prompt (TK-65).
 	repo, baseBranch, workBranch := resolveTicketVCS(ticket, "")
 	if strings.TrimSpace(ticket.GitRepository) != "" {


### PR DESCRIPTION
When a ticket is active, `tk get -v` now shows an **In Progress** line:
`active since <ts> (<elapsed>) — <assignee>`. The start time is the latest transition into the current active streak, derived from the **already-loaded history** (no extra query); the elapsed is humanized (`just now`/`Nm`/`Nh`/`Nd`). Idle tickets show no line.

Context: much of TK-57 is already satisfied — the tk skill now does `claim`+`active` when working a ticket, and `tk ls` groups active tickets at the top with their assignee (TK-73), so "is it in progress, by whom" is already visible. This adds the missing **start time / elapsed**.

## Tests
`TestPrintTicketDetailsShowsInProgressWithStartTime`. `make lint` clean; full `cmd/tk` suite green.

## Deferred (filed as follow-ups under TK-57)
- **TK-88** persistent `started_at` column (accurate without history)
- **TK-89** `tk ls` "active for" elapsed column
- **TK-90** TUI + web in-progress/elapsed surfacing

🤖 Generated with [Claude Code](https://claude.com/claude-code)