### PR TITLE
TK-88: persistent started_at column for tickets

### DIFF
--- a/cmd/tk/printer.go
+++ b/cmd/tk/printer.go
@@ -523,7 +523,13 @@ func printTicketDetails(ticket store.Ticket, dependencies []store.Dependency, hi
 	// already-loaded history so there is no extra query.
 	if strings.EqualFold(strings.TrimSpace(ticket.State), store.StateActive) {
 		val := "active"
-		if since := activeSinceFromHistory(history); since != "" {
+		// Prefer the persistent started_at column (TK-88); fall back to the
+		// history-derived start for tickets that went active before the column.
+		since := strings.TrimSpace(ticket.StartedAt)
+		if since == "" {
+			since = activeSinceFromHistory(history)
+		}
+		if since != "" {
 			val = "active since " + since
 			if elapsed := humanizeSince(since); elapsed != "" {
 				val += " (" + elapsed + ")"

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -490,6 +490,9 @@ components:
         updated_at:
           type: string
           format: date-time
+        started_at:
+          type: string
+          description: When the ticket last entered the active state (in-progress since).
 
     ResolvedGuidance:
       type: object

--- a/internal/store/reorder.go
+++ b/internal/store/reorder.go
@@ -92,7 +92,7 @@ func ReorderChildTickets(ctx context.Context, db *sql.DB, parentID string, order
 // explicit sort_order (creation order as tie-break).
 func ListChildTicketsByOrder(ctx context.Context, db *sql.DB, parentID string) ([]Ticket, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, '')
+		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
 		FROM tickets
 		WHERE parent_id = ? AND deleted = 0
 		ORDER BY sort_order, created_at, ticket_id

--- a/internal/store/schema_version.go
+++ b/internal/store/schema_version.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	LegacySchemaVersion  = 1
-	CurrentSchemaVersion = 9
+	CurrentSchemaVersion = 10
 	schemaMetaTable      = "schema_meta"
 	schemaVersionKey     = "schema_version"
 )

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1726,6 +1726,13 @@ CREATE TABLE user_notifications (
 		}
 	}
 
+	// Add started_at to tickets: when a ticket enters the active state (TK-88).
+	if !columnExists(ctx, db, "tickets", "started_at") {
+		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN started_at TEXT NOT NULL DEFAULT ''`); err != nil {
+			return err
+		}
+	}
+
 	// Add agent_role to users (refiner, developer, tester etc.).
 	if !columnExists(ctx, db, "users", "agent_role") {
 		if _, err := db.ExecContext(ctx, `ALTER TABLE users ADD COLUMN agent_role TEXT NOT NULL DEFAULT ''`); err != nil {

--- a/internal/store/ticket.go
+++ b/internal/store/ticket.go
@@ -54,6 +54,7 @@ type Ticket struct {
 	ReleaseID               *int        `json:"release_id,omitempty"`
 	RecommendedReady        bool        `json:"recommended_ready"`
 	PrURL                   string      `json:"pr_url,omitempty"`
+	StartedAt               string      `json:"started_at,omitempty"`
 	CreatedBy               string      `json:"created_by"`
 	CreatedAt               string      `json:"created_at"`
 	UpdatedAt               string      `json:"updated_at"`
@@ -553,11 +554,14 @@ writeTicket:
 	if !reopened && current.Complete {
 		completeVal = 1
 	}
+	// started_at records when work began: stamp it on the transition INTO the
+	// active state; otherwise preserve the existing value (TK-88).
 	result, err := db.ExecContext(ctx, `
 		UPDATE tickets
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, git_branch = ?, parent_id = ?, assignee = ?, workflow_stage_id = ?, role_id = ?, stage = ?, state = ?, status = ?, priority = ?, sort_order = ?, estimate_effort = ?, estimate_complete = ?, complete = ?, type = ?, updated_at = CURRENT_TIMESTAMP
+		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, git_branch = ?, parent_id = ?, assignee = ?, workflow_stage_id = ?, role_id = ?, stage = ?, state = ?, status = ?, priority = ?, sort_order = ?, estimate_effort = ?, estimate_complete = ?, complete = ?, type = ?, updated_at = CURRENT_TIMESTAMP,
+			started_at = CASE WHEN ? = 'active' AND ? != 'active' THEN CURRENT_TIMESTAMP ELSE ? END
 		WHERE ticket_id = ?
-	`, title, params.Description, nextAcceptanceCriteria, dorJSON, dodJSON, acJSON, nextGitRepository, nextGitBranch, nullableString(params.ParentID), assignee, nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), params.Priority, params.Order, params.EstimateEffort, strings.TrimSpace(params.EstimateComplete), completeVal, nextType, id)
+	`, title, params.Description, nextAcceptanceCriteria, dorJSON, dodJSON, acJSON, nextGitRepository, nextGitBranch, nullableString(params.ParentID), assignee, nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), params.Priority, params.Order, params.EstimateEffort, strings.TrimSpace(params.EstimateComplete), completeVal, nextType, state, current.State, current.StartedAt, id)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -1207,7 +1211,7 @@ func ListTickets(ctx context.Context, db *sql.DB, params TicketListParams) ([]Ti
 	}
 
 	query := `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, '')
+		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
 		FROM tickets
 		WHERE project_id = ?
 	`
@@ -1293,7 +1297,7 @@ func SearchTickets(ctx context.Context, db *sql.DB, projectID int64, query strin
 
 func GetTicketByProject(ctx context.Context, db *sql.DB, projectID int64, id string) (Ticket, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, '')
+		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
 		FROM tickets
 		WHERE project_id = ? AND ticket_id = ? AND deleted = 0
 	`, projectID, id)
@@ -1309,7 +1313,7 @@ func GetTicketByProject(ctx context.Context, db *sql.DB, projectID int64, id str
 
 func GetTicket(ctx context.Context, db *sql.DB, id string) (Ticket, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, '')
+		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
 		FROM tickets
 		WHERE ticket_id = ? AND deleted = 0
 	`, id)
@@ -1413,19 +1417,19 @@ func ListTicketParents(ctx context.Context, db *sql.DB, id string) ([]Ticket, er
 		  description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch,
 		  workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order,
 		  estimate_effort, estimate_complete, health_score, assignee, author,
-		  draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, created_by, created_at, updated_at, recommended_ready, pr_url) AS (
+		  draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, created_by, created_at, updated_at, recommended_ready, pr_url, started_at) AS (
 			SELECT ticket_id, project_id, parent_id, clone_of, type, title,
 			  description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch,
 			  workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order,
 			  estimate_effort, estimate_complete, health_score, assignee, COALESCE(author,''),
-			  draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by,''), created_at, updated_at, COALESCE(recommended_ready,0), COALESCE(pr_url,'')
+			  draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by,''), created_at, updated_at, COALESCE(recommended_ready,0), COALESCE(pr_url,''), COALESCE(started_at,'')
 			FROM tickets WHERE ticket_id = ? AND deleted = 0
 			UNION ALL
 			SELECT t.ticket_id, t.project_id, t.parent_id, t.clone_of, t.type, t.title,
 			  t.description, t.acceptance_criteria, t.dor_map, t.dod_map, t.ac_map, t.git_repository, t.git_branch,
 			  t.workflow_id, t.workflow_stage_id, t.role_id, t.stage, t.state, t.status, t.priority, t.sort_order,
 			  t.estimate_effort, t.estimate_complete, t.health_score, t.assignee, COALESCE(t.author,''),
-			  t.draft, t.complete, t.archived, t.deleted, t.previous_workflow_stage_id, t.previous_role_id, t.release_id, COALESCE(t.created_by,''), t.created_at, t.updated_at, COALESCE(t.recommended_ready,0), COALESCE(t.pr_url,'')
+			  t.draft, t.complete, t.archived, t.deleted, t.previous_workflow_stage_id, t.previous_role_id, t.release_id, COALESCE(t.created_by,''), t.created_at, t.updated_at, COALESCE(t.recommended_ready,0), COALESCE(t.pr_url,''), COALESCE(t.started_at,'')
 			FROM tickets t
 			JOIN ancestors a ON t.ticket_id = a.parent_id
 		)
@@ -1433,7 +1437,7 @@ func ListTicketParents(ctx context.Context, db *sql.DB, id string) ([]Ticket, er
 		  description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch,
 		  workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order,
 		  estimate_effort, estimate_complete, health_score, assignee, author,
-		  draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, created_by, created_at, updated_at, recommended_ready, pr_url
+		  draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, created_by, created_at, updated_at, recommended_ready, pr_url, started_at
 		FROM ancestors
 		WHERE ticket_id != ?
 	`, id, id)
@@ -1532,6 +1536,7 @@ func scanTicket(s scanner) (Ticket, error) {
 		&ticket.UpdatedAt,
 		&recommendedReady,
 		&ticket.PrURL,
+		&ticket.StartedAt,
 	); err != nil {
 		return Ticket{}, err
 	}
@@ -1830,7 +1835,7 @@ func recalculateParentLifecycle(ctx context.Context, db *sql.DB, id, actorID str
 
 func listStoredChildTickets(ctx context.Context, db *sql.DB, parentID string) ([]Ticket, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, '')
+		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
 		FROM tickets
 		WHERE parent_id = ? AND deleted = 0
 		ORDER BY created_at, ticket_id
@@ -1853,7 +1858,7 @@ func listStoredChildTickets(ctx context.Context, db *sql.DB, parentID string) ([
 
 func getStoredTicket(ctx context.Context, db *sql.DB, id string) (Ticket, error) {
 	ticket, err := scanTicket(db.QueryRowContext(ctx, `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, '')
+		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
 		FROM tickets
 		WHERE ticket_id = ?
 	`, id))
@@ -2095,7 +2100,7 @@ func ticketClaimable(ctx context.Context, db *sql.DB, ticket Ticket, projectID i
 
 func findAssignedTicketForUser(ctx context.Context, db *sql.DB, projectID int64, username, state string) (Ticket, bool, error) {
 	query := `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, '')
+		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
 		FROM tickets
 		WHERE assignee = ? AND complete = 0 AND archived = 0 AND deleted = 0 AND state = ?
 	`
@@ -2128,7 +2133,7 @@ func findClaimCandidate(ctx context.Context, db *sql.DB, projectID int64, roleNa
 	if projectID == 0 {
 		return Ticket{}, false, errors.New("project is required")
 	}
-	query := `SELECT t.ticket_id, t.project_id, t.parent_id, t.clone_of, t.type, t.title, t.description, t.acceptance_criteria, t.dor_map, t.dod_map, t.ac_map, t.git_repository, t.git_branch, t.workflow_id, t.workflow_stage_id, t.role_id, t.stage, t.state, t.status, t.priority, t.sort_order, t.estimate_effort, t.estimate_complete, t.health_score, t.assignee, COALESCE(t.author, ''), t.draft, t.complete, t.archived, t.deleted, t.previous_workflow_stage_id, t.previous_role_id, t.release_id, COALESCE(t.created_by, ''), t.created_at, t.updated_at, COALESCE(t.recommended_ready, 0), COALESCE(t.pr_url, '')
+	query := `SELECT t.ticket_id, t.project_id, t.parent_id, t.clone_of, t.type, t.title, t.description, t.acceptance_criteria, t.dor_map, t.dod_map, t.ac_map, t.git_repository, t.git_branch, t.workflow_id, t.workflow_stage_id, t.role_id, t.stage, t.state, t.status, t.priority, t.sort_order, t.estimate_effort, t.estimate_complete, t.health_score, t.assignee, COALESCE(t.author, ''), t.draft, t.complete, t.archived, t.deleted, t.previous_workflow_stage_id, t.previous_role_id, t.release_id, COALESCE(t.created_by, ''), t.created_at, t.updated_at, COALESCE(t.recommended_ready, 0), COALESCE(t.pr_url, ''), COALESCE(t.started_at, '')
 		FROM tickets t
 		JOIN projects p ON p.project_id = t.project_id
 		LEFT JOIN roles r ON r.role_id = t.role_id

--- a/internal/store/ticket_test.go
+++ b/internal/store/ticket_test.go
@@ -574,6 +574,56 @@ func TestCreateAndUpdateTicketAllowLineageIndependentOfType(t *testing.T) {
 	}
 }
 
+func TestUpdateTicketStartedAtLifecycle(t *testing.T) {
+	t.Parallel()
+	db := testDB(t)
+	ctx := context.Background()
+
+	project, err := CreateProject(ctx, db, "Started Project", "", "", "")
+	if err != nil {
+		t.Fatalf("CreateProject() error = %v", err)
+	}
+	ticket, err := CreateTicket(ctx, db, TicketCreateParams{ProjectID: project.ID, Type: "task", Title: "Work"})
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+	if strings.TrimSpace(ticket.StartedAt) != "" {
+		t.Fatalf("new ticket should have empty started_at, got %q", ticket.StartedAt)
+	}
+
+	params := func(state, title string) TicketUpdateParams {
+		return TicketUpdateParams{Title: title, State: state, Assignee: "admin", ActorUsername: "admin", ActorRole: "admin"}
+	}
+
+	// Entering active stamps started_at.
+	active, err := UpdateTicket(ctx, db, ticket.ID, params(StateActive, "Work"))
+	if err != nil {
+		t.Fatalf("UpdateTicket(active) error = %v", err)
+	}
+	if strings.TrimSpace(active.StartedAt) == "" {
+		t.Fatal("started_at should be stamped on the active transition")
+	}
+	started := active.StartedAt
+
+	// A content edit while active preserves started_at.
+	edited, err := UpdateTicket(ctx, db, ticket.ID, params(StateActive, "Renamed"))
+	if err != nil {
+		t.Fatalf("UpdateTicket(content) error = %v", err)
+	}
+	if edited.StartedAt != started {
+		t.Fatalf("started_at must be preserved on content edit: %q -> %q", started, edited.StartedAt)
+	}
+
+	// Leaving active preserves the (historical) started_at value.
+	idle, err := UpdateTicket(ctx, db, ticket.ID, params(StateIdle, "Renamed"))
+	if err != nil {
+		t.Fatalf("UpdateTicket(idle) error = %v", err)
+	}
+	if idle.StartedAt != started {
+		t.Fatalf("started_at should be preserved when leaving active: %q -> %q", started, idle.StartedAt)
+	}
+}
+
 func TestCreateTicketAcceptsCanonicalTypes(t *testing.T) {
 	t.Parallel()
 	db := testDB(t)


### PR DESCRIPTION
Adds a durable `started_at` so a ticket's in-progress time is accurate everywhere, not just derived from history (the interim approach from TK-57).

## What
- New `tickets.started_at` column, **stamped `CURRENT_TIMESTAMP` on the transition into the `active` state**, preserved on content edits and when leaving active (via a `CASE` in the `UpdateTicket` write).
- Schema **v9 → v10** with an additive `ALTER TABLE … ADD COLUMN` migration (server auto-upgrades on startup; `tk admin upgrade-database` for CLI dbs).
- `started_at` threaded through **every** ticket SELECT — the 8 flat queries plus the recursive `ancestors` CTE (column list + recursive member + outer select) and the `t.`-aliased subtree query — and `scanTicket`.
- `tk get -v` now prefers the column, falling back to the history-derived start for tickets that went active before this change.
- Added to the OpenAPI `Ticket` schema.

## Tests
`TestUpdateTicketStartedAtLifecycle` (empty on create → set on active → preserved on content edit → preserved when leaving active). `make lint` + `validate-openapi` clean; `internal/store` (minus the pre-existing `TestFailureEscalationInboxLifecycle`, which also fails on `main`), `libticket`, `internal/client`, `internal/server`, and full `cmd/tk` suites green.

Closes the foundation under TK-57; unblocks **TK-89** (ls "active for" column) and **TK-90** (TUI/web), which can now read `started_at` directly.

## Note
`started_at` is set on the `UpdateTicket` active-transition path (covers `tk active`/`tk state active`). Other internal active-setting paths (e.g. agent work assignment) can be wired in a follow-up if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)