### PR TITLE
TK-89: ACTIVE (in-progress-for) column in tk ls

### DIFF
--- a/cmd/tk/main_test.go
+++ b/cmd/tk/main_test.go
@@ -2287,6 +2287,30 @@ func TestRunListShowsPullRequestColumn(t *testing.T) {
 	}
 }
 
+func TestRunListShowsActiveForColumn(t *testing.T) {
+	setupLocalCLI(t)
+
+	id := createLocalTask(t, []string{"add", "Work in progress"})
+	if err := run([]string{"claim", "-id", id}); err != nil {
+		t.Fatalf("claim error = %v", err)
+	}
+	if err := run([]string{"active", "-id", id}); err != nil {
+		t.Fatalf("active error = %v", err)
+	}
+
+	out := captureStdout(t, func() {
+		if err := run([]string{"ls", "-nocolor"}); err != nil {
+			t.Fatalf("ls error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "ACTIVE") {
+		t.Fatalf("ls output missing ACTIVE column header:\n%s", out)
+	}
+	if !strings.Contains(out, "just now") {
+		t.Fatalf("ls output missing elapsed time for active ticket:\n%s", out)
+	}
+}
+
 func TestRunListShowsActiveTicketsFirstWithSeparator(t *testing.T) {
 	setupLocalCLI(t)
 

--- a/cmd/tk/printer.go
+++ b/cmd/tk/printer.go
@@ -863,6 +863,24 @@ func printTicketTable(tickets []store.Ticket, parentKeys map[string]string, agen
 
 	showOpen := includeArchived   // only show OPEN column when mixed open/closed
 	showPR := len(prByTicket) > 0 // only show PR column when some ticket has a PR
+	// Show an "ACTIVE" (in-progress-for) column when any listed ticket is active
+	// with a recorded start time (TK-89, reads started_at from TK-88).
+	showActive := false
+	for _, t := range tickets {
+		if strings.EqualFold(strings.TrimSpace(t.State), store.StateActive) && strings.TrimSpace(t.StartedAt) != "" {
+			showActive = true
+			break
+		}
+	}
+	activeFor := func(t store.Ticket) string {
+		if !strings.EqualFold(strings.TrimSpace(t.State), store.StateActive) {
+			return "-"
+		}
+		if elapsed := humanizeSince(t.StartedAt); elapsed != "" {
+			return elapsed
+		}
+		return "-"
+	}
 
 	makeHeader := func() string {
 		cols := "ID\tTYPE\tTITLE\tSTAGE\tSTATE\tDRAFT"
@@ -870,6 +888,9 @@ func printTicketTable(tickets []store.Ticket, parentKeys map[string]string, agen
 			cols += "\tCOMPLETE"
 		}
 		cols += "\tASSIGNEE"
+		if showActive {
+			cols += "\tACTIVE"
+		}
 		if showPR {
 			cols += "\tPR"
 		}
@@ -911,6 +932,9 @@ func printTicketTable(tickets []store.Ticket, parentKeys map[string]string, agen
 			row += "\t" + ticketCompleteLabel(t)
 		}
 		row += "\t" + assignee
+		if showActive {
+			row += "\t" + activeFor(t)
+		}
 		if showPR {
 			pr := "-"
 			if v := strings.TrimSpace(prByTicket[t.ID]); v != "" {


### PR DESCRIPTION
`tk ls` now shows how long in-progress tickets have been active.

## What
- When any listed ticket is `active` with a recorded `started_at` (from TK-88), `tk ls` adds an **ACTIVE** column showing the humanized elapsed time (`just now` / `Nm` / `Nh` / `Nd`); `-` for non-active rows.
- The column only renders when there's at least one active ticket, and sits **before PRIORITY** so the short value isn't clipped (the last column gets truncated by the multibyte tree symbols — same reason the PR column sits there).
- Pairs with the existing active-first grouping + separator (TK-73): the in-progress block at the top now also shows its age.

## Tests
`TestRunListShowsActiveForColumn` (claim+active a ticket → ls shows the ACTIVE header and an elapsed value). `make lint` clean; full `cmd/tk` suite green.

Second of the TK-57 follow-ups (after TK-88). Remaining: **TK-90** (TUI + web).

🤖 Generated with [Claude Code](https://claude.com/claude-code)