### PR TITLE
TK-106: Extensible-schema design doc, ADR, diagrams & per-column classification

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1142,3 +1142,13 @@ Outcomes:
 - **same version** — `You are on the latest version (VERSION)`
 - **newer available** — `A newer version of ticket is available, upgrade using: go install github.com/simonski/ticket@latest`
 - **local is newer** — `Your local copy is newer than the repo`
+
+## Schema evolution (extensible attributes)
+
+Schema change in `tk` is governed by a three-tier model (epic TK-105): typed
+first-class columns for queried/constrained data, a per-entity `attrs` JSONB
+attribute bag as the default home for new optional/sparse/per-type fields (added
+in Go with no migration), and promotion of bag fields to expression indexes when
+they need to be queried. Migrations take a WAL-checkpointed, integrity-verified
+backup and auto-rollback on failure. See `docs/design/extensible-schema.md` and
+`docs/adr/0001-json-attribute-bags.md`.

--- a/docs/ENTITY_MODEL.md
+++ b/docs/ENTITY_MODEL.md
@@ -1116,3 +1116,27 @@ This example is intentionally small, but it shows the principle:
 
 > `tk prompt <id>` is where the entity model becomes operational by turning
 > project + lineage + workflow + guidance into one coherent work brief.
+
+---
+
+## Extensible attributes (`attrs` JSON bag)
+
+> Added by epic TK-105. Full design: `docs/design/extensible-schema.md`;
+> decision record: `docs/adr/0001-json-attribute-bags.md`.
+
+To lower the likelihood and blast radius of schema change, the high-churn
+entities (TICKET, PROJECT, ROLE, STAGE) each carry an `attrs` **JSONB** column —
+a governed attribute bag. Fields are classified into three tiers:
+
+1. **Tier 1 — first-class columns.** Anything needing a foreign key, `NOT NULL`,
+   a hot-path `WHERE`/`ORDER BY`, or aggregation. Unchanged.
+2. **Tier 2 — the `attrs` bag.** The default home for optional, sparse,
+   display-only, and per-type fields. Adding a Tier-2 field is a pure-Go change
+   to a typed accessor struct — **no SQL migration, no schema-version bump**.
+3. **Tier 3 — promotion.** A bag field that needs to be queried is promoted via
+   an idempotent expression index (`json_extract(attrs,'$.field')`) or, rarely, a
+   generated column.
+
+This means the *default* way to add a field no longer changes the schema. See the
+design document for the per-column classification of which existing fields are
+kept as columns, folded into the bag, or moved.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1495,3 +1495,11 @@ Tests must cover:
 - Export/import round-trip fidelity
 - Context graph: edge CRUD, node validation, graph assembly, and text search
 - Decomposition reordering: permutation validation and persisted child order
+
+## Extensible attributes (`attrs`)
+
+High-churn entities (tickets, projects, roles, workflow_stages) carry an `attrs`
+JSONB column — a governed attribute bag for optional, sparse, display-only and
+per-type fields. New Tier-2 fields are added without a schema migration or
+version bump; fields are promoted to expression indexes (`json_extract`) when
+they must be queried. Authoritative design: `docs/design/extensible-schema.md`.

--- a/docs/adr/0001-json-attribute-bags.md
+++ b/docs/adr/0001-json-attribute-bags.md
@@ -1,0 +1,64 @@
+# ADR 0001: JSON attribute bags for extensible schema
+
+- Status: Accepted (epic TK-105 / story TK-106)
+- Date: 2026-06-22
+- Deciders: Simon Gauld
+
+## Context
+
+`tk` stores all data in a single SQLite database with a monolithic, additive
+migration system (`internal/store/store.go`, `internal/store/schema_version.go`).
+Adding a field to a core entity (tickets/projects/roles/workflow_stages) is
+costly out of proportion to its value: every addition needs a schema-version bump
+and ripples positionally through ~10 hand-written `SELECT`s plus a 41-arg
+`scanTicket`. We want to lower both the likelihood and the blast radius of schema
+change without losing queryability or migration safety.
+
+## Decision
+
+Adopt a **governed three-tier model**:
+
+1. **Tier 1 — first-class columns** for anything needing FK / NOT NULL / hot
+   WHERE-ORDER BY / aggregation. Unchanged.
+2. **Tier 2 — a per-entity `attrs` JSONB bag** as the default home for optional,
+   sparse, display-only, and per-type fields. Adding a Tier-2 field is a pure-Go
+   change to a typed accessor struct — no SQL, no version bump.
+3. **Tier 3 — promotion** of a bag field to query-grade via an idempotent
+   expression index (`json_extract`) or, rarely, a generated column.
+
+Store the bag as **JSONB (BLOB)** using SQLite 3.45+ binary JSON, available via
+`modernc.org/sqlite v1.48.0`. Centralize the ticket column list + scan to remove
+the fan-out. Harden migrations with checkpointed, integrity-verified backups and
+automatic rollback.
+
+## Alternatives considered
+
+### A. Status quo — keep adding typed columns
+Rejected. This is exactly the churn the epic exists to remove. ALTER TABLE is
+cheap, but the code fan-out and version coupling are not.
+
+### B. EAV side table (`ticket_attributes(ticket_id, key, value, type)`)
+Rejected for core fields. Pros: never ALTER, fully dynamic. Cons: every read
+becomes a join or pivot, the atomic row is lost, reporting/sorting is painful,
+and type-safety evaporates. Classic anti-pattern for first-class entity data.
+
+### C. Plain TEXT JSON column
+Partially accepted but superseded. The existing `dor_map`/`dod_map`/`ac_map`
+columns already use TEXT JSON and work. JSONB is more compact and faster to parse
+while remaining queryable by the same `json_*` functions, so new storage uses
+JSONB; TEXT JSON is retained only transitionally until S6 folds those columns in.
+
+### D. Generated columns for everything
+Rejected as the default. Generated columns are useful for promotion (Tier 3) but
+defining one per field reintroduces per-field DDL. Reserved for the rare case
+that needs a real column surface over a bag field.
+
+## Consequences
+
+- Adding an optional field becomes a no-migration, no-version-bump Go change.
+- Querying a bag field requires an explicit promotion step (expression index),
+  making "is this field queryable?" an intentional decision rather than a default.
+- The `attrs` blob is opaque in raw SQLite shells (mitigated: read via
+  `json(attrs)`); slightly higher write cost to encode JSONB.
+- Migration safety is materially improved for ALL migration paths, not just the
+  consolidation in this epic.

--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -1,0 +1,296 @@
+# Extensible Schema: JSON Attribute Bags + Reinforced Migration Safety
+
+> Status: **Design (S1 / TK-106)** — sign-off gate for epic **TK-105**.
+> Implementation stories: TK-107 (migration safety), TK-108 (column-list
+> centralization), TK-109 (introduce `attrs`), TK-110 (queryable bag),
+> TK-111–TK-114 (per-entity consolidation).
+
+## 1. Problem
+
+Adding a single field to a core entity is disproportionately expensive today.
+The cost is **not** the `ALTER TABLE` — that is one idempotent line and the
+additive migration framework in `internal/store/store.go` already handles it.
+The cost is two-fold:
+
+1. **DDL churn / version coupling.** Every optional field needs a schema-version
+   bump (`CurrentSchemaVersion` in `internal/store/schema_version.go`) and a
+   migration guard, even when the field is sparse, display-only, or specific to
+   one ticket type.
+2. **Code fan-out.** Columns are listed *positionally* in ~10 hand-written
+   `SELECT` statements (`internal/store/ticket.go`, `internal/store/reorder.go`)
+   plus a 41-argument `scanTicket`. Adding `started_at` (TK-88) meant threading
+   `COALESCE(started_at,'')` through every one of those call sites in the correct
+   ordinal position, plus the struct, INSERT/UPDATE, OpenAPI and tests.
+
+We want to lower both the **likelihood** and the **blast radius** of future
+schema change, while keeping the schema queryable and safe to migrate.
+
+## 2. Goals & non-goals
+
+**Goals**
+- Make the *default* way to add an optional field require **no DDL and no schema
+  version bump**.
+- Eliminate the positional `SELECT`/scan fan-out so even genuine column changes
+  touch one place.
+- Keep fields queryable (filter/sort/index) when they need to be.
+- Make every migration self-protecting: a verified backup is always taken and a
+  failed migration auto-rolls-back.
+
+**Non-goals (this epic)**
+- No Postgres / non-SQLite backend.
+- No end-user "custom fields" UI (this epic builds the substrate, not the
+  feature).
+- No change to the lifecycle model (`docs/LIFECYCLE.md`).
+
+## 3. The three-tier model
+
+We deliberately do **not** turn everything into JSON. Untyped JSON bags become
+dumping grounds that defeat querying and constraints. Instead we define three
+tiers with explicit promotion rules.
+
+### Tier 1 — First-class columns (unchanged)
+Real typed columns. Used for anything that needs a **foreign key**, a
+**`NOT NULL` constraint**, a **hot-path `WHERE`/`ORDER BY`**, or **aggregation**.
+Examples: `state`, `stage`, `status`, `project_id`, `parent_id`, `priority`,
+`sort_order`, lifecycle flags (`draft`/`complete`/`archived`/`deleted`),
+timestamps.
+
+### Tier 2 — The attribute bag (`attrs`, JSONB)
+One `attrs` column per high-churn entity, storing a JSON object. This is the
+**default home** for:
+- new optional / sparse fields,
+- display-only or rarely-queried fields,
+- **per-type** fields (a `bug`'s repro steps, a `spike`'s timebox) that would
+  otherwise be sparse wide columns.
+
+Adding a Tier-2 field = **add a field to a typed Go accessor struct**. No SQL, no
+migration, no version bump.
+
+### Tier 3 — Promotion
+When a Tier-2 field starts needing to be filtered / sorted / indexed, it is
+*promoted* without a destructive migration:
+
+1. **Expression index** (preferred) — idempotent, no table rewrite:
+   ```sql
+   CREATE INDEX IF NOT EXISTS idx_tickets_attrs_severity
+     ON tickets (json_extract(attrs, '$.severity'));
+   ```
+2. **Generated column** (heavier, only when a real column surface is required):
+   a `GENERATED ALWAYS AS (json_extract(attrs,'$.x')) VIRTUAL` column. Documented
+   as the fallback; not implemented unless a concrete need arises.
+
+### Promotion decision tree
+
+```mermaid
+flowchart TD
+  A[New or evolving field] --> B{Needs FK / NOT NULL / hot WHERE-ORDER BY / aggregation?}
+  B -- Yes --> C[Tier 1: real column]
+  B -- No --> D[Tier 2: attrs bag - no DDL]
+  D --> E{Later needs filter / sort / index?}
+  E -- No --> D
+  E -- Yes, light --> F[Tier 3: expression index on json_extract]
+  E -- Yes, needs column surface --> G[Tier 3: generated column]
+```
+
+## 4. Storage format: JSONB
+
+SQLite has no `JSONB` *column type* (unlike Postgres). "JSONB" in SQLite is the
+binary on-disk encoding introduced in **SQLite 3.45** (Jan 2024), produced by
+`jsonb()` / `jsonb_extract()` and stored in a `BLOB`. Our driver
+`modernc.org/sqlite v1.48.0` embeds a SQLite new enough to support it.
+
+Decision: **store `attrs` as JSONB (BLOB)**, written via `jsonb(?)` and read via
+`json(attrs)` (which renders JSONB back to text for Go's `encoding/json`), with
+`json_extract(attrs,'$.path')` for queries. Rationale: more compact and faster to
+parse than TEXT JSON; `json_extract` works transparently on either encoding so
+expression indexes are unaffected.
+
+The column is declared `attrs BLOB NOT NULL DEFAULT (jsonb('{}'))` so existing
+rows and inserts that omit it get a valid empty object.
+
+> Coexistence: the existing `dor_map` / `dod_map` / `ac_map` TEXT-JSON columns
+> keep working unchanged until S6 folds them into `attrs`. Both encodings are
+> readable by the same `json_*` functions during the transition.
+
+## 5. Typed accessor layer
+
+The bag is **not** accessed as a raw `map[string]any` in business logic. Each
+entity gets a typed Go struct that marshals to/from `attrs`:
+
+```go
+// TicketAttrs is the typed view of tickets.attrs. Adding an optional field here
+// requires NO SQL and NO schema-version bump.
+type TicketAttrs struct {
+    GitRepository    string      `json:"git_repository,omitempty"`
+    GitBranch        string      `json:"git_branch,omitempty"`
+    EstimateComplete string      `json:"estimate_complete,omitempty"`
+    HealthScore      int         `json:"health_score,omitempty"`
+    Author           string      `json:"author,omitempty"`
+    PrURL            string      `json:"pr_url,omitempty"`
+    DOR              GuidanceMap `json:"dor_map,omitempty"`
+    DOD              GuidanceMap `json:"dod_map,omitempty"`
+    AC               GuidanceMap `json:"ac_map,omitempty"`
+    // future optional fields land here — no migration
+}
+```
+
+- `omitempty` keeps the stored object minimal/sparse.
+- Unknown keys are preserved on round-trip where practical (so an older binary
+  does not silently drop a newer field) — implemented by retaining a raw
+  `map[string]json.RawMessage` overflow alongside the typed struct.
+- A shared helper marshals/unmarshals (`encoding/json`) and is the single place
+  that talks to the `attrs` column.
+
+## 6. Killing the fan-out (TK-108)
+
+Independent of JSON, the ticket column list and scan are centralized into a
+single source of truth:
+
+- One canonical column-list constant/builder used by every read query.
+- One scan helper whose scan-target order is guaranteed consistent with that
+  list.
+
+After this, adding a Tier-1 column touches the list + struct + scan helper in one
+place instead of ~10 SELECTs, and adding `attrs` (TK-109) is a one-line change to
+the list.
+
+## 7. Migration safety (TK-107)
+
+Today `BackupDatabase()` does a plain file copy of `.db`/`-wal`/`-shm` before
+`UpgradeInPlace()`, but only from the server-startup path
+(`cmd/tk/cmd_setup.go:autoUpgradeDatabase`), with **no WAL checkpoint, no
+integrity verification, and no rollback**.
+
+Reinforcements:
+
+```mermaid
+flowchart TD
+  S[UpgradeInPlace start] --> CP[PRAGMA wal_checkpoint TRUNCATE]
+  CP --> BK[Copy db + sidecars to timestamped backup]
+  BK --> V{Verify backup: integrity_check + schema version}
+  V -- fail --> ABORT[Abort, do not touch live DB]
+  V -- ok --> MIG[Run migrations in tx]
+  MIG -- success --> DONE[Write new schema_version, keep backup per retention]
+  MIG -- failure --> RB[Restore live DB + sidecars from backup]
+  RB --> ERR[Return clear error, original DB intact]
+```
+
+1. `PRAGMA wal_checkpoint(TRUNCATE)` before copy → self-contained backup.
+2. Verify the backup (`PRAGMA integrity_check` + readable schema version) before
+   touching the live DB; abort if it fails.
+3. Take the backup **inside `UpgradeInPlace`** so every caller is protected.
+4. Auto-rollback: restore live DB + sidecars from the verified backup on failure.
+5. Timestamped backups with a documented retention policy.
+6. Test: inject a deliberately broken migration; assert original DB recovered,
+   schema version unchanged, error surfaced.
+
+## 8. Entity model — before & after
+
+```mermaid
+erDiagram
+  TICKETS {
+    string ticket_id PK
+    int    project_id FK
+    string state
+    string stage
+    blob   attrs "JSONB: soft + per-type fields"
+  }
+  PROJECTS {
+    int  project_id PK
+    string prefix
+    blob attrs "JSONB"
+  }
+  ROLES {
+    int role_id PK
+    int workflow_id FK
+    blob attrs "JSONB"
+  }
+  WORKFLOW_STAGES {
+    int workflow_stage_id PK
+    int workflow_id FK
+    blob attrs "JSONB"
+  }
+  PROJECTS ||--o{ TICKETS : has
+  WORKFLOWS ||--o{ ROLES : defines
+  WORKFLOWS ||--o{ WORKFLOW_STAGES : defines
+```
+
+## 9. Per-column classification
+
+Legend: **Keep** = stays a Tier-1 column. **Move** = relocate value into `attrs`.
+**Fold** = existing TEXT-JSON column merged as a nested key in `attrs`.
+Conservative bias: anything filtered / sorted / FK'd / aggregated stays **Keep**.
+
+### 9.1 `tickets`
+
+| Column | Decision | Rationale |
+|--------|----------|-----------|
+| ticket_id, project_id, parent_id, clone_of | Keep | PK / FKs |
+| type, title, description, acceptance_criteria | Keep | core, always present, displayed everywhere |
+| workflow_stage_id, role_id, stage, state, status | Keep | hot lifecycle filters |
+| priority, sort_order | Keep | sorted/ordered |
+| estimate_effort | Keep | aggregation candidate (sums/rollups) |
+| draft, complete, archived, deleted | Keep | hot boolean filters |
+| previous_workflow_stage_id, previous_role_id, release_id, workflow_id | Keep | FKs / lifecycle |
+| assignee, created_by | Keep | filtered |
+| recommended_ready, ready | Keep | filtered flags |
+| started_at, created_at, updated_at | Keep | sorted timestamps |
+| dor_map, dod_map, ac_map | **Fold** | already JSON; natural bag members |
+| git_repository, git_branch | **Move** | soft, rarely filtered |
+| estimate_complete | **Move** | display date string |
+| health_score | **Move** | display metric (promote via index if ever sorted) |
+| author | **Move** | soft, display |
+| pr_url | **Move** | soft, display |
+| `open` (legacy) | **Drop** | dead column, superseded by complete/archived |
+
+### 9.2 `projects`
+
+| Column | Decision | Rationale |
+|--------|----------|-----------|
+| project_id, prefix, title | Keep | PK / identity / displayed |
+| status, visibility | Keep | filtered |
+| workflow_id, programme_id, default_draft | Keep | FKs / behavior flags |
+| ticket_sequence | Keep | sequence counter (mutated atomically) |
+| created_by, created_at, updated_at | Keep | identity/sort |
+| description, acceptance_criteria | Keep | core, displayed |
+| dor_map, dod_map, ac_map | **Fold** | already JSON |
+| git_repository, notes | **Move** | soft, display |
+| agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key | **Move** | config sub-object → `attrs.agent_model` |
+
+### 9.3 `roles`
+
+| Column | Decision | Rationale |
+|--------|----------|-----------|
+| role_id, workflow_id, title | Keep | PK / FK / unique identity |
+| created_at, updated_at | Keep | sort |
+| dor_map, dod_map, ac_map | **Fold** | already JSON |
+| description, acceptance_criteria | **Move** | guidance text, never filtered |
+
+### 9.4 `workflow_stages`
+
+| Column | Decision | Rationale |
+|--------|----------|-----------|
+| workflow_stage_id, workflow_id, stage_name | Keep | PK / FK / unique identity |
+| sort_order | Keep | ordering |
+| is_backlog_stage | Keep | filtered flag |
+| created_at, updated_at | Keep | sort |
+| description, acceptance_criteria | **Move** | guidance text |
+| definition_of_ready, definition_of_done | **Move** | guidance text |
+
+> Workflow export/import (which serializes stages) must round-trip after the
+> move — see TK-114 acceptance criteria.
+
+## 10. Alternatives considered
+
+See ADR `docs/adr/0001-json-attribute-bags.md`. Summary: status-quo additive
+columns (rejected: the churn this epic exists to remove), an EAV side table
+(rejected: join cost, loss of atomic row, reporting pain), and plain TEXT JSON
+(rejected in favour of JSONB for size/speed; TEXT retained only transitionally).
+
+## 11. Rollout / sequencing
+
+Docs (this story) → migration safety (TK-107) + fan-out refactor (TK-108) →
+introduce `attrs` (TK-109) → queryable bag (TK-110) → per-entity consolidation
+TK-111 (tickets, first/riskiest) → TK-112/113/114 (projects/roles/stages). Each
+story branches from the epic tip and PRs into `epic/extensible-schema`; the epic
+PRs into `main` only once all stories land.


### PR DESCRIPTION
S1 of epic TK-105 (#refs TK-106). **Docs only** — the sign-off gate for the epic.

## What
- `docs/design/extensible-schema.md` — three-tier model (columns / `attrs` JSONB bag / promotion), JSONB storage decision, typed accessor design, migration-safety flow, and **per-column classification** tables for tickets/projects/roles/workflow_stages (Keep/Move/Fold/Drop), with Mermaid diagrams (promotion decision tree, migration+rollback flow, ER before/after).
- `docs/adr/0001-json-attribute-bags.md` — decision + rejected alternatives (status-quo columns, EAV, plain TEXT JSON, generated-columns-for-everything).
- References added to `ENTITY_MODEL.md`, `DESIGN.md`, `SPEC.md`.

## Why
Lowers the likelihood and blast radius of future schema change: adding an optional field becomes a no-migration, no-version-bump Go change; querying is an explicit promotion step.

No production Go/SQL changed. Targets the epic branch, not main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)