### PR TITLE
TK-108: Centralize ticket column list + scan helper (kill SELECT fan-out)

### DIFF
--- a/internal/store/reorder.go
+++ b/internal/store/reorder.go
@@ -92,7 +92,7 @@ func ReorderChildTickets(ctx context.Context, db *sql.DB, parentID string, order
 // explicit sort_order (creation order as tie-break).
 func ListChildTicketsByOrder(ctx context.Context, db *sql.DB, parentID string) ([]Ticket, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
+		SELECT `+ticketSelectColumns("")+`
 		FROM tickets
 		WHERE parent_id = ? AND deleted = 0
 		ORDER BY sort_order, created_at, ticket_id

--- a/internal/store/ticket.go
+++ b/internal/store/ticket.go
@@ -1211,7 +1211,7 @@ func ListTickets(ctx context.Context, db *sql.DB, params TicketListParams) ([]Ti
 	}
 
 	query := `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
+		SELECT ` + ticketSelectColumns("") + `
 		FROM tickets
 		WHERE project_id = ?
 	`
@@ -1297,7 +1297,7 @@ func SearchTickets(ctx context.Context, db *sql.DB, projectID int64, query strin
 
 func GetTicketByProject(ctx context.Context, db *sql.DB, projectID int64, id string) (Ticket, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
+		SELECT `+ticketSelectColumns("")+`
 		FROM tickets
 		WHERE project_id = ? AND ticket_id = ? AND deleted = 0
 	`, projectID, id)
@@ -1313,7 +1313,7 @@ func GetTicketByProject(ctx context.Context, db *sql.DB, projectID int64, id str
 
 func GetTicket(ctx context.Context, db *sql.DB, id string) (Ticket, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
+		SELECT `+ticketSelectColumns("")+`
 		FROM tickets
 		WHERE ticket_id = ? AND deleted = 0
 	`, id)
@@ -1413,31 +1413,15 @@ func ListTicketParents(ctx context.Context, db *sql.DB, id string) ([]Ticket, er
 	// Load the full ancestor chain in one recursive CTE query instead of
 	// making one GetTicket() call per ancestor level (O(depth) queries).
 	rows, err := db.QueryContext(ctx, `
-		WITH RECURSIVE ancestors(ticket_id, project_id, parent_id, clone_of, type, title,
-		  description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch,
-		  workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order,
-		  estimate_effort, estimate_complete, health_score, assignee, author,
-		  draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, created_by, created_at, updated_at, recommended_ready, pr_url, started_at) AS (
-			SELECT ticket_id, project_id, parent_id, clone_of, type, title,
-			  description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch,
-			  workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order,
-			  estimate_effort, estimate_complete, health_score, assignee, COALESCE(author,''),
-			  draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by,''), created_at, updated_at, COALESCE(recommended_ready,0), COALESCE(pr_url,''), COALESCE(started_at,'')
+		WITH RECURSIVE ancestors(`+ticketColumnList()+`) AS (
+			SELECT `+ticketSelectColumns("")+`
 			FROM tickets WHERE ticket_id = ? AND deleted = 0
 			UNION ALL
-			SELECT t.ticket_id, t.project_id, t.parent_id, t.clone_of, t.type, t.title,
-			  t.description, t.acceptance_criteria, t.dor_map, t.dod_map, t.ac_map, t.git_repository, t.git_branch,
-			  t.workflow_id, t.workflow_stage_id, t.role_id, t.stage, t.state, t.status, t.priority, t.sort_order,
-			  t.estimate_effort, t.estimate_complete, t.health_score, t.assignee, COALESCE(t.author,''),
-			  t.draft, t.complete, t.archived, t.deleted, t.previous_workflow_stage_id, t.previous_role_id, t.release_id, COALESCE(t.created_by,''), t.created_at, t.updated_at, COALESCE(t.recommended_ready,0), COALESCE(t.pr_url,''), COALESCE(t.started_at,'')
+			SELECT `+ticketSelectColumns("t")+`
 			FROM tickets t
 			JOIN ancestors a ON t.ticket_id = a.parent_id
 		)
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title,
-		  description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch,
-		  workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order,
-		  estimate_effort, estimate_complete, health_score, assignee, author,
-		  draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, created_by, created_at, updated_at, recommended_ready, pr_url, started_at
+		SELECT `+ticketColumnList()+`
 		FROM ancestors
 		WHERE ticket_id != ?
 	`, id, id)
@@ -1476,6 +1460,58 @@ func ListTicketParents(ctx context.Context, db *sql.DB, id string) ([]Ticket, er
 
 type scanner interface {
 	Scan(dest ...any) error
+}
+
+// ticketColumnNames is the single source of truth for the tickets columns, in the
+// exact order scanTicket reads them. Adding a column means appending here (plus a
+// scan target in scanTicket and a field on Ticket) instead of editing every
+// SELECT in this package.
+var ticketColumnNames = []string{
+	"ticket_id", "project_id", "parent_id", "clone_of", "type", "title",
+	"description", "acceptance_criteria", "dor_map", "dod_map", "ac_map",
+	"git_repository", "git_branch", "workflow_id", "workflow_stage_id", "role_id",
+	"stage", "state", "status", "priority", "sort_order", "estimate_effort",
+	"estimate_complete", "health_score", "assignee", "author", "draft", "complete",
+	"archived", "deleted", "previous_workflow_stage_id", "previous_role_id",
+	"release_id", "created_by", "created_at", "updated_at", "recommended_ready",
+	"pr_url", "started_at",
+}
+
+// ticketColumnCoalesce maps nullable columns to the SQL literal substituted via
+// COALESCE when selecting them, so scanTicket can scan into non-pointer fields.
+var ticketColumnCoalesce = map[string]string{
+	"author":            "''",
+	"created_by":        "''",
+	"recommended_ready": "0",
+	"pr_url":            "''",
+	"started_at":        "''",
+}
+
+// ticketSelectColumns returns the comma-separated SELECT expressions for reading a
+// ticket row in scanTicket order. When alias is non-empty (e.g. "t"), every column
+// reference is prefixed with it; COALESCE wrappers are applied per
+// ticketColumnCoalesce.
+func ticketSelectColumns(alias string) string {
+	prefix := ""
+	if alias != "" {
+		prefix = alias + "."
+	}
+	parts := make([]string, len(ticketColumnNames))
+	for i, col := range ticketColumnNames {
+		if def, ok := ticketColumnCoalesce[col]; ok {
+			parts[i] = "COALESCE(" + prefix + col + ", " + def + ")"
+		} else {
+			parts[i] = prefix + col
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// ticketColumnList returns the bare comma-separated column names in scanTicket
+// order, used for CTE column declarations and for selecting out of a CTE whose
+// values are already coalesced.
+func ticketColumnList() string {
+	return strings.Join(ticketColumnNames, ", ")
 }
 
 func scanTicket(s scanner) (Ticket, error) {
@@ -1835,7 +1871,7 @@ func recalculateParentLifecycle(ctx context.Context, db *sql.DB, id, actorID str
 
 func listStoredChildTickets(ctx context.Context, db *sql.DB, parentID string) ([]Ticket, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
+		SELECT `+ticketSelectColumns("")+`
 		FROM tickets
 		WHERE parent_id = ? AND deleted = 0
 		ORDER BY created_at, ticket_id
@@ -1858,7 +1894,7 @@ func listStoredChildTickets(ctx context.Context, db *sql.DB, parentID string) ([
 
 func getStoredTicket(ctx context.Context, db *sql.DB, id string) (Ticket, error) {
 	ticket, err := scanTicket(db.QueryRowContext(ctx, `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
+		SELECT `+ticketSelectColumns("")+`
 		FROM tickets
 		WHERE ticket_id = ?
 	`, id))
@@ -2100,7 +2136,7 @@ func ticketClaimable(ctx context.Context, db *sql.DB, ticket Ticket, projectID i
 
 func findAssignedTicketForUser(ctx context.Context, db *sql.DB, projectID int64, username, state string) (Ticket, bool, error) {
 	query := `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
+		SELECT ` + ticketSelectColumns("") + `
 		FROM tickets
 		WHERE assignee = ? AND complete = 0 AND archived = 0 AND deleted = 0 AND state = ?
 	`
@@ -2133,7 +2169,7 @@ func findClaimCandidate(ctx context.Context, db *sql.DB, projectID int64, roleNa
 	if projectID == 0 {
 		return Ticket{}, false, errors.New("project is required")
 	}
-	query := `SELECT t.ticket_id, t.project_id, t.parent_id, t.clone_of, t.type, t.title, t.description, t.acceptance_criteria, t.dor_map, t.dod_map, t.ac_map, t.git_repository, t.git_branch, t.workflow_id, t.workflow_stage_id, t.role_id, t.stage, t.state, t.status, t.priority, t.sort_order, t.estimate_effort, t.estimate_complete, t.health_score, t.assignee, COALESCE(t.author, ''), t.draft, t.complete, t.archived, t.deleted, t.previous_workflow_stage_id, t.previous_role_id, t.release_id, COALESCE(t.created_by, ''), t.created_at, t.updated_at, COALESCE(t.recommended_ready, 0), COALESCE(t.pr_url, ''), COALESCE(t.started_at, '')
+	query := `SELECT ` + ticketSelectColumns("t") + `
 		FROM tickets t
 		JOIN projects p ON p.project_id = t.project_id
 		LEFT JOIN roles r ON r.role_id = t.role_id


### PR DESCRIPTION
S3 of epic TK-105 (refs TK-108). **Pure refactor, no behavior change.**

## What
Adds a single source of truth for the tickets columns in `internal/store/ticket.go`:
- `ticketColumnNames` — canonical column order matching `scanTicket`.
- `ticketColumnCoalesce` — nullable columns + their COALESCE defaults.
- `ticketSelectColumns(alias)` — builds the SELECT expression list (optionally alias-prefixed, COALESCE applied).
- `ticketColumnList()` — bare names for CTE column declarations / selecting out of a CTE.

Refactors **all 9 ticket read sites** to use them: `ListTickets`, `GetTicket`, `GetTicketByProject`, `listStoredChildTickets`, `getStoredTicket`, `findAssignedTicketForUser`, `findClaimCandidate` (aliased), the recursive ancestor CTE (declaration + anchor + recursive + final select), and `reorder.ListChildTicketsByOrder`.

## Why
Previously a new column had to be threaded positionally through ~10 hand-written SELECTs. Now it's: append to `ticketColumnNames` + add a scan target + struct field. This is what makes adding `attrs` (TK-109) a one-line change and de-risks the consolidation stories.

## Tests
`go test ./internal/store/ ./internal/server/ ./internal/client/ ./libticket/ ./cmd/tk/` all green except the **pre-existing** `TestFailureEscalationInboxLifecycle` (also red on `origin/main`). Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)