### PR TITLE
TK-90: in-progress + elapsed in TUI detail and web modal

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1365,6 +1365,16 @@ func (m Model) viewDetail() []string {
 		add("role", m.roleName(*t.RoleID))
 	}
 	add("assignee", t.Assignee)
+	if strings.EqualFold(strings.TrimSpace(t.State), store.StateActive) {
+		val := "active"
+		if s := strings.TrimSpace(t.StartedAt); s != "" {
+			val = "active since " + s
+			if e := humanizeSince(s); e != "" {
+				val += " (" + e + ")"
+			}
+		}
+		add("in progress", val)
+	}
 	add("parent", optionalStringValue(t.ParentID))
 	add("clone of", optionalStringValue(t.CloneOf))
 	add("git repo", t.GitRepository)
@@ -1516,6 +1526,25 @@ func optionalStringValue(value *string) string {
 		return ""
 	}
 	return *value
+}
+
+// humanizeSince renders a coarse elapsed time since a stored UTC timestamp.
+func humanizeSince(ts string) string {
+	t, err := time.Parse("2006-01-02 15:04:05", strings.TrimSpace(ts))
+	if err != nil {
+		return ""
+	}
+	d := time.Since(t.UTC())
+	switch {
+	case d < time.Minute:
+		return "just now"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
+	}
 }
 
 func formatResolvedGuidance(guidance store.ResolvedGuidance) string {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -140,6 +140,32 @@ func TestViewDetailShowsPullRequests(t *testing.T) {
 	}
 }
 
+func TestViewDetailShowsInProgress(t *testing.T) {
+	m := newModel(nil, config.Config{}, Themes[ThemeTheGrey])
+	m.width = 100
+	m.height = 30
+	m.project = store.Project{ID: 1, Prefix: "PRJ", Title: "Alpha", Status: "open"}
+	selected := store.Ticket{
+		ID: "PRJ-3", Type: "task", Title: "Work", Stage: store.StageDevelop,
+		State: store.StateActive, Status: "develop/active", StartedAt: "2026-03-02 09:00:00",
+	}
+	m.selected = &selected
+
+	out := strings.Join(m.viewDetail(), "\n")
+	for _, needle := range []string{"in progress", "active since 2026-03-02 09:00:00"} {
+		if !strings.Contains(out, needle) {
+			t.Fatalf("detail view missing %q:\n%s", needle, out)
+		}
+	}
+
+	// An idle ticket shows no in-progress line.
+	idle := store.Ticket{ID: "PRJ-4", Type: "task", Title: "Idle", Stage: store.StageDesign, State: store.StateIdle, Status: "design/idle"}
+	m.selected = &idle
+	if strings.Contains(strings.Join(m.viewDetail(), "\n"), "in progress") {
+		t.Fatal("idle ticket should not show an in-progress line")
+	}
+}
+
 func TestProjectEditAndNewTicketViewsShowLifecycleFields(t *testing.T) {
 	projectWorkflowID := int64(3)
 	ticketWorkflowID := int64(5)

--- a/web/default/index.html
+++ b/web/default/index.html
@@ -999,6 +999,7 @@
                     <span class="rr-msg"><strong>Refiner recommends ready for development.</strong> Review and approve to move this ticket to the development queue.</span>
                     <button id="ticket-mark-ready-btn" class="btn btn-primary btn-sm" type="button">Mark Ready</button>
                 </div>
+                <div id="ticket-in-progress" class="hidden" style="font-size:0.85rem;margin-bottom:0.5rem;color:#2e7d32;"></div>
                 <div id="ticket-pr-url" class="hidden" style="font-size:0.85rem;margin-bottom:0.5rem;"></div>
                 <div id="ticket-pull-requests-section" class="modal-section hidden" style="margin-bottom:0.5rem;">
                     <div class="section-heading">Pull Requests</div>

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -1125,6 +1125,19 @@
                 .replace(/'/g, "&#39;");
         }
 
+        // humanizeSince renders a coarse elapsed time since a stored UTC timestamp
+        // ("2026-06-22 18:08:52"), mirroring the CLI/TUI helper (TK-90).
+        function humanizeSince(ts) {
+            if (!ts) return "";
+            const then = new Date(String(ts).trim().replace(" ", "T") + "Z");
+            if (isNaN(then.getTime())) return "";
+            const ms = Date.now() - then.getTime();
+            if (ms < 60000) return "just now";
+            if (ms < 3600000) return Math.floor(ms / 60000) + "m";
+            if (ms < 86400000) return Math.floor(ms / 3600000) + "h";
+            return Math.floor(ms / 86400000) + "d";
+        }
+
         function closeDialog(result) {
             if (els.dialogOverlay) {
                 els.dialogOverlay.classList.add("hidden");
@@ -7157,6 +7170,21 @@
                     rrBanner.classList.remove("hidden");
                 } else {
                     rrBanner.classList.add("hidden");
+                }
+            }
+            // In-progress badge: show how long an active ticket has been worked (TK-90).
+            const inProgressEl = document.getElementById("ticket-in-progress");
+            if (inProgressEl) {
+                if (ticket.state === "active") {
+                    let label = "In progress";
+                    if (ticket.started_at) {
+                        const elapsed = humanizeSince(ticket.started_at);
+                        label += " · active since " + ticket.started_at + (elapsed ? " (" + elapsed + ")" : "");
+                    }
+                    inProgressEl.textContent = label;
+                    inProgressEl.classList.remove("hidden");
+                } else {
+                    inProgressEl.classList.add("hidden");
                 }
             }
             // PR URL display


### PR DESCRIPTION
Completes the TK-57 thread: the in-progress start time/elapsed now shows in the TUI and web too (after the CLI in TK-57 and `tk ls` in TK-89). Both read `started_at` (TK-88).

## What
- **TUI detail** (`internal/tui/model.go`): active tickets get an `in progress` line — `active since <ts> (<elapsed>)`; idle tickets show nothing.
- **Web ticket modal** (`web/default/index.html` + `web/shared/app.js`): a green in-progress badge with `active since <ts> (<elapsed>)`, shown only when `state === "active"`.
- Adds a `humanizeSince` helper in each (Go + JS), mirroring the CLI helper (`just now`/`Nm`/`Nh`/`Nd`).

## Tests
- `TestViewDetailShowsInProgress` (active shows the line + timestamp; idle does not). `internal/tui` green; `make lint` clean.
- Web change verified against the **embedded server** (`web/static.go` embeds `default/*`+`shared/*`): the badge element and `humanizeSince` are present in the served `/` and `/app.js`.

## Note
The Playwright suite couldn't run here — the `serve-site.py` test harness returns 404 for `/index.html` (pre-existing setup issue, the same one tracked in `docs/TODO.md`'s site2 follow-up), unrelated to this change. Verified manually via `tk server` instead.

Last of the three TK-57 follow-ups (TK-88, TK-89, TK-90).

🤖 Generated with [Claude Code](https://claude.com/claude-code)