### PR TITLE
TK-107: Reinforce migration safety (verified backup + auto-rollback)

### DIFF
--- a/cmd/tk/cmd_setup.go
+++ b/cmd/tk/cmd_setup.go
@@ -821,15 +821,13 @@ func autoUpgradeDatabase(dbPath string) error {
 	if version >= store.CurrentSchemaVersion {
 		return nil
 	}
-	backup := fmt.Sprintf("%s.bak-%s", dbPath, time.Now().Format("20060102-150405"))
-	if backupErr := store.BackupDatabase(dbPath, backup); backupErr != nil {
-		return fmt.Errorf("pre-upgrade backup failed: %w", backupErr)
-	}
-	from, upErr := store.UpgradeInPlace(context.Background(), dbPath)
+	// UpgradeInPlaceWithBackup takes a WAL-checkpointed, integrity-verified backup
+	// before mutating the database and rolls back automatically on failure.
+	res, upErr := store.UpgradeInPlaceWithBackup(context.Background(), dbPath)
 	if upErr != nil {
 		return fmt.Errorf("database upgrade failed: %w", upErr)
 	}
-	fmt.Printf("auto-upgraded database %s (schema version %d -> %d); backup: %s\n", dbPath, from, store.CurrentSchemaVersion, backup)
+	fmt.Printf("auto-upgraded database %s (schema version %d -> %d); backup: %s\n", dbPath, res.From, res.To, res.BackupPath)
 	return nil
 }
 

--- a/cmd/tk/cmd_version.go
+++ b/cmd/tk/cmd_version.go
@@ -57,7 +57,7 @@ func runUpgradeDatabase(args []string) error {
 	fs := flag.NewFlagSet("upgrade-database", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	dbPath := fs.String("f", "", "SQLite database file (default: resolved/local database)")
-	noBackup := fs.Bool("no-backup", false, "skip the safety backup taken before upgrading")
+	noBackup := fs.Bool("no-backup", false, "do not retain the verified pre-upgrade backup on success (a backup is always taken and used for rollback)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -85,22 +85,28 @@ func runUpgradeDatabase(args []string) error {
 		return fmt.Errorf("database not found at %s: %w", path, err)
 	}
 
-	if !*noBackup {
-		backup := fmt.Sprintf("%s.bak-%s", path, time.Now().Format("20060102-150405"))
-		if err := store.BackupDatabase(path, backup); err != nil {
-			return fmt.Errorf("backup failed: %w", err)
-		}
-		fmt.Printf("backup written: %s\n", backup)
-	}
-
-	from, err := store.UpgradeInPlace(context.Background(), path)
+	// The upgrade always takes a WAL-checkpointed, integrity-verified backup
+	// internally and rolls back from it if the migration fails, so a safety
+	// backup can no longer be skipped. The -no-backup flag is retained for
+	// compatibility and now only suppresses retention of that backup on success.
+	res, err := store.UpgradeInPlaceWithBackup(context.Background(), path)
 	if err != nil {
 		return err
 	}
-	if from == store.CurrentSchemaVersion {
+	if res.BackupPath != "" {
+		if *noBackup {
+			_ = os.Remove(res.BackupPath)
+			for _, suffix := range []string{"-wal", "-shm"} {
+				_ = os.Remove(res.BackupPath + suffix)
+			}
+		} else {
+			fmt.Printf("backup written: %s\n", res.BackupPath)
+		}
+	}
+	if res.From == store.CurrentSchemaVersion {
 		fmt.Printf("upgraded %s in place (schema version %d; re-applied pending column migrations)\n", path, store.CurrentSchemaVersion)
 	} else {
-		fmt.Printf("upgraded %s in place (schema version %d -> %d)\n", path, from, store.CurrentSchemaVersion)
+		fmt.Printf("upgraded %s in place (schema version %d -> %d)\n", path, res.From, res.To)
 	}
 	fmt.Println("restart the tk server to pick up the upgraded database")
 	return nil

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -193,6 +193,39 @@ tk project ls
 > **Note:** `tk import` replaces the local database contents with the snapshot
 > in the file you pass via `-i`.
 
+### Pre-upgrade backups and automatic rollback
+
+Schema upgrades (`tk admin upgrade-database` and the automatic upgrade the server
+performs on startup) are self-protecting:
+
+1. The write-ahead log is checkpointed and the database file (plus `-wal`/`-shm`
+   sidecars) is copied to a timestamped backup next to it:
+   `ticket.db.bak-YYYYMMDD-HHMMSS.nnnnnnnnn`.
+2. That backup is verified (`PRAGMA integrity_check` + schema-version read)
+   **before** the live database is touched. If verification fails, the upgrade
+   aborts without modifying the database.
+3. If the migration fails partway, the database is automatically restored from the
+   verified backup and a clear error is returned — the original database is left
+   intact.
+4. On success, backups older than the most recent `5` (`DefaultBackupRetention`)
+   are pruned.
+
+To restore manually from a pre-upgrade backup (e.g. if both migration and the
+automatic rollback failed, which the error message will tell you):
+
+```bash
+# Stop the server first, then for database ticket.db and backup suffix <STAMP>:
+rm -f ticket.db ticket.db-wal ticket.db-shm
+cp ticket.db.bak-<STAMP> ticket.db
+# copy sidecars too if present
+[ -f ticket.db.bak-<STAMP>-wal ] && cp ticket.db.bak-<STAMP>-wal ticket.db-wal
+[ -f ticket.db.bak-<STAMP>-shm ] && cp ticket.db.bak-<STAMP>-shm ticket.db-shm
+```
+
+`tk admin upgrade-database -no-backup` does not skip this safety backup (it is
+always taken and used for rollback); it only declines to *retain* the backup
+after a successful upgrade.
+
 ### Client/server restore checklist
 
 1. Stop any running `tk server` process pointed at the same local database.

--- a/internal/store/migration_safety_test.go
+++ b/internal/store/migration_safety_test.go
@@ -1,0 +1,186 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// countTickets opens path read-only-ish and returns the number of rows in tickets.
+func countTickets(t *testing.T, path string) int {
+	t.Helper()
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer raw.Close()
+	var n int
+	if err := raw.QueryRow(`SELECT COUNT(*) FROM tickets`).Scan(&n); err != nil {
+		t.Fatalf("count tickets error = %v", err)
+	}
+	return n
+}
+
+func currentVersionDBWithTicket(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ticket.db")
+	if err := Init(path, "admin", "secret12"); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	_, err = CreateTicket(context.Background(), db, TicketCreateParams{
+		ProjectID: 1, Type: "task", Title: "safety ticket",
+	})
+	if closeErr := db.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+	return path
+}
+
+// TestUpgradeInPlaceRollsBackOnFailedMigration injects a migration that mutates the
+// live database and then fails; the original data and schema version must be
+// recovered from the verified backup, and the error must be surfaced.
+func TestUpgradeInPlaceRollsBackOnFailedMigration(t *testing.T) {
+	// Not parallel: mutates the runSchemaUpgrade package seam.
+	path := currentVersionDBWithTicket(t)
+	if got := countTickets(t, path); got != 1 {
+		t.Fatalf("precondition: countTickets = %d, want 1", got)
+	}
+	wantVersion, err := DetectSchemaVersion(path)
+	if err != nil {
+		t.Fatalf("DetectSchemaVersion() error = %v", err)
+	}
+
+	prev := runSchemaUpgrade
+	runSchemaUpgrade = func(ctx context.Context, p string, found int) error {
+		// Destructive change BEFORE failing, to prove rollback restores data.
+		raw, openErr := sql.Open("sqlite", p)
+		if openErr != nil {
+			return openErr
+		}
+		if _, execErr := raw.Exec(`DELETE FROM tickets`); execErr != nil {
+			_ = raw.Close()
+			return execErr
+		}
+		_ = raw.Close()
+		return errors.New("injected migration failure")
+	}
+	defer func() { runSchemaUpgrade = prev }()
+
+	_, upErr := UpgradeInPlace(context.Background(), path)
+	if upErr == nil {
+		t.Fatal("UpgradeInPlace() error = nil, want injected failure")
+	}
+
+	// Data recovered.
+	if got := countTickets(t, path); got != 1 {
+		t.Fatalf("after rollback countTickets = %d, want 1 (data not recovered)", got)
+	}
+	// Schema version unchanged.
+	if got, vErr := DetectSchemaVersion(path); vErr != nil {
+		t.Fatalf("DetectSchemaVersion() after rollback error = %v", vErr)
+	} else if got != wantVersion {
+		t.Fatalf("schema version after rollback = %d, want %d", got, wantVersion)
+	}
+}
+
+// TestUpgradeInPlaceTakesVerifiedBackup confirms a verifiable backup is produced
+// before the migration runs.
+func TestUpgradeInPlaceTakesVerifiedBackup(t *testing.T) {
+	t.Parallel()
+	path := currentVersionDBWithTicket(t)
+
+	res, err := UpgradeInPlaceWithBackup(context.Background(), path)
+	if err != nil {
+		t.Fatalf("UpgradeInPlaceWithBackup() error = %v", err)
+	}
+	if res.BackupPath == "" {
+		t.Fatal("BackupPath is empty; no backup was taken")
+	}
+	if _, statErr := os.Stat(res.BackupPath); statErr != nil {
+		t.Fatalf("backup file missing: %v", statErr)
+	}
+	if vErr := verifyDatabaseBackup(context.Background(), res.BackupPath, res.From); vErr != nil {
+		t.Fatalf("backup did not verify: %v", vErr)
+	}
+}
+
+// TestVerifyDatabaseBackupRejectsBadBackups ensures verification fails for a
+// corrupt file and for a wrong expected version, so a bad backup cannot precede a
+// migration.
+func TestVerifyDatabaseBackupRejectsBadBackups(t *testing.T) {
+	t.Parallel()
+	path := currentVersionDBWithTicket(t)
+	version, err := DetectSchemaVersion(path)
+	if err != nil {
+		t.Fatalf("DetectSchemaVersion() error = %v", err)
+	}
+
+	// Good backup verifies at the right version.
+	if vErr := verifyDatabaseBackup(context.Background(), path, version); vErr != nil {
+		t.Fatalf("good backup failed to verify: %v", vErr)
+	}
+	// Wrong expected version is rejected.
+	if vErr := verifyDatabaseBackup(context.Background(), path, version+1); vErr == nil {
+		t.Fatal("verifyDatabaseBackup() error = nil for wrong version, want error")
+	}
+	// A garbage (non-SQLite) file is rejected.
+	bad := filepath.Join(t.TempDir(), "garbage.db")
+	if writeErr := os.WriteFile(bad, []byte("this is not a sqlite database"), 0o600); writeErr != nil {
+		t.Fatalf("write garbage error = %v", writeErr)
+	}
+	if vErr := verifyDatabaseBackup(context.Background(), bad, version); vErr == nil {
+		t.Fatal("verifyDatabaseBackup() error = nil for corrupt file, want error")
+	}
+}
+
+// TestPruneOldBackupsRetainsNewest verifies the retention policy keeps only the
+// newest N backups.
+func TestPruneOldBackupsRetainsNewest(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	base := filepath.Join(dir, "ticket.db")
+	if err := os.WriteFile(base, []byte("live"), 0o600); err != nil {
+		t.Fatalf("write base error = %v", err)
+	}
+	// Create 7 timestamped backups with sortable suffixes.
+	stamps := []string{
+		"20260101-000001.000000000",
+		"20260101-000002.000000000",
+		"20260101-000003.000000000",
+		"20260101-000004.000000000",
+		"20260101-000005.000000000",
+		"20260101-000006.000000000",
+		"20260101-000007.000000000",
+	}
+	for _, s := range stamps {
+		if err := os.WriteFile(base+".bak-"+s, []byte("b"), 0o600); err != nil {
+			t.Fatalf("write backup error = %v", err)
+		}
+	}
+	if err := pruneOldBackups(base, 3); err != nil {
+		t.Fatalf("pruneOldBackups() error = %v", err)
+	}
+	matches, err := filepath.Glob(base + ".bak-*")
+	if err != nil {
+		t.Fatalf("glob error = %v", err)
+	}
+	if len(matches) != 3 {
+		t.Fatalf("after prune kept %d backups, want 3: %v", len(matches), matches)
+	}
+	// The three newest must remain.
+	for _, s := range stamps[len(stamps)-3:] {
+		if _, statErr := os.Stat(base + ".bak-" + s); statErr != nil {
+			t.Fatalf("expected newest backup %s to remain: %v", s, statErr)
+		}
+	}
+}

--- a/internal/store/schema_version.go
+++ b/internal/store/schema_version.go
@@ -8,8 +8,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -17,6 +19,9 @@ const (
 	CurrentSchemaVersion = 10
 	schemaMetaTable      = "schema_meta"
 	schemaVersionKey     = "schema_version"
+	// DefaultBackupRetention is the number of timestamped pre-upgrade backups
+	// kept alongside a database; older ones are pruned after a successful upgrade.
+	DefaultBackupRetention = 5
 )
 
 type SchemaVersionError struct {
@@ -229,9 +234,58 @@ func UpgradeDatabase(ctx context.Context, sourcePath, targetPath string) error {
 	return ImportSnapshot(ctx, targetDB, snapshot)
 }
 
+// UpgradeResult describes the outcome of an in-place upgrade.
+type UpgradeResult struct {
+	From       int    // schema version found before the upgrade
+	To         int    // schema version after the upgrade (CurrentSchemaVersion)
+	BackupPath string // path to the verified pre-upgrade backup that was taken
+}
+
+// runSchemaUpgrade performs the actual schema migration for a database whose
+// detected version is found (<= CurrentSchemaVersion). It is held in a package
+// variable so tests can inject a failing migration to exercise rollback; production
+// always uses runSchemaUpgradeDefault.
+var runSchemaUpgrade = runSchemaUpgradeDefault
+
+func runSchemaUpgradeDefault(ctx context.Context, path string, found int) error {
+	if found == CurrentSchemaVersion {
+		db, openErr := openSQLite(path)
+		if openErr != nil {
+			return openErr
+		}
+		defer db.Close()
+		if schemaErr := createSchema(ctx, db); schemaErr != nil {
+			return schemaErr
+		}
+		return enableWAL(ctx, db)
+	}
+
+	// Older schema: rebuild into a fresh database (which brings the schema fully
+	// current and re-imports the data) and atomically swap it into place.
+	tmpDir, err := os.MkdirTemp(filepath.Dir(path), ".tk-upgrade-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+	rebuilt := filepath.Join(tmpDir, "ticket.db")
+	if err := UpgradeDatabase(ctx, path, rebuilt); err != nil {
+		return err
+	}
+	return replaceSQLiteDatabase(rebuilt, path)
+}
+
 // UpgradeInPlace upgrades the database at path so its schema matches the current
 // version, leaving the database at the same path. It returns the schema version
-// found before the upgrade.
+// found before the upgrade. See UpgradeInPlaceWithBackup for the backup details.
+func UpgradeInPlace(ctx context.Context, path string) (int, error) {
+	res, err := UpgradeInPlaceWithBackup(ctx, path)
+	return res.From, err
+}
+
+// UpgradeInPlaceWithBackup upgrades the database at path in place, taking a
+// WAL-checkpointed, integrity-verified backup BEFORE any mutation and rolling the
+// database back from that backup if the migration fails. Every migration path is
+// protected, not just server startup.
 //
 //   - If the database is already at the current version, it re-applies the
 //     idempotent additive migrations in place (createSchema creates any missing
@@ -240,46 +294,148 @@ func UpgradeDatabase(ctx context.Context, sourcePath, targetPath string) error {
 //   - If the database is at an older version, it rebuilds a fresh database from a
 //     snapshot of the upgraded data and atomically swaps it into place.
 //   - If the database is newer than this binary, it returns a SchemaVersionError.
-func UpgradeInPlace(ctx context.Context, path string) (int, error) {
+//
+// On success, backups older than DefaultBackupRetention are pruned.
+func UpgradeInPlaceWithBackup(ctx context.Context, path string) (UpgradeResult, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
-		return 0, errors.New("database path is required")
+		return UpgradeResult{}, errors.New("database path is required")
 	}
 	found, err := DetectSchemaVersion(path)
 	if err != nil {
-		return 0, err
+		return UpgradeResult{}, err
 	}
+	res := UpgradeResult{From: found, To: CurrentSchemaVersion}
 	if found > CurrentSchemaVersion {
-		return found, &SchemaVersionError{Path: path, Found: found, Current: CurrentSchemaVersion, UpgradeNeeded: false}
+		return res, &SchemaVersionError{Path: path, Found: found, Current: CurrentSchemaVersion, UpgradeNeeded: false}
 	}
 
-	if found == CurrentSchemaVersion {
-		db, openErr := openSQLite(path)
-		if openErr != nil {
-			return found, openErr
-		}
-		defer db.Close()
-		if schemaErr := createSchema(ctx, db); schemaErr != nil {
-			return found, schemaErr
-		}
-		return found, enableWAL(ctx, db)
-	}
-
-	// Older schema: rebuild into a fresh database (which brings the schema fully
-	// current and re-imports the data) and atomically swap it into place.
-	tmpDir, err := os.MkdirTemp(filepath.Dir(path), ".tk-upgrade-")
+	// Take a checkpointed, integrity-verified backup before mutating the live DB.
+	backupPath, err := takeVerifiedBackup(ctx, path, found)
 	if err != nil {
-		return found, err
+		return res, fmt.Errorf("pre-upgrade backup failed: %w", err)
 	}
-	defer os.RemoveAll(tmpDir)
-	rebuilt := filepath.Join(tmpDir, "ticket.db")
-	if err := UpgradeDatabase(ctx, path, rebuilt); err != nil {
-		return found, err
+	res.BackupPath = backupPath
+
+	if migErr := runSchemaUpgrade(ctx, path, found); migErr != nil {
+		if restoreErr := restoreFromBackup(backupPath, path); restoreErr != nil {
+			return res, fmt.Errorf("migration failed (%v) AND automatic rollback failed (%v); restore manually from %s", migErr, restoreErr, backupPath)
+		}
+		return res, fmt.Errorf("migration failed and was rolled back from backup %s: %w", backupPath, migErr)
 	}
-	if err := replaceSQLiteDatabase(rebuilt, path); err != nil {
-		return found, err
+
+	if pruneErr := pruneOldBackups(path, DefaultBackupRetention); pruneErr != nil {
+		// Pruning is best-effort housekeeping; do not fail a successful upgrade.
+		return res, nil //nolint:nilerr // intentional: prune failures must not fail the upgrade
 	}
-	return found, nil
+	return res, nil
+}
+
+// backupPathFor returns a unique timestamped backup path for a database. The
+// nanosecond suffix keeps backups taken in quick succession distinct and sortable.
+func backupPathFor(path string) string {
+	return fmt.Sprintf("%s.bak-%s", path, time.Now().Format("20060102-150405.000000000"))
+}
+
+// takeVerifiedBackup checkpoints the WAL of the live database, copies it (and its
+// sidecars) to a timestamped backup, and verifies that backup with an integrity
+// check and a schema-version read before returning. The live database is not
+// modified.
+func takeVerifiedBackup(ctx context.Context, path string, expectedVersion int) (string, error) {
+	if err := checkpointWAL(ctx, path); err != nil {
+		return "", fmt.Errorf("wal checkpoint failed: %w", err)
+	}
+	backupPath := backupPathFor(path)
+	if err := copySQLiteDatabase(path, backupPath); err != nil {
+		return "", err
+	}
+	if err := verifyDatabaseBackup(ctx, backupPath, expectedVersion); err != nil {
+		return "", fmt.Errorf("backup verification failed: %w", err)
+	}
+	return backupPath, nil
+}
+
+// checkpointWAL flushes the write-ahead log into the main database file so a file
+// copy of the main file is a self-contained, consistent backup. It is harmless on
+// a database that is not in WAL mode.
+func checkpointWAL(ctx context.Context, path string) error {
+	db, err := openSQLite(path)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	_, err = db.ExecContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE);`)
+	return err
+}
+
+// verifyDatabaseBackup opens a backup database, runs PRAGMA integrity_check, and
+// confirms it reports the expected schema version. It returns an error if the
+// backup is unreadable, corrupt, or at an unexpected version.
+func verifyDatabaseBackup(ctx context.Context, path string, expectedVersion int) error {
+	db, err := openSQLite(path)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	var result string
+	if scanErr := db.QueryRowContext(ctx, `PRAGMA integrity_check;`).Scan(&result); scanErr != nil {
+		return scanErr
+	}
+	if !strings.EqualFold(strings.TrimSpace(result), "ok") {
+		return fmt.Errorf("integrity_check returned %q", result)
+	}
+	got, err := readSchemaVersion(ctx, db)
+	if err != nil {
+		return err
+	}
+	if got != expectedVersion {
+		return fmt.Errorf("backup schema version is %d, expected %d", got, expectedVersion)
+	}
+	return nil
+}
+
+// restoreFromBackup restores the live database (and its sidecars) from a backup,
+// used to roll back a failed migration. Stale live sidecars are removed first so
+// the restored main file is authoritative.
+func restoreFromBackup(backupPath, livePath string) error {
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if err := os.Remove(livePath + suffix); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return copySQLiteDatabase(backupPath, livePath)
+}
+
+// pruneOldBackups removes all but the newest keep timestamped backups (and their
+// sidecars) for a database. Backups sort chronologically by their zero-padded
+// timestamp suffix.
+func pruneOldBackups(path string, keep int) error {
+	if keep <= 0 {
+		return nil
+	}
+	matches, err := filepath.Glob(path + ".bak-*")
+	if err != nil {
+		return err
+	}
+	backups := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if strings.HasSuffix(m, "-wal") || strings.HasSuffix(m, "-shm") {
+			continue
+		}
+		backups = append(backups, m)
+	}
+	if len(backups) <= keep {
+		return nil
+	}
+	sort.Strings(backups)
+	for _, b := range backups[:len(backups)-keep] {
+		for _, suffix := range []string{"", "-wal", "-shm"} {
+			if err := os.Remove(b + suffix); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // replaceSQLiteDatabase atomically replaces the database at dst (and its WAL/SHM


### PR DESCRIPTION
S2 of epic TK-105 (refs TK-107). Hardens the migration pipeline **before** any data-moving migration in the epic.

## What
- `UpgradeInPlace` now takes a **WAL-checkpointed, integrity-verified backup inside itself** — every migration path is protected, not just server startup.
- The backup is verified (`PRAGMA integrity_check` + schema-version read) **before** the live DB is touched; the upgrade aborts if verification fails.
- **Automatic rollback**: a migration that fails partway restores the DB (and sidecars) from the verified backup and returns a clear error; the original DB is left intact.
- Timestamped backups with retention (`DefaultBackupRetention = 5`), pruned on success.
- `UpgradeResult` + `UpgradeInPlaceWithBackup`; `UpgradeInPlace` is a thin wrapper. `runSchemaUpgrade` is a test seam for injecting a failing migration.
- cmd callers use the internal verified backup (no redundant copy); `-no-backup` now only declines to *retain* the backup — it can never skip the safety net.
- RUNBOOKS: pre-upgrade backup, rollback, and manual restore documented.

## Tests
- `TestUpgradeInPlaceRollsBackOnFailedMigration` — injects a destructive-then-failing migration; asserts data + schema version recovered and error surfaced.
- `TestUpgradeInPlaceTakesVerifiedBackup`, `TestVerifyDatabaseBackupRejectsBadBackups`, `TestPruneOldBackupsRetainsNewest`.
- `go test ./internal/store/` green except a **pre-existing** failure `TestFailureEscalationInboxLifecycle` that also fails on `origin/main` (unrelated to this change). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)