### PR TITLE
TK-110: Queryable attribute bag (json_extract helpers + expression indexes)

### DIFF
--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -92,6 +92,22 @@ flowchart TD
   E -- Yes, needs column surface --> G[Tier 3: generated column]
 ```
 
+### Querying the bag in practice (Tier-3 API)
+
+The promotion mechanism is implemented in `internal/store/attrs_query.go`:
+
+- `ValidAttrsKey(key)` — restricts attrs keys to `[A-Za-z0-9_]+` so a json path can
+  never inject SQL. All query/index helpers validate the key before it reaches SQL.
+- `EnsureAttrIndex(ctx, db, table, key)` — the promotion action. Idempotently
+  creates `idx_<table>_attrs_<key> ON <table>(json_extract(attrs,'$.<key>'))`. No
+  table rewrite, no schema-version bump; safe to call repeatedly.
+- `ListTicketsByAttr(ctx, db, projectID, key, value)` — a worked example that
+  filters and orders tickets on a bag field via `json_extract`; the expression
+  index above serves it (verified with `EXPLAIN QUERY PLAN` in the tests).
+
+A consolidation story (S6) that moves a queried column into the bag calls
+`EnsureAttrIndex` for that field so existing filters/sorts keep their index.
+
 ## 4. Storage format: TEXT JSON (not binary JSONB)
 
 SQLite has no `JSONB` *column type* (unlike Postgres). "JSONB" in SQLite is the

--- a/internal/store/attrs_query.go
+++ b/internal/store/attrs_query.go
@@ -1,0 +1,97 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"regexp"
+)
+
+// attrsKeyPattern restricts attrs JSON keys usable in SQL (json_extract paths and
+// index names) to a safe identifier alphabet. Keys come from a validated allowlist,
+// never raw user input concatenated into SQL — this keeps json_extract expressions
+// injection-safe.
+var attrsKeyPattern = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+
+// attrsIndexableTables is the set of tables that carry an attrs bag and may have
+// expression indexes created over it.
+var attrsIndexableTables = map[string]bool{
+	"tickets":         true,
+	"projects":        true,
+	"roles":           true,
+	"workflow_stages": true,
+}
+
+// ValidAttrsKey reports whether key is a safe top-level attrs key for use in a
+// json_extract path or an index name.
+func ValidAttrsKey(key string) bool {
+	return attrsKeyPattern.MatchString(key)
+}
+
+// attrsExtractExpr returns a json_extract SQL expression for a single top-level
+// attrs key, optionally prefixed by a table alias. The key must be validated with
+// ValidAttrsKey by the caller; this returns an error otherwise so a bad key can
+// never reach SQL.
+func attrsExtractExpr(alias, key string) (string, error) {
+	if !ValidAttrsKey(key) {
+		return "", fmt.Errorf("invalid attrs key %q", key)
+	}
+	column := "attrs"
+	if alias != "" {
+		column = alias + ".attrs"
+	}
+	return fmt.Sprintf("json_extract(%s, '$.%s')", column, key), nil
+}
+
+// EnsureAttrIndex creates, idempotently, an expression index over a single attrs
+// JSON key on a table. This is the Tier-3 "promotion" mechanism from
+// docs/design/extensible-schema.md: a bag field that needs to be filtered or sorted
+// is promoted to query-grade with an index and NO table rewrite or schema-version
+// bump. Safe to call repeatedly (CREATE INDEX IF NOT EXISTS).
+func EnsureAttrIndex(ctx context.Context, db *sql.DB, table, key string) error {
+	if !attrsIndexableTables[table] {
+		return fmt.Errorf("unknown attrs table %q", table)
+	}
+	if !ValidAttrsKey(key) {
+		return fmt.Errorf("invalid attrs key %q", key)
+	}
+	stmt := fmt.Sprintf(
+		"CREATE INDEX IF NOT EXISTS idx_%s_attrs_%s ON %s (json_extract(attrs, '$.%s'))",
+		table, key, table, key,
+	)
+	_, err := db.ExecContext(ctx, stmt)
+	return err
+}
+
+// ListTicketsByAttr returns the live tickets in a project whose attrs bag has the
+// given top-level key equal to value, ordered by that value. It demonstrates the
+// queryable bag end-to-end: filtering and sorting on a json_extract expression that
+// an EnsureAttrIndex expression index can serve. The key is validated, so the query
+// is injection-safe even though the path is interpolated.
+func ListTicketsByAttr(ctx context.Context, db *sql.DB, projectID int64, key, value string) ([]Ticket, error) {
+	if projectID == 0 {
+		return nil, fmt.Errorf("project is required")
+	}
+	expr, err := attrsExtractExpr("", key)
+	if err != nil {
+		return nil, err
+	}
+	query := `SELECT ` + ticketSelectColumns("") + `
+		FROM tickets
+		WHERE project_id = ? AND deleted = 0 AND ` + expr + ` = ?
+		ORDER BY ` + expr + `, ticket_id`
+	rows, err := db.QueryContext(ctx, query, projectID, value)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	tickets := make([]Ticket, 0)
+	for rows.Next() {
+		ticket, scanErr := scanTicket(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		tickets = append(tickets, ticket)
+	}
+	return tickets, rows.Err()
+}

--- a/internal/store/attrs_query_test.go
+++ b/internal/store/attrs_query_test.go
@@ -1,0 +1,96 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestValidAttrsKey(t *testing.T) {
+	t.Parallel()
+	for _, k := range []string{"severity", "wip_limit", "Repro2"} {
+		if !ValidAttrsKey(k) {
+			t.Errorf("ValidAttrsKey(%q) = false, want true", k)
+		}
+	}
+	for _, k := range []string{"", "a.b", "a'b", "a b", "$.x", "a);DROP"} {
+		if ValidAttrsKey(k) {
+			t.Errorf("ValidAttrsKey(%q) = true, want false", k)
+		}
+	}
+}
+
+func TestEnsureAttrIndexRejectsBadInput(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+	if err := EnsureAttrIndex(ctx, db, "not_a_table", "x"); err == nil {
+		t.Fatal("EnsureAttrIndex with bad table = nil error, want error")
+	}
+	if err := EnsureAttrIndex(ctx, db, "tickets", "bad key"); err == nil {
+		t.Fatal("EnsureAttrIndex with bad key = nil error, want error")
+	}
+}
+
+// TestListTicketsByAttrUsesIndex demonstrates the queryable bag end-to-end: filter
+// and sort tickets on a bag field, and confirm the expression index is used.
+func TestListTicketsByAttrUsesIndex(t *testing.T) {
+	// Not parallel: creates an index on the shared schema of its own DB.
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	mk := func(title, sev string) {
+		if _, err := CreateTicket(ctx, db, TicketCreateParams{
+			ProjectID: 1, Type: "bug", Title: title, Attrs: Attrs{"severity": sev},
+		}); err != nil {
+			t.Fatalf("CreateTicket(%s) error = %v", title, err)
+		}
+	}
+	mk("a", "high")
+	mk("b", "low")
+	mk("c", "high")
+
+	// Promote the field with an expression index (idempotent; call twice).
+	if err := EnsureAttrIndex(ctx, db, "tickets", "severity"); err != nil {
+		t.Fatalf("EnsureAttrIndex() error = %v", err)
+	}
+	if err := EnsureAttrIndex(ctx, db, "tickets", "severity"); err != nil {
+		t.Fatalf("EnsureAttrIndex() second call error = %v", err)
+	}
+
+	got, err := ListTicketsByAttr(ctx, db, 1, "severity", "high")
+	if err != nil {
+		t.Fatalf("ListTicketsByAttr() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("ListTicketsByAttr() returned %d tickets, want 2", len(got))
+	}
+	for _, tk := range got {
+		if tk.Attrs.GetString("severity") != "high" {
+			t.Fatalf("unexpected ticket in result: %s severity=%s", tk.Title, tk.Attrs.GetString("severity"))
+		}
+	}
+
+	// Confirm the planner uses the expression index for the filter.
+	var planRows strings.Builder
+	rows, err := db.QueryContext(ctx, `EXPLAIN QUERY PLAN
+		SELECT ticket_id FROM tickets
+		WHERE project_id = ? AND deleted = 0 AND json_extract(attrs, '$.severity') = ?`, 1, "high")
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		if scanErr := rows.Scan(&id, &parent, &notused, &detail); scanErr != nil {
+			t.Fatalf("scan plan error = %v", scanErr)
+		}
+		planRows.WriteString(detail)
+		planRows.WriteString("\n")
+	}
+	plan := planRows.String()
+	if !strings.Contains(plan, "idx_tickets_attrs_severity") {
+		t.Fatalf("expression index not used by planner; plan:\n%s", plan)
+	}
+}


### PR DESCRIPTION
S5 of epic TK-105 (refs TK-110). Implements the Tier-3 promotion path: making a bag field queryable without DDL churn.

## What (`internal/store/attrs_query.go`)
- `ValidAttrsKey` — allowlist `^[A-Za-z0-9_]+$`; every helper validates the key before it touches SQL, so `json_extract` paths can't inject.
- `EnsureAttrIndex(ctx, db, table, key)` — **the promotion action**: idempotent `CREATE INDEX IF NOT EXISTS idx_<table>_attrs_<key> ON <table>(json_extract(attrs,'$.<key>'))`. No table rewrite, no version bump.
- `ListTicketsByAttr` — worked example: filter + order tickets on a bag field via `json_extract`.

## Tests
Key validation, bad-table/bad-key rejection, end-to-end filter/sort returning the right rows, and an **`EXPLAIN QUERY PLAN`** assertion that the expression index is actually used by the planner. Lint clean.

## Docs
Design doc now documents the promotion API and notes S6 will call `EnsureAttrIndex` for any consolidated field that was previously queried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)