### PR TITLE
TK-109: Introduce attrs JSON attribute bag (tickets/projects/roles/stages)

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1146,7 +1146,7 @@ Outcomes:
 ## Schema evolution (extensible attributes)
 
 Schema change in `tk` is governed by a three-tier model (epic TK-105): typed
-first-class columns for queried/constrained data, a per-entity `attrs` JSONB
+first-class columns for queried/constrained data, a per-entity `attrs` JSON (TEXT)
 attribute bag as the default home for new optional/sparse/per-type fields (added
 in Go with no migration), and promotion of bag fields to expression indexes when
 they need to be queried. Migrations take a WAL-checkpointed, integrity-verified

--- a/docs/ENTITY_MODEL.md
+++ b/docs/ENTITY_MODEL.md
@@ -1125,7 +1125,7 @@ This example is intentionally small, but it shows the principle:
 > decision record: `docs/adr/0001-json-attribute-bags.md`.
 
 To lower the likelihood and blast radius of schema change, the high-churn
-entities (TICKET, PROJECT, ROLE, STAGE) each carry an `attrs` **JSONB** column —
+entities (TICKET, PROJECT, ROLE, STAGE) each carry an `attrs` **JSON (TEXT)** column —
 a governed attribute bag. Fields are classified into three tiers:
 
 1. **Tier 1 — first-class columns.** Anything needing a foreign key, `NOT NULL`,

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1499,7 +1499,7 @@ Tests must cover:
 ## Extensible attributes (`attrs`)
 
 High-churn entities (tickets, projects, roles, workflow_stages) carry an `attrs`
-JSONB column — a governed attribute bag for optional, sparse, display-only and
+JSON (TEXT) column — a governed attribute bag for optional, sparse, display-only and
 per-type fields. New Tier-2 fields are added without a schema migration or
 version bump; fields are promoted to expression indexes (`json_extract`) when
 they must be queried. Authoritative design: `docs/design/extensible-schema.md`.

--- a/docs/adr/0001-json-attribute-bags.md
+++ b/docs/adr/0001-json-attribute-bags.md
@@ -20,16 +20,21 @@ Adopt a **governed three-tier model**:
 
 1. **Tier 1 — first-class columns** for anything needing FK / NOT NULL / hot
    WHERE-ORDER BY / aggregation. Unchanged.
-2. **Tier 2 — a per-entity `attrs` JSONB bag** as the default home for optional,
+2. **Tier 2 — a per-entity `attrs` JSON bag** as the default home for optional,
    sparse, display-only, and per-type fields. Adding a Tier-2 field is a pure-Go
    change to a typed accessor struct — no SQL, no version bump.
 3. **Tier 3 — promotion** of a bag field to query-grade via an idempotent
    expression index (`json_extract`) or, rarely, a generated column.
 
-Store the bag as **JSONB (BLOB)** using SQLite 3.45+ binary JSON, available via
-`modernc.org/sqlite v1.48.0`. Centralize the ticket column list + scan to remove
-the fan-out. Harden migrations with checkpointed, integrity-verified backups and
-automatic rollback.
+Store the bag as **TEXT JSON** (`TEXT NOT NULL DEFAULT '{}'`). Binary JSONB
+(SQLite 3.45+, available via `modernc.org/sqlite v1.48.0`) was the original
+choice for compactness but was rejected during implementation because binary
+JSONB does not survive the generic snapshot export/import that backs both
+backup/restore and the migration rebuild path (binary bytes are not valid UTF-8
+and round-trip as "malformed JSON"). `json_extract` and expression indexes work
+identically on TEXT, so queryability is unaffected. Centralize the ticket column
+list + scan to remove the fan-out. Harden migrations with checkpointed,
+integrity-verified backups and automatic rollback.
 
 ## Alternatives considered
 
@@ -44,9 +49,9 @@ and type-safety evaporates. Classic anti-pattern for first-class entity data.
 
 ### C. Plain TEXT JSON column
 Partially accepted but superseded. The existing `dor_map`/`dod_map`/`ac_map`
-columns already use TEXT JSON and work. JSONB is more compact and faster to parse
-while remaining queryable by the same `json_*` functions, so new storage uses
-JSONB; TEXT JSON is retained only transitionally until S6 folds those columns in.
+columns already use TEXT JSON and work. Binary JSONB would be more compact but
+does not survive snapshot export/import (see Decision), so TEXT JSON is the
+chosen storage for `attrs` as well — consistent with the existing guidance maps.
 
 ### D. Generated columns for everything
 Rejected as the default. Generated columns are useful for promotion (Tier 3) but
@@ -58,7 +63,7 @@ that needs a real column surface over a bag field.
 - Adding an optional field becomes a no-migration, no-version-bump Go change.
 - Querying a bag field requires an explicit promotion step (expression index),
   making "is this field queryable?" an intentional decision rather than a default.
-- The `attrs` blob is opaque in raw SQLite shells (mitigated: read via
-  `json(attrs)`); slightly higher write cost to encode JSONB.
+- `attrs` is human-readable TEXT JSON in raw SQLite shells and round-trips
+  cleanly through snapshot export/import.
 - Migration safety is materially improved for ALL migration paths, not just the
   consolidation in this epic.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -252,6 +252,12 @@ components:
         updated_at:
           type: string
           format: date-time
+        attrs:
+          type: object
+          additionalProperties: true
+          description: >-
+            Extensible attribute bag (epic TK-105). Optional/sparse fields stored
+            without a schema migration. Omitting attrs on update preserves it.
 
     PullRequest:
       type: object
@@ -493,6 +499,13 @@ components:
         started_at:
           type: string
           description: When the ticket last entered the active state (in-progress since).
+        attrs:
+          type: object
+          additionalProperties: true
+          description: >-
+            Extensible attribute bag (epic TK-105). Home for optional, sparse,
+            display-only and per-type fields; new fields are added without a schema
+            migration. On update, omitting attrs preserves the existing bag.
 
     ResolvedGuidance:
       type: object
@@ -697,6 +710,12 @@ components:
         updated_at:
           type: string
           format: date-time
+        attrs:
+          type: object
+          additionalProperties: true
+          description: >-
+            Extensible attribute bag (epic TK-105). Set via the stage attrs setter;
+            preserved across normal stage updates.
 
     InterventionState:
       type: object
@@ -948,6 +967,12 @@ components:
         updated_at:
           type: string
           format: date-time
+        attrs:
+          type: object
+          additionalProperties: true
+          description: >-
+            Extensible attribute bag (epic TK-105). Optional/sparse fields stored
+            without a schema migration. Omitting attrs on update preserves it.
 
     Label:
       type: object

--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -92,25 +92,31 @@ flowchart TD
   E -- Yes, needs column surface --> G[Tier 3: generated column]
 ```
 
-## 4. Storage format: JSONB
+## 4. Storage format: TEXT JSON (not binary JSONB)
 
 SQLite has no `JSONB` *column type* (unlike Postgres). "JSONB" in SQLite is the
 binary on-disk encoding introduced in **SQLite 3.45** (Jan 2024), produced by
 `jsonb()` / `jsonb_extract()` and stored in a `BLOB`. Our driver
 `modernc.org/sqlite v1.48.0` embeds a SQLite new enough to support it.
 
-Decision: **store `attrs` as JSONB (BLOB)**, written via `jsonb(?)` and read via
-`json(attrs)` (which renders JSONB back to text for Go's `encoding/json`), with
-`json_extract(attrs,'$.path')` for queries. Rationale: more compact and faster to
-parse than TEXT JSON; `json_extract` works transparently on either encoding so
-expression indexes are unaffected.
+The original design (S1) proposed binary JSONB for compactness. During
+implementation (S4) we found a blocking problem: **binary JSONB does not survive
+the snapshot export/import** used by both the backup/restore feature
+(`tk export`/`tk import`) and the migration rebuild path (`UpgradeDatabase`). The
+snapshot serializes every column generically via `[]byte → string → JSON`, and
+binary JSONB bytes are not valid UTF-8, so a round-tripped value comes back as
+"malformed JSON". Data integrity of backups and migrations outranks the marginal
+size/speed win of binary encoding.
 
-The column is declared `attrs BLOB NOT NULL DEFAULT (jsonb('{}'))` so existing
-rows and inserts that omit it get a valid empty object.
+Decision (revised): **store `attrs` as `TEXT NOT NULL DEFAULT '{}'`**, written as
+plain JSON text (`attrs = ?`) and read as text. `json_extract(attrs,'$.path')`
+and expression indexes work identically on TEXT, so Tier-3 promotion (§3) is
+unchanged. The constant `'{}'` default is also permitted on
+`ALTER TABLE ADD COLUMN`, so the migration needs no backfill.
 
 > Coexistence: the existing `dor_map` / `dod_map` / `ac_map` TEXT-JSON columns
-> keep working unchanged until S6 folds them into `attrs`. Both encodings are
-> readable by the same `json_*` functions during the transition.
+> keep working unchanged until S6 folds them into `attrs`. All are TEXT JSON and
+> readable by the same `json_*` functions.
 
 ## 5. Typed accessor layer
 

--- a/internal/server/api_projects.go
+++ b/internal/server/api_projects.go
@@ -64,6 +64,7 @@ func (r *router) registerProjectHandlers() {
 				AgentModelName:     projectPayload.AgentModelName,
 				AgentModelURL:      projectPayload.AgentModelURL,
 				AgentModelAPIKey:   projectPayload.AgentModelAPIKey,
+				Attrs:              projectPayload.Attrs,
 			})
 			if err != nil {
 				writeStoreError(w, err)
@@ -1481,6 +1482,7 @@ func (r *router) registerProjectHandlers() {
 				AgentModelName:     projectPayload.AgentModelName,
 				AgentModelURL:      projectPayload.AgentModelURL,
 				AgentModelAPIKey:   projectPayload.AgentModelAPIKey,
+				Attrs:              projectPayload.Attrs,
 			})
 			if err != nil {
 				if errors.Is(err, store.ErrProjectNotFound) {

--- a/internal/server/api_roles.go
+++ b/internal/server/api_roles.go
@@ -47,6 +47,7 @@ func (r *router) registerRoleHandlers() {
 				DORMap:             payload.DORMap,
 				DODMap:             payload.DODMap,
 				ACMap:              payload.ACMap,
+				Attrs:              payload.Attrs,
 			})
 			if err != nil {
 				writeStoreError(w, err)
@@ -83,6 +84,7 @@ func (r *router) registerRoleHandlers() {
 				DORMap:             payload.DORMap,
 				DODMap:             payload.DODMap,
 				ACMap:              payload.ACMap,
+				Attrs:              payload.Attrs,
 			})
 			if err != nil {
 				if errors.Is(err, sql.ErrNoRows) {

--- a/internal/server/api_tickets.go
+++ b/internal/server/api_tickets.go
@@ -209,6 +209,7 @@ func (r *router) registerTicketHandlers() {
 			State:              state,
 			Author:             user.Username,
 			CreatedBy:          user.ID,
+			Attrs:              ticketPayload.Attrs,
 		})
 		if err != nil {
 			writeStoreError(w, err)
@@ -1813,6 +1814,7 @@ func (r *router) registerTicketHandlers() {
 					EstimateEffort:     ticketPayload.EstimateEffort,
 					EstimateComplete:   ticketPayload.EstimateComplete,
 					Type:               ticketPayload.Type,
+					Attrs:              ticketPayload.Attrs,
 					UpdatedBy:          user.ID,
 					ActorUsername:      user.Username,
 					ActorRole:          user.Role,

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -76,6 +76,7 @@ type projectRequest struct {
 	AgentModelName     string            `json:"agent_model_name"`
 	AgentModelURL      string            `json:"agent_model_url"`
 	AgentModelAPIKey   string            `json:"agent_model_api_key"`
+	Attrs              store.Attrs       `json:"attrs,omitempty"`
 }
 
 type pullRequestRequest struct {
@@ -103,6 +104,7 @@ type roleRequest struct {
 	DORMap             store.GuidanceMap `json:"dor_map,omitempty"`
 	DODMap             store.GuidanceMap `json:"dod_map,omitempty"`
 	ACMap              store.GuidanceMap `json:"ac_map,omitempty"`
+	Attrs              store.Attrs       `json:"attrs,omitempty"`
 }
 
 type agentModelConfigRequest struct {
@@ -196,6 +198,7 @@ type ticketRequest struct {
 	EstimateEffort     int               `json:"estimate_effort"`
 	EstimateComplete   string            `json:"estimate_complete,omitempty"`
 	Assignee           string            `json:"assignee"`
+	Attrs              store.Attrs       `json:"attrs,omitempty"`
 	Message            string            `json:"message,omitempty"`
 }
 

--- a/internal/store/attrs.go
+++ b/internal/store/attrs.go
@@ -1,0 +1,101 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Attrs is the extensible attribute bag stored in the `attrs` column on the
+// high-churn entities (tickets, projects, roles, workflow_stages). It is the
+// default home for new optional, sparse, display-only, and per-type fields: such a
+// field can be added in Go without a schema migration or schema-version bump. See
+// docs/design/extensible-schema.md and docs/adr/0001-json-attribute-bags.md.
+//
+// The bag is stored as TEXT JSON (not binary JSONB) so it survives the generic
+// snapshot export/import used by backups and the migration rebuild path. It is
+// queryable via json_extract; fields that must be filtered/sorted are "promoted"
+// with an expression index rather than a new column.
+type Attrs map[string]any
+
+// marshalAttrs serializes an Attrs bag to compact JSON text for the TEXT attrs
+// column. A nil or empty bag yields "{}" so the column is never NULL when written.
+func marshalAttrs(a Attrs) (string, error) {
+	if len(a) == 0 {
+		return "{}", nil
+	}
+	b, err := json.Marshal(a)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// parseAttrs parses attrs JSON text (as returned by json(attrs)) into an Attrs
+// bag. Empty, whitespace-only, or SQL-NULL text yields an empty (non-nil) bag so
+// callers can always read and mutate the result safely.
+func parseAttrs(text string) (Attrs, error) {
+	t := strings.TrimSpace(text)
+	if t == "" || t == "null" {
+		return Attrs{}, nil
+	}
+	var a Attrs
+	if err := json.Unmarshal([]byte(t), &a); err != nil {
+		return nil, err
+	}
+	if a == nil {
+		a = Attrs{}
+	}
+	return a, nil
+}
+
+// GetString returns the value at key as a string, or "" if absent or not a string.
+func (a Attrs) GetString(key string) string {
+	if v, ok := a[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// GetInt returns the value at key as an int. JSON numbers decode to float64, which
+// is handled here. Returns 0 if absent or not numeric.
+func (a Attrs) GetInt(key string) int {
+	switch v := a[key].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case json.Number:
+		n, _ := v.Int64()
+		return int(n)
+	default:
+		return 0
+	}
+}
+
+// SetString sets key to a non-empty string value, deleting the key when val is
+// empty so the stored bag stays sparse. It is a no-op on a nil map.
+func (a Attrs) SetString(key, val string) {
+	if a == nil {
+		return
+	}
+	if val == "" {
+		delete(a, key)
+		return
+	}
+	a[key] = val
+}
+
+// SetInt sets key to a non-zero int value, deleting the key when val is zero so the
+// stored bag stays sparse. It is a no-op on a nil map.
+func (a Attrs) SetInt(key string, val int) {
+	if a == nil {
+		return
+	}
+	if val == 0 {
+		delete(a, key)
+		return
+	}
+	a[key] = val
+}

--- a/internal/store/attrs_test.go
+++ b/internal/store/attrs_test.go
@@ -1,0 +1,241 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func attrsTestDB(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "attrs.db")
+	if err := Init(path, "admin", "secret12"); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db, path
+}
+
+func TestTicketAttrsRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	// Empty bag: created without attrs reads back empty.
+	plain, err := CreateTicket(ctx, db, TicketCreateParams{ProjectID: 1, Type: "task", Title: "plain"})
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+	if len(plain.Attrs) != 0 {
+		t.Fatalf("new ticket attrs = %v, want empty", plain.Attrs)
+	}
+
+	// Populated + nested bag round-trips through create.
+	nested := Attrs{
+		"repro_steps": "open app; click; crash",
+		"severity":    "high",
+		"meta":        map[string]any{"count": float64(3), "tags": []any{"a", "b"}},
+	}
+	tk, err := CreateTicket(ctx, db, TicketCreateParams{ProjectID: 1, Type: "bug", Title: "bug", Attrs: nested})
+	if err != nil {
+		t.Fatalf("CreateTicket(with attrs) error = %v", err)
+	}
+	got, err := GetTicket(ctx, db, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if !reflect.DeepEqual(got.Attrs, nested) {
+		t.Fatalf("round-tripped attrs = %#v, want %#v", got.Attrs, nested)
+	}
+
+	// Update with nil Attrs preserves the existing bag.
+	if _, err := UpdateTicket(ctx, db, tk.ID, TicketUpdateParams{Title: "bug2", ActorUsername: "admin", ActorRole: "admin"}); err != nil {
+		t.Fatalf("UpdateTicket(preserve) error = %v", err)
+	}
+	preserved, err := GetTicket(ctx, db, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if !reflect.DeepEqual(preserved.Attrs, nested) {
+		t.Fatalf("after preserve update attrs = %#v, want %#v", preserved.Attrs, nested)
+	}
+
+	// Update with a new bag replaces it.
+	replacement := Attrs{"severity": "low"}
+	if _, err := UpdateTicket(ctx, db, tk.ID, TicketUpdateParams{Title: "bug2", Attrs: replacement, ActorUsername: "admin", ActorRole: "admin"}); err != nil {
+		t.Fatalf("UpdateTicket(replace) error = %v", err)
+	}
+	replaced, err := GetTicket(ctx, db, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if !reflect.DeepEqual(replaced.Attrs, replacement) {
+		t.Fatalf("after replace attrs = %#v, want %#v", replaced.Attrs, replacement)
+	}
+}
+
+func TestProjectAttrsRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	bag := Attrs{"jira_key": "ABC-1", "config": map[string]any{"x": float64(1)}}
+	p, err := CreateProjectWithParams(ctx, db, ProjectCreateParams{Title: "P", Prefix: "PX", Attrs: bag})
+	if err != nil {
+		t.Fatalf("CreateProjectWithParams() error = %v", err)
+	}
+	got, err := GetProjectByID(ctx, db, p.ID)
+	if err != nil {
+		t.Fatalf("GetProjectByID() error = %v", err)
+	}
+	if !reflect.DeepEqual(got.Attrs, bag) {
+		t.Fatalf("project attrs = %#v, want %#v", got.Attrs, bag)
+	}
+	// Preserve on update without Attrs.
+	if _, err := UpdateProjectWithParams(ctx, db, p.ID, ProjectUpdateParams{Title: "P2"}); err != nil {
+		t.Fatalf("UpdateProjectWithParams() error = %v", err)
+	}
+	pres, err := GetProjectByID(ctx, db, p.ID)
+	if err != nil {
+		t.Fatalf("GetProjectByID() error = %v", err)
+	}
+	if !reflect.DeepEqual(pres.Attrs, bag) {
+		t.Fatalf("project attrs after preserve = %#v, want %#v", pres.Attrs, bag)
+	}
+}
+
+func TestRoleAttrsRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	bag := Attrs{"color": "blue"}
+	r, err := CreateRoleWithParams(ctx, db, RoleCreateParams{Title: "Architect", Attrs: bag})
+	if err != nil {
+		t.Fatalf("CreateRoleWithParams() error = %v", err)
+	}
+	got, err := GetRoleByID(ctx, db, r.ID)
+	if err != nil {
+		t.Fatalf("GetRoleByID() error = %v", err)
+	}
+	if !reflect.DeepEqual(got.Attrs, bag) {
+		t.Fatalf("role attrs = %#v, want %#v", got.Attrs, bag)
+	}
+}
+
+func TestWorkflowStageAttrsRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	wf, err := CreateWorkflow(ctx, db, "wf-attrs", "")
+	if err != nil {
+		t.Fatalf("CreateWorkflow() error = %v", err)
+	}
+	stage, err := AddWorkflowStageWithDefinitions(ctx, db, wf.ID, "design", "", "", "", 0)
+	if err != nil {
+		t.Fatalf("AddWorkflowStageWithDefinitions() error = %v", err)
+	}
+	if len(stage.Attrs) != 0 {
+		t.Fatalf("new stage attrs = %v, want empty", stage.Attrs)
+	}
+	bag := Attrs{"board_color": "green", "wip_limit": float64(5)}
+	updated, err := SetWorkflowStageAttrs(ctx, db, stage.ID, bag)
+	if err != nil {
+		t.Fatalf("SetWorkflowStageAttrs() error = %v", err)
+	}
+	if !reflect.DeepEqual(updated.Attrs, bag) {
+		t.Fatalf("stage attrs = %#v, want %#v", updated.Attrs, bag)
+	}
+	// A normal stage update must preserve attrs (attrs is not in its SET clause).
+	if _, err := UpdateWorkflowStage(ctx, db, stage.ID, "design", "desc", "ac"); err != nil {
+		t.Fatalf("UpdateWorkflowStage() error = %v", err)
+	}
+	wfs, err := GetWorkflow(ctx, db, wf.ID)
+	if err != nil {
+		t.Fatalf("GetWorkflow() error = %v", err)
+	}
+	if len(wfs.Stages) == 0 || !reflect.DeepEqual(wfs.Stages[0].Attrs, bag) {
+		t.Fatalf("stage attrs after normal update not preserved: %+v", wfs.Stages)
+	}
+}
+
+// TestAttrsZeroDDLExtensibility demonstrates that a brand-new optional field can be
+// stored and read back with NO schema migration and NO schema-version bump — the
+// whole point of the bag. The schema version is identical before and after.
+func TestAttrsZeroDDLExtensibility(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+
+	before, err := DetectSchemaVersion(path)
+	if err != nil {
+		t.Fatalf("DetectSchemaVersion() error = %v", err)
+	}
+	// A field that does not exist anywhere in the schema today.
+	tk, err := CreateTicket(ctx, db, TicketCreateParams{
+		ProjectID: 1, Type: "spike", Title: "timeboxed",
+		Attrs: Attrs{"timebox_hours": float64(8), "spike_outcome": "spike-doc"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+	got, err := GetTicket(ctx, db, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if got.Attrs.GetInt("timebox_hours") != 8 || got.Attrs.GetString("spike_outcome") != "spike-doc" {
+		t.Fatalf("new field not stored/read: %#v", got.Attrs)
+	}
+	after, err := DetectSchemaVersion(path)
+	if err != nil {
+		t.Fatalf("DetectSchemaVersion() error = %v", err)
+	}
+	if before != after {
+		t.Fatalf("schema version changed (%d -> %d) for a new Tier-2 field; expected no migration", before, after)
+	}
+}
+
+// TestAttrsMigrationReaddsColumns exercises the additive attrs migration: dropping
+// the attrs columns and re-running the in-place upgrade restores them.
+func TestAttrsMigrationReaddsColumns(t *testing.T) {
+	// Not parallel: opens the DB with a second raw connection.
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+	_ = db.Close()
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	for _, table := range []string{"tickets", "projects", "roles", "workflow_stages"} {
+		if _, err := raw.Exec(`ALTER TABLE ` + table + ` DROP COLUMN attrs`); err != nil {
+			_ = raw.Close()
+			t.Fatalf("drop attrs from %s error = %v", table, err)
+		}
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw.Close() error = %v", err)
+	}
+
+	if _, err := UpgradeInPlace(ctx, path); err != nil {
+		t.Fatalf("UpgradeInPlace() error = %v", err)
+	}
+
+	check, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() after upgrade error = %v", err)
+	}
+	defer check.Close()
+	for _, table := range []string{"tickets", "projects", "roles", "workflow_stages"} {
+		if !columnExists(ctx, check, table, "attrs") {
+			t.Fatalf("attrs column not restored on %s", table)
+		}
+	}
+}

--- a/internal/store/project.go
+++ b/internal/store/project.go
@@ -44,6 +44,7 @@ type Project struct {
 	AgentModelURL      string      `json:"agent_model_url"`
 	AgentModelAPIKey   string      `json:"agent_model_api_key"`
 	ProgrammeID        *int64      `json:"programme_id"`
+	Attrs              Attrs       `json:"attrs,omitempty"`
 }
 
 func (p Project) ResolveGuidance(stage string) ResolvedGuidance {
@@ -69,6 +70,7 @@ type ProjectCreateParams struct {
 	AgentModelName     string
 	AgentModelURL      string
 	AgentModelAPIKey   string
+	Attrs              Attrs
 }
 
 type ProjectUpdateParams struct {
@@ -88,6 +90,7 @@ type ProjectUpdateParams struct {
 	AgentModelName     string
 	AgentModelURL      string
 	AgentModelAPIKey   string
+	Attrs              Attrs // nil = preserve existing attrs; non-nil = replace the bag
 }
 
 func CreateProject(ctx context.Context, db *sql.DB, title, description, acceptanceCriteria, createdBy string) (Project, error) {
@@ -152,19 +155,24 @@ func CreateProjectWithParams(ctx context.Context, db *sql.DB, params ProjectCrea
 	if acceptanceCriteria == "" && acMap != nil {
 		acceptanceCriteria = acMap[DefaultGuidanceStageKey]
 	}
+	attrsJSON, err := marshalAttrs(params.Attrs)
+	if err != nil {
+		return Project{}, err
+	}
 	query := `
-		INSERT INTO projects (prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO projects (prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, attrs)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	args := []any{
 		uniquePrefix, title, strings.TrimSpace(params.Description), acceptanceCriteria, dorJSON, dodJSON, acJSON,
 		strings.TrimSpace(params.GitRepository), strings.TrimSpace(params.Notes), visibility, nullableUserID(params.CreatedBy), workflowID,
 		strings.TrimSpace(params.AgentModelProvider), strings.TrimSpace(params.AgentModelName), strings.TrimSpace(params.AgentModelURL), strings.TrimSpace(params.AgentModelAPIKey),
+		attrsJSON,
 	}
 	if hasExplicitID {
 		query = `
-			INSERT INTO projects (project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?)
+			INSERT INTO projects (project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, attrs)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?, ?)
 		`
 		args = append([]any{explicitID}, args...)
 	}
@@ -200,16 +208,21 @@ func scanProject(s scanner) (Project, error) {
 	var workflowID sql.NullInt64
 	var programmeID sql.NullInt64
 	var dorJSON, dodJSON, acJSON string
+	var attrsJSON sql.NullString
 	if err := s.Scan(
 		&project.ID, &project.Prefix, &project.Title, &project.Description, &project.AcceptanceCriteria,
 		&dorJSON, &dodJSON, &acJSON, &project.GitRepository, &project.Notes, &project.Status, &project.Visibility,
 		&project.DefaultDraft, &project.CreatedBy, &project.CreatedAt, &project.UpdatedAt, &workflowID,
 		&project.AgentModelProvider, &project.AgentModelName, &project.AgentModelURL, &project.AgentModelAPIKey,
-		&programmeID,
+		&programmeID, &attrsJSON,
 	); err != nil {
 		return Project{}, err
 	}
 	var err error
+	project.Attrs, err = parseAttrs(attrsJSON.String)
+	if err != nil {
+		return Project{}, err
+	}
 	project.DORMap, err = parseGuidanceMap(dorJSON)
 	if err != nil {
 		return Project{}, err
@@ -240,7 +253,7 @@ func ListProjects(ctx context.Context, db *sql.DB, limit int) ([]Project, error)
 		limit = 1000
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
 		FROM projects
 		ORDER BY created_at, project_id
 		LIMIT ?
@@ -289,7 +302,7 @@ func ListProjectsVisibleToUser(ctx context.Context, db *sql.DB, user User) ([]Pr
 			FROM teams parent
 			JOIN team_scope ts ON ts.parent_team_id = parent.team_id
 		)
-		SELECT DISTINCT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id
+		SELECT DISTINCT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id, p.attrs
 		FROM projects p
 		LEFT JOIN project_members pm ON pm.project_id = p.project_id AND pm.user_id = ?
 		LEFT JOIN project_teams pt ON pt.project_id = p.project_id
@@ -335,7 +348,7 @@ func GetProject(ctx context.Context, db *sql.DB, rawID string) (Project, error) 
 		return GetProjectByID(ctx, db, id)
 	}
 	row := db.QueryRowContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
 		FROM projects
 		WHERE prefix = ?
 	`, strings.ToUpper(rawID))
@@ -358,7 +371,7 @@ func GetProjectByID(ctx context.Context, db *sql.DB, id int64) (Project, error) 
 		return Project{}, err
 	}
 	row := db.QueryRowContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
 		FROM projects
 		WHERE project_id = ?
 	`, id)
@@ -388,7 +401,7 @@ func GetProjectByGitRepository(ctx context.Context, db *sql.DB, gitRepository st
 		return Project{}, err
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id,
+		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id, p.attrs,
 		       r.repository
 		FROM projects p
 		JOIN project_git_repositories r ON r.project_id = p.project_id
@@ -449,17 +462,22 @@ func scanProjectWithWorkflowIDAndRepository(s scanner) (projectWithRepository, e
 	var workflowID sql.NullInt64
 	var programmeID sql.NullInt64
 	var dorJSON, dodJSON, acJSON string
+	var attrsJSON sql.NullString
 	if err := s.Scan(
 		&result.project.ID, &result.project.Prefix, &result.project.Title, &result.project.Description, &result.project.AcceptanceCriteria,
 		&dorJSON, &dodJSON, &acJSON, &result.project.GitRepository, &result.project.Notes, &result.project.Status, &result.project.Visibility,
 		&result.project.DefaultDraft, &result.project.CreatedBy, &result.project.CreatedAt, &result.project.UpdatedAt, &workflowID,
 		&result.project.AgentModelProvider, &result.project.AgentModelName, &result.project.AgentModelURL, &result.project.AgentModelAPIKey,
-		&programmeID,
+		&programmeID, &attrsJSON,
 		&result.repository,
 	); err != nil {
 		return projectWithRepository{}, err
 	}
 	var err error
+	result.project.Attrs, err = parseAttrs(attrsJSON.String)
+	if err != nil {
+		return projectWithRepository{}, err
+	}
 	result.project.DORMap, err = parseGuidanceMap(dorJSON)
 	if err != nil {
 		return projectWithRepository{}, err
@@ -578,11 +596,19 @@ func UpdateProjectWithParams(ctx context.Context, db *sql.DB, id int64, params P
 	if err != nil {
 		return Project{}, err
 	}
+	attrsToWrite := current.Attrs
+	if params.Attrs != nil {
+		attrsToWrite = params.Attrs
+	}
+	attrsJSON, err := marshalAttrs(attrsToWrite)
+	if err != nil {
+		return Project{}, err
+	}
 	_, err = db.ExecContext(ctx, `
 		UPDATE projects
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, notes = ?, status = ?, visibility = ?, workflow_id = ?, agent_model_provider = ?, agent_model_name = ?, agent_model_url = ?, agent_model_api_key = ?, updated_at = CURRENT_TIMESTAMP
+		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, notes = ?, status = ?, visibility = ?, workflow_id = ?, agent_model_provider = ?, agent_model_name = ?, agent_model_url = ?, agent_model_api_key = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE project_id = ?
-	`, nextTitle, nextDescription, nextAC, dorJSON, dodJSON, acJSON, nextRepo, nextNotes, nextStatus, nextVisibility, nextWorkflowID, nextAgentModelProvider, nextAgentModelName, nextAgentModelURL, nextAgentModelAPIKey, id)
+	`, nextTitle, nextDescription, nextAC, dorJSON, dodJSON, acJSON, nextRepo, nextNotes, nextStatus, nextVisibility, nextWorkflowID, nextAgentModelProvider, nextAgentModelName, nextAgentModelURL, nextAgentModelAPIKey, attrsJSON, id)
 	if err != nil {
 		return Project{}, err
 	}
@@ -612,7 +638,7 @@ func validProjectVisibility(visibility string) bool {
 
 func getProjectByTitle(ctx context.Context, db *sql.DB, title string) (Project, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
 		FROM projects
 		WHERE LOWER(title) = LOWER(?)
 		ORDER BY project_id

--- a/internal/store/project_alias.go
+++ b/internal/store/project_alias.go
@@ -34,7 +34,7 @@ func GetProjectByAlias(ctx context.Context, db *sql.DB, alias, userID string) (P
 	}
 	trimmedUserID := strings.TrimSpace(userID)
 	query := `
-		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id
+		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id, p.attrs
 		FROM project_aliases pa
 		JOIN projects p ON p.project_id = pa.project_id
 		WHERE pa.alias_name = ? AND ((pa.user_id IS NULL AND ? = '') OR pa.user_id = ?)

--- a/internal/store/role.go
+++ b/internal/store/role.go
@@ -19,6 +19,7 @@ type Role struct {
 	ACMap              GuidanceMap `json:"ac_map,omitempty"`
 	CreatedAt          string      `json:"created_at"`
 	UpdatedAt          string      `json:"updated_at"`
+	Attrs              Attrs       `json:"attrs,omitempty"`
 }
 
 type RoleCreateParams struct {
@@ -30,6 +31,7 @@ type RoleCreateParams struct {
 	DORMap             GuidanceMap
 	DODMap             GuidanceMap
 	ACMap              GuidanceMap
+	Attrs              Attrs
 }
 
 type RoleUpdateParams struct {
@@ -39,6 +41,7 @@ type RoleUpdateParams struct {
 	DORMap             GuidanceMap
 	DODMap             GuidanceMap
 	ACMap              GuidanceMap
+	Attrs              Attrs // nil = preserve existing attrs; non-nil = replace the bag
 }
 
 func (r Role) ResolveGuidance(stage string) ResolvedGuidance {
@@ -80,15 +83,19 @@ func CreateRoleWithParams(ctx context.Context, db *sql.DB, params RoleCreatePara
 	if acceptanceCriteria == "" && acMap != nil {
 		acceptanceCriteria = acMap[DefaultGuidanceStageKey]
 	}
+	attrsJSON, err := marshalAttrs(params.Attrs)
+	if err != nil {
+		return Role{}, err
+	}
 	query := `
-		INSERT INTO roles (workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		INSERT INTO roles (workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, attrs, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 	`
-	args := []any{nullableInt64(params.WorkflowID), title, strings.TrimSpace(params.Description), acceptanceCriteria, dorJSON, dodJSON, acJSON}
+	args := []any{nullableInt64(params.WorkflowID), title, strings.TrimSpace(params.Description), acceptanceCriteria, dorJSON, dodJSON, acJSON, attrsJSON}
 	if hasExplicitID {
 		query = `
-			INSERT INTO roles (role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+			INSERT INTO roles (role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, attrs, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		`
 		args = append([]any{explicitID}, args...)
 	}
@@ -110,10 +117,15 @@ func scanRoleValues(scan func(dest ...any) error) (Role, error) {
 	var role Role
 	var workflowID sql.NullInt64
 	var dorJSON, dodJSON, acJSON string
-	if err := scan(&role.ID, &workflowID, &role.Title, &role.Description, &role.AcceptanceCriteria, &dorJSON, &dodJSON, &acJSON, &role.CreatedAt, &role.UpdatedAt); err != nil {
+	var attrsJSON sql.NullString
+	if err := scan(&role.ID, &workflowID, &role.Title, &role.Description, &role.AcceptanceCriteria, &dorJSON, &dodJSON, &acJSON, &role.CreatedAt, &role.UpdatedAt, &attrsJSON); err != nil {
 		return Role{}, err
 	}
 	var err error
+	role.Attrs, err = parseAttrs(attrsJSON.String)
+	if err != nil {
+		return Role{}, err
+	}
 	role.DORMap, err = parseGuidanceMap(dorJSON)
 	if err != nil {
 		return Role{}, err
@@ -186,11 +198,19 @@ func UpdateRoleWithParams(ctx context.Context, db *sql.DB, id int64, params Role
 	if err != nil {
 		return Role{}, err
 	}
+	attrsToWrite := current.Attrs
+	if params.Attrs != nil {
+		attrsToWrite = params.Attrs
+	}
+	attrsJSON, err := marshalAttrs(attrsToWrite)
+	if err != nil {
+		return Role{}, err
+	}
 	result, err := db.ExecContext(ctx, `
 		UPDATE roles
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, updated_at = CURRENT_TIMESTAMP
+		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE role_id = ?
-	`, title, description, acceptanceCriteria, dorJSON, dodJSON, acJSON, id)
+	`, title, description, acceptanceCriteria, dorJSON, dodJSON, acJSON, attrsJSON, id)
 	if err != nil {
 		return Role{}, err
 	}
@@ -209,7 +229,7 @@ func ListRoles(ctx context.Context, db *sql.DB, limit int) ([]Role, error) {
 		limit = 1000
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at
+		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
 		FROM roles
 		ORDER BY title
 		LIMIT ?
@@ -223,7 +243,7 @@ func ListRoles(ctx context.Context, db *sql.DB, limit int) ([]Role, error) {
 
 func ListRolesByWorkflow(ctx context.Context, db *sql.DB, workflowID int64) ([]Role, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at
+		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
 		FROM roles
 		WHERE workflow_id = ?
 		ORDER BY title
@@ -249,7 +269,7 @@ func scanRoles(rows *sql.Rows) ([]Role, error) {
 
 func GetRoleByID(ctx context.Context, db *sql.DB, id int64) (Role, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at
+		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
 		FROM roles
 		WHERE role_id = ?
 	`, id)
@@ -258,7 +278,7 @@ func GetRoleByID(ctx context.Context, db *sql.DB, id int64) (Role, error) {
 
 func GetRoleByTitle(ctx context.Context, db *sql.DB, title string) (Role, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at
+		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
 		FROM roles
 		WHERE title = ?
 	`, strings.TrimSpace(title))
@@ -267,7 +287,7 @@ func GetRoleByTitle(ctx context.Context, db *sql.DB, title string) (Role, error)
 
 func getRoleByTitleTx(ctx context.Context, tx *sql.Tx, title string) (Role, error) {
 	row := tx.QueryRowContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at
+		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
 		FROM roles
 		WHERE title = ?
 	`, strings.TrimSpace(title))
@@ -336,7 +356,7 @@ func ReorderWorkflowStageRoles(ctx context.Context, db *sql.DB, workflowID, stag
 
 func ListWorkflowStageRoles(ctx context.Context, db *sql.DB, workflowID, stageID int64) ([]Role, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT r.role_id, r.workflow_id, r.title, r.description, r.acceptance_criteria, r.dor_map, r.dod_map, r.ac_map, r.created_at, r.updated_at
+		SELECT r.role_id, r.workflow_id, r.title, r.description, r.acceptance_criteria, r.dor_map, r.dod_map, r.ac_map, r.created_at, r.updated_at, r.attrs
 		FROM workflow_stage_roles sr
 		JOIN roles r ON r.role_id = sr.role_id
 		WHERE sr.workflow_id = ? AND sr.stage_id = ?

--- a/internal/store/schema_version.go
+++ b/internal/store/schema_version.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	LegacySchemaVersion  = 1
-	CurrentSchemaVersion = 10
+	CurrentSchemaVersion = 11
 	schemaMetaTable      = "schema_meta"
 	schemaVersionKey     = "schema_version"
 	// DefaultBackupRetention is the number of timestamped pre-upgrade backups

--- a/internal/store/sdlc.go
+++ b/internal/store/sdlc.go
@@ -39,6 +39,7 @@ type WorkflowStage struct {
 	NextStageIDs       []int64 `json:"next_stage_ids,omitempty"`
 	CreatedAt          string  `json:"created_at"`
 	UpdatedAt          string  `json:"updated_at"`
+	Attrs              Attrs   `json:"attrs,omitempty"`
 }
 
 type WorkflowWithStages struct {
@@ -246,8 +247,8 @@ func AddWorkflowStageWithDefinitions(ctx context.Context, db *sql.DB, workflowID
 		return WorkflowStage{}, errors.New("stage name is required")
 	}
 	result, err := db.ExecContext(ctx, `
-		INSERT INTO workflow_stages (workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		INSERT INTO workflow_stages (workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, attrs, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, '{}', CURRENT_TIMESTAMP)
 	`, workflowID, stageName, strings.TrimSpace(wow), strings.TrimSpace(dor), strings.TrimSpace(dor), strings.TrimSpace(dod), sortOrder)
 	if err != nil {
 		return WorkflowStage{}, err
@@ -268,6 +269,31 @@ func SetWorkflowStageBacklog(ctx context.Context, db *sql.DB, stageID int64, isB
 		WHERE workflow_stage_id = ?
 	`, isBacklogStage, stageID)
 	return err
+}
+
+// SetWorkflowStageAttrs replaces the extensible attribute bag for a stage. Normal
+// stage updates do not touch attrs, so the bag is preserved across them; this is
+// the explicit way to write it.
+func SetWorkflowStageAttrs(ctx context.Context, db *sql.DB, stageID int64, attrs Attrs) (WorkflowStage, error) {
+	attrsJSON, err := marshalAttrs(attrs)
+	if err != nil {
+		return WorkflowStage{}, err
+	}
+	result, err := db.ExecContext(ctx, `
+		UPDATE workflow_stages SET attrs = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE workflow_stage_id = ?
+	`, attrsJSON, stageID)
+	if err != nil {
+		return WorkflowStage{}, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return WorkflowStage{}, err
+	}
+	if affected == 0 {
+		return WorkflowStage{}, sql.ErrNoRows
+	}
+	return getWorkflowStageRow(ctx, db, stageID)
 }
 
 func UpdateWorkflowStage(ctx context.Context, db *sql.DB, stageID int64, name, description, acceptanceCriteria string) (WorkflowStage, error) {
@@ -871,15 +897,21 @@ func getWorkflowRow(ctx context.Context, db *sql.DB, id int64) (Workflow, error)
 
 func getWorkflowStageRow(ctx context.Context, db *sql.DB, id int64) (WorkflowStage, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT workflow_stage_id, workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at
+		SELECT workflow_stage_id, workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at, attrs
 		FROM workflow_stages
 		WHERE workflow_stage_id = ?
 	`, id)
 	var s WorkflowStage
+	var attrsJSON sql.NullString
 	if err := row.Scan(&s.ID, &s.WorkflowID, &s.StageName, &s.Description,
-		&s.AcceptanceCriteria, &s.DefinitionOfReady, &s.DefinitionOfDone, &s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		&s.AcceptanceCriteria, &s.DefinitionOfReady, &s.DefinitionOfDone, &s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt, &attrsJSON); err != nil {
 		return WorkflowStage{}, err
 	}
+	attrs, err := parseAttrs(attrsJSON.String)
+	if err != nil {
+		return WorkflowStage{}, err
+	}
+	s.Attrs = attrs
 	roles, err := ListWorkflowStageRoles(ctx, db, s.WorkflowID, s.ID)
 	if err != nil {
 		return WorkflowStage{}, err
@@ -896,7 +928,7 @@ func getWorkflowStageRow(ctx context.Context, db *sql.DB, id int64) (WorkflowSta
 
 func listWorkflowStages(ctx context.Context, db *sql.DB, workflowID int64) ([]WorkflowStage, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT workflow_stage_id, workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at
+		SELECT workflow_stage_id, workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at, attrs
 		FROM workflow_stages
 		WHERE workflow_id = ?
 		ORDER BY sort_order, workflow_stage_id
@@ -908,10 +940,16 @@ func listWorkflowStages(ctx context.Context, db *sql.DB, workflowID int64) ([]Wo
 	stages := make([]WorkflowStage, 0)
 	for rows.Next() {
 		var s WorkflowStage
+		var attrsJSON sql.NullString
 		if scanErr := rows.Scan(&s.ID, &s.WorkflowID, &s.StageName, &s.Description,
-			&s.AcceptanceCriteria, &s.DefinitionOfReady, &s.DefinitionOfDone, &s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt); scanErr != nil {
+			&s.AcceptanceCriteria, &s.DefinitionOfReady, &s.DefinitionOfDone, &s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt, &attrsJSON); scanErr != nil {
 			return nil, scanErr
 		}
+		attrs, parseErr := parseAttrs(attrsJSON.String)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		s.Attrs = attrs
 		stages = append(stages, s)
 	}
 	if rowsErr := rows.Err(); rowsErr != nil {
@@ -942,7 +980,7 @@ func listWorkflowStages(ctx context.Context, db *sql.DB, workflowID int64) ([]Wo
 // given workflowID in a single query and returns them grouped by stage_id.
 func listWorkflowStageRolesBatch(ctx context.Context, db *sql.DB, workflowID int64) (map[int64][]Role, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT sr.stage_id, r.role_id, r.workflow_id, r.title, r.description, r.acceptance_criteria, r.dor_map, r.dod_map, r.ac_map, r.created_at, r.updated_at
+		SELECT sr.stage_id, r.role_id, r.workflow_id, r.title, r.description, r.acceptance_criteria, r.dor_map, r.dod_map, r.ac_map, r.created_at, r.updated_at, r.attrs
 		FROM workflow_stage_roles sr
 		JOIN roles r ON r.role_id = sr.role_id
 		WHERE sr.workflow_id = ?

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -281,6 +281,7 @@ CREATE TABLE IF NOT EXISTS roles (
 	dor_map TEXT NOT NULL DEFAULT '{}',
 	dod_map TEXT NOT NULL DEFAULT '{}',
 	ac_map TEXT NOT NULL DEFAULT '{}',
+	attrs TEXT NOT NULL DEFAULT '{}',
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	FOREIGN KEY(workflow_id) REFERENCES workflows(workflow_id),
@@ -310,6 +311,7 @@ CREATE TABLE IF NOT EXISTS projects (
 	agent_model_name TEXT NOT NULL DEFAULT '',
 	agent_model_url TEXT NOT NULL DEFAULT '',
 	agent_model_api_key TEXT NOT NULL DEFAULT '',
+	attrs TEXT NOT NULL DEFAULT '{}',
 	FOREIGN KEY(created_by) REFERENCES users(user_id),
 	FOREIGN KEY(workflow_id) REFERENCES workflows(workflow_id)
 );
@@ -385,6 +387,7 @@ CREATE TABLE IF NOT EXISTS tickets (
 	created_by TEXT,
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	attrs TEXT NOT NULL DEFAULT '{}',
 	FOREIGN KEY(project_id) REFERENCES projects(project_id),
 	FOREIGN KEY(parent_id) REFERENCES tickets(ticket_id),
 	FOREIGN KEY(clone_of) REFERENCES tickets(ticket_id),
@@ -606,6 +609,7 @@ CREATE TABLE IF NOT EXISTS workflow_stages (
 	is_backlog_stage INTEGER NOT NULL DEFAULT 0,
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	attrs TEXT NOT NULL DEFAULT '{}',
 	FOREIGN KEY(workflow_id) REFERENCES workflows(workflow_id),
 	UNIQUE(workflow_id, stage_name)
 );
@@ -1737,6 +1741,19 @@ CREATE TABLE user_notifications (
 	if !columnExists(ctx, db, "users", "agent_role") {
 		if _, err := db.ExecContext(ctx, `ALTER TABLE users ADD COLUMN agent_role TEXT NOT NULL DEFAULT ''`); err != nil {
 			return err
+		}
+	}
+
+	// Add the extensible JSON attribute bag (TK-109) to the high-churn entities.
+	// Stored as TEXT JSON (not binary JSONB) so it survives the generic snapshot
+	// export/import used by backups and the migration rebuild path; json_extract
+	// queries and expression indexes work identically on TEXT. A constant '{}'
+	// default is permitted on ADD COLUMN, so no backfill is required.
+	for _, table := range []string{"tickets", "projects", "roles", "workflow_stages"} {
+		if !columnExists(ctx, db, table, "attrs") {
+			if _, err := db.ExecContext(ctx, `ALTER TABLE `+table+` ADD COLUMN attrs TEXT NOT NULL DEFAULT '{}'`); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/store/ticket.go
+++ b/internal/store/ticket.go
@@ -58,6 +58,7 @@ type Ticket struct {
 	CreatedBy               string      `json:"created_by"`
 	CreatedAt               string      `json:"created_at"`
 	UpdatedAt               string      `json:"updated_at"`
+	Attrs                   Attrs       `json:"attrs,omitempty"`
 }
 
 func (t Ticket) ResolveGuidance(stage string) ResolvedGuidance {
@@ -86,6 +87,7 @@ type TicketCreateParams struct {
 	Author             string
 	State              string
 	CreatedBy          string
+	Attrs              Attrs
 }
 
 type TicketUpdateParams struct {
@@ -111,6 +113,7 @@ type TicketUpdateParams struct {
 	Type               string // if non-empty, update the ticket type
 	ReleaseID          *int   // nil = don't change, use SetReleaseID flag to clear
 	SetReleaseID       bool   // true = apply ReleaseID (even if nil, meaning clear it)
+	Attrs              Attrs  // nil = preserve existing attrs; non-nil = replace the bag
 }
 
 type TicketListParams struct {
@@ -282,10 +285,14 @@ func CreateTicket(ctx context.Context, db *sql.DB, params TicketCreateParams) (T
 	if err != nil {
 		return Ticket{}, err
 	}
+	attrsJSON, err := marshalAttrs(params.Attrs)
+	if err != nil {
+		return Ticket{}, err
+	}
 	_, err = tx.ExecContext(ctx, `
-		INSERT INTO tickets (ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, author, draft, created_by)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, key, params.ProjectID, nullableString(params.ParentID), nullableString(params.CloneOf), params.Type, params.Title, params.Description, acceptanceCriteria, dorJSON, dodJSON, acJSON, strings.TrimSpace(params.GitRepository), strings.TrimSpace(params.GitBranch), nullableInt64(ticketWorkflowID), nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), priority, order, params.EstimateEffort, strings.TrimSpace(params.EstimateComplete), 0, strings.TrimSpace(params.Assignee), strings.TrimSpace(params.Author), 1, nullableUserID(params.CreatedBy))
+		INSERT INTO tickets (ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, author, draft, created_by, attrs)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, key, params.ProjectID, nullableString(params.ParentID), nullableString(params.CloneOf), params.Type, params.Title, params.Description, acceptanceCriteria, dorJSON, dodJSON, acJSON, strings.TrimSpace(params.GitRepository), strings.TrimSpace(params.GitBranch), nullableInt64(ticketWorkflowID), nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), priority, order, params.EstimateEffort, strings.TrimSpace(params.EstimateComplete), 0, strings.TrimSpace(params.Assignee), strings.TrimSpace(params.Author), 1, nullableUserID(params.CreatedBy), attrsJSON)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -554,14 +561,23 @@ writeTicket:
 	if !reopened && current.Complete {
 		completeVal = 1
 	}
+	// attrs: preserve the existing bag unless the caller supplies a replacement.
+	attrsToWrite := current.Attrs
+	if params.Attrs != nil {
+		attrsToWrite = params.Attrs
+	}
+	attrsJSON, err := marshalAttrs(attrsToWrite)
+	if err != nil {
+		return Ticket{}, err
+	}
 	// started_at records when work began: stamp it on the transition INTO the
 	// active state; otherwise preserve the existing value (TK-88).
 	result, err := db.ExecContext(ctx, `
 		UPDATE tickets
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, git_branch = ?, parent_id = ?, assignee = ?, workflow_stage_id = ?, role_id = ?, stage = ?, state = ?, status = ?, priority = ?, sort_order = ?, estimate_effort = ?, estimate_complete = ?, complete = ?, type = ?, updated_at = CURRENT_TIMESTAMP,
+		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, git_branch = ?, parent_id = ?, assignee = ?, workflow_stage_id = ?, role_id = ?, stage = ?, state = ?, status = ?, priority = ?, sort_order = ?, estimate_effort = ?, estimate_complete = ?, complete = ?, type = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP,
 			started_at = CASE WHEN ? = 'active' AND ? != 'active' THEN CURRENT_TIMESTAMP ELSE ? END
 		WHERE ticket_id = ?
-	`, title, params.Description, nextAcceptanceCriteria, dorJSON, dodJSON, acJSON, nextGitRepository, nextGitBranch, nullableString(params.ParentID), assignee, nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), params.Priority, params.Order, params.EstimateEffort, strings.TrimSpace(params.EstimateComplete), completeVal, nextType, state, current.State, current.StartedAt, id)
+	`, title, params.Description, nextAcceptanceCriteria, dorJSON, dodJSON, acJSON, nextGitRepository, nextGitBranch, nullableString(params.ParentID), assignee, nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), params.Priority, params.Order, params.EstimateEffort, strings.TrimSpace(params.EstimateComplete), completeVal, nextType, attrsJSON, state, current.State, current.StartedAt, id)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -1474,7 +1490,7 @@ var ticketColumnNames = []string{
 	"estimate_complete", "health_score", "assignee", "author", "draft", "complete",
 	"archived", "deleted", "previous_workflow_stage_id", "previous_role_id",
 	"release_id", "created_by", "created_at", "updated_at", "recommended_ready",
-	"pr_url", "started_at",
+	"pr_url", "started_at", "attrs",
 }
 
 // ticketColumnCoalesce maps nullable columns to the SQL literal substituted via
@@ -1533,6 +1549,7 @@ func scanTicket(s scanner) (Ticket, error) {
 	var prevRoleID sql.NullInt64
 	var releaseID sql.NullInt64
 	var recommendedReady int
+	var attrsJSON sql.NullString
 	if err := s.Scan(
 		&ticket.ID,
 		&ticket.ProjectID,
@@ -1573,9 +1590,15 @@ func scanTicket(s scanner) (Ticket, error) {
 		&recommendedReady,
 		&ticket.PrURL,
 		&ticket.StartedAt,
+		&attrsJSON,
 	); err != nil {
 		return Ticket{}, err
 	}
+	attrs, err := parseAttrs(attrsJSON.String)
+	if err != nil {
+		return Ticket{}, err
+	}
+	ticket.Attrs = attrs
 	if parentID.Valid {
 		ticket.ParentID = &parentID.String
 	}


### PR DESCRIPTION
S4 of epic TK-105 (refs TK-109). Establishes the Tier-2 substrate — the bag starts empty (no existing columns move yet; that's S6a–d).

## What
- `internal/store/attrs.go`: `Attrs` (map[string]any) + `marshalAttrs`/`parseAttrs` + typed get/set helpers.
- Schema: `attrs` column added to `tickets`, `projects`, `roles`, `workflow_stages` (createSchema + additive migration); **schema version 10 → 11**.
- CRUD wiring across all four entities: reads via the (centralized, for tickets) scans, writes in INSERT/UPDATE; `Create*`/`Update*` params gain `Attrs`. Update preserves the bag when `Attrs` is nil; `SetWorkflowStageAttrs` for stages (normal stage updates preserve it).
- API: ticket/project/role request DTOs accept `attrs`; responses already encode it; `openapi.yaml` documents `attrs` on all four schemas.
- Tests: per-entity round-trip (empty/populated/nested, preserve vs replace), **zero-DDL extensibility** (a new field needs no schema-version bump), migration re-adds dropped columns.

## ⚠️ Storage decision change: TEXT JSON, not binary JSONB
S1 proposed binary JSONB. During implementation I found binary JSONB **does not survive the generic snapshot export/import** that backs both backup/restore *and* the migration rebuild path (binary bytes aren't valid UTF-8 → round-trips as "malformed JSON" — verified with a probe). Switched to `TEXT NOT NULL DEFAULT '{}'`. `json_extract` and expression indexes (S5) work identically on TEXT, so Tier-3 promotion is unaffected, and the `'{}'` constant default needs no migration backfill. Design doc + ADR updated with the rationale.

## Tests
`go test ./internal/store ./internal/server ./internal/client ./libticket ./cmd/tk` green (only the pre-existing `TestFailureEscalationInboxLifecycle`, also red on main, fails). Lint clean. `make validate-openapi` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)