### PR TITLE
TK-111: Consolidate tickets soft columns into attrs (physical drop)

### DIFF
--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -245,6 +245,13 @@ Conservative bias: anything filtered / sorted / FK'd / aggregated stays **Keep**
 
 ### 9.1 `tickets`
 
+> **Status (TK-111):** the Move columns below (`git_repository`, `git_branch`,
+> `estimate_complete`, `health_score`, `author`, `pr_url`) and the dead `open`
+> column have been consolidated into `attrs` and physically dropped. They remain
+> typed `Ticket` fields, hydrated from the bag. The `dor_map`/`dod_map`/`ac_map`
+> **Fold** is tracked as a separate cross-cutting follow-up (it spans the guidance
+> resolution used by tickets, projects and roles).
+
 | Column | Decision | Rationale |
 |--------|----------|-----------|
 | ticket_id, project_id, parent_id, clone_of | Keep | PK / FKs |

--- a/internal/store/agent.go
+++ b/internal/store/agent.go
@@ -328,7 +328,7 @@ func ListAgentStatuses(ctx context.Context, db *sql.DB) ([]AgentStatus, error) {
 			LEFT JOIN projects p ON p.project_id = t.project_id
 			LEFT JOIN workflows w ON w.workflow_id = t.workflow_id
 			LEFT JOIN roles r ON r.role_id = t.role_id
-			WHERE t.state = 'active' AND t.open = 1 AND t.assignee IS NOT NULL AND TRIM(t.assignee) <> ''
+			WHERE t.state = 'active' AND t.archived = 0 AND t.assignee IS NOT NULL AND TRIM(t.assignee) <> ''
 		)
 		WHERE rn = 1
 	`)

--- a/internal/store/consolidate_tickets_test.go
+++ b/internal/store/consolidate_tickets_test.go
@@ -1,0 +1,142 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// TestConsolidateTicketsMigrationNoDataLoss simulates a pre-consolidation (v11)
+// tickets table — the soft columns still present and populated — and verifies the
+// upgrade moves every value into the attrs bag with no data loss, drops the
+// columns, and that the values are still readable via the typed Ticket fields.
+func TestConsolidateTicketsMigrationNoDataLoss(t *testing.T) {
+	// Not parallel: manipulates schema_version and raw columns.
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+	tk, err := CreateTicket(ctx, db, TicketCreateParams{ProjectID: 1, Type: "task", Title: "to-migrate"})
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	// Recreate the pre-consolidation shape.
+	for _, stmt := range []string{
+		`ALTER TABLE tickets ADD COLUMN git_repository TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE tickets ADD COLUMN git_branch TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE tickets ADD COLUMN estimate_complete TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE tickets ADD COLUMN health_score INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE tickets ADD COLUMN author TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE tickets ADD COLUMN pr_url TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE tickets ADD COLUMN open INTEGER NOT NULL DEFAULT 1`,
+	} {
+		if _, execErr := raw.Exec(stmt); execErr != nil {
+			_ = raw.Close()
+			t.Fatalf("setup %q error = %v", stmt, execErr)
+		}
+	}
+	if _, execErr := raw.Exec(
+		`UPDATE tickets SET git_repository=?, git_branch=?, estimate_complete=?, health_score=?, author=?, pr_url=?, attrs='{}' WHERE ticket_id=?`,
+		"git@example.com:x.git", "feature/x", "2026-01-15", 42, "alice", "https://pr/1", tk.ID,
+	); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("populate error = %v", execErr)
+	}
+	if _, execErr := raw.Exec(`UPDATE schema_meta SET value='11' WHERE key='schema_version'`); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("set version error = %v", execErr)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw.Close() error = %v", err)
+	}
+
+	if _, err := UpgradeInPlace(ctx, path); err != nil {
+		t.Fatalf("UpgradeInPlace() error = %v", err)
+	}
+
+	db2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() after upgrade error = %v", err)
+	}
+	defer db2.Close()
+
+	got, err := GetTicket(ctx, db2, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if got.GitRepository != "git@example.com:x.git" {
+		t.Errorf("GitRepository = %q, want preserved", got.GitRepository)
+	}
+	if got.GitBranch != "feature/x" {
+		t.Errorf("GitBranch = %q, want preserved", got.GitBranch)
+	}
+	if got.EstimateComplete != "2026-01-15" {
+		t.Errorf("EstimateComplete = %q, want preserved", got.EstimateComplete)
+	}
+	if got.HealthScore != 42 {
+		t.Errorf("HealthScore = %d, want 42", got.HealthScore)
+	}
+	if got.Author != "alice" {
+		t.Errorf("Author = %q, want alice", got.Author)
+	}
+	if got.PrURL != "https://pr/1" {
+		t.Errorf("PrURL = %q, want preserved", got.PrURL)
+	}
+
+	// Columns must be gone after consolidation.
+	for _, col := range []string{"git_repository", "git_branch", "estimate_complete", "health_score", "author", "pr_url", "open"} {
+		if columnExists(ctx, db2, "tickets", col) {
+			t.Errorf("tickets.%s still exists after consolidation", col)
+		}
+	}
+}
+
+// TestConsolidatedTicketFieldsRoundTrip verifies the soft fields still work
+// end-to-end through the typed Ticket fields after consolidation, and that the
+// user-visible Attrs bag does not duplicate them.
+func TestConsolidatedTicketFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	tk, err := CreateTicket(ctx, db, TicketCreateParams{
+		ProjectID: 1, Type: "bug", Title: "rt",
+		GitRepository: "git@x", GitBranch: "main", Author: "bob",
+		Attrs: Attrs{"severity": "high"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+	got, err := GetTicket(ctx, db, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if got.GitRepository != "git@x" || got.GitBranch != "main" || got.Author != "bob" {
+		t.Fatalf("typed soft fields not round-tripped: %+v", got)
+	}
+	// The extra bag keeps the genuinely-extra key but not the typed/back-compat ones.
+	if got.Attrs.GetString("severity") != "high" {
+		t.Fatalf("extra attr lost: %#v", got.Attrs)
+	}
+	if _, dup := got.Attrs["git_repository"]; dup {
+		t.Fatalf("attrs duplicates a typed field: %#v", got.Attrs)
+	}
+
+	// Dedicated setters write through to the bag.
+	if _, err := SetTicketPrURL(ctx, db, tk.ID, "https://pr/9"); err != nil {
+		t.Fatalf("SetTicketPrURL() error = %v", err)
+	}
+	after, err := GetTicket(ctx, db, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if after.PrURL != "https://pr/9" {
+		t.Fatalf("PrURL via setter = %q, want https://pr/9", after.PrURL)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -364,8 +364,6 @@ CREATE TABLE IF NOT EXISTS tickets (
 	dor_map TEXT NOT NULL DEFAULT '{}',
 	dod_map TEXT NOT NULL DEFAULT '{}',
 	ac_map TEXT NOT NULL DEFAULT '{}',
-	git_repository TEXT NOT NULL DEFAULT '',
-	git_branch TEXT NOT NULL DEFAULT '',
 	workflow_stage_id INTEGER,
 	role_id INTEGER,
 	stage TEXT NOT NULL DEFAULT 'develop',
@@ -374,8 +372,6 @@ CREATE TABLE IF NOT EXISTS tickets (
 	priority INTEGER NOT NULL DEFAULT 3,
 	sort_order INTEGER NOT NULL DEFAULT 0,
 	estimate_effort INTEGER NOT NULL DEFAULT 0,
-	estimate_complete TEXT NOT NULL DEFAULT '',
-	health_score INTEGER NOT NULL DEFAULT 0,
 	assignee TEXT NOT NULL DEFAULT '',
 	draft INTEGER NOT NULL DEFAULT 1,
 	complete INTEGER NOT NULL DEFAULT 0,
@@ -1073,16 +1069,9 @@ CREATE TABLE user_notifications (
 			return err
 		}
 	}
-	if !columnExists(ctx, db, "tickets", "estimate_complete") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN estimate_complete TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "tickets", "git_repository") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN git_repository TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
+	// estimate_complete and git_repository moved into the attrs bag (TK-111); their
+	// legacy ADD COLUMN migrations were removed and the columns are dropped by the
+	// attrs-consolidation step below.
 	if !columnExists(ctx, db, "tickets", "dor_map") {
 		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN dor_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
 			return err
@@ -1098,28 +1087,8 @@ CREATE TABLE user_notifications (
 			return err
 		}
 	}
-	if !columnExists(ctx, db, "tickets", "git_branch") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN git_branch TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "tickets", "health_score") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN health_score INTEGER NOT NULL DEFAULT 0`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "tickets", "open") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN open INTEGER NOT NULL DEFAULT 1`); err != nil {
-			return err
-		}
-		// Legacy behavior used archived for close/open. Preserve closed state and reset archived.
-		if _, err := db.ExecContext(ctx, `UPDATE tickets SET open = CASE WHEN archived = 1 THEN 0 ELSE 1 END`); err != nil {
-			return err
-		}
-		if _, err := db.ExecContext(ctx, `UPDATE tickets SET archived = 0`); err != nil {
-			return err
-		}
-	}
+	// git_branch and health_score moved into the attrs bag (TK-111); the legacy
+	// `open` column is dropped entirely. See the attrs-consolidation step below.
 	if !columnExists(ctx, db, "tickets", "deleted") {
 		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0`); err != nil {
 			return err
@@ -1572,16 +1541,9 @@ CREATE TABLE user_notifications (
 			return err
 		}
 	}
-	// Add author column to store the username of who created the ticket
-	if !columnExists(ctx, db, "tickets", "author") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN author TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-		// Backfill author from created_by user ID
-		if _, err := db.ExecContext(ctx, `UPDATE tickets SET author = COALESCE((SELECT u.username FROM users u WHERE u.user_id = tickets.created_by), '') WHERE author = ''`); err != nil {
-			return err
-		}
-	}
+	// author moved into the attrs bag (TK-111); its legacy ADD COLUMN + backfill
+	// were removed. The attrs-consolidation step below migrates and drops it,
+	// backfilling author from created_by into attrs for rows that lack it.
 	// Account lockout columns for brute-force protection.
 	if !columnExists(ctx, db, "users", "failed_login_attempts") {
 		if _, err := db.ExecContext(ctx, `ALTER TABLE users ADD COLUMN failed_login_attempts INTEGER DEFAULT 0`); err != nil {
@@ -1606,7 +1568,6 @@ CREATE TABLE user_notifications (
 		{table: "tickets", column: "assignee", stmt: `CREATE INDEX IF NOT EXISTS idx_tickets_assignee ON tickets(assignee)`},
 		{table: "tickets", column: "stage", stmt: `CREATE INDEX IF NOT EXISTS idx_tickets_stage ON tickets(stage)`},
 		{table: "tickets", column: "state", stmt: `CREATE INDEX IF NOT EXISTS idx_tickets_state ON tickets(state)`},
-		{table: "tickets", column: "open", stmt: `CREATE INDEX IF NOT EXISTS idx_tickets_open ON tickets(open)`},
 		{table: "tickets", column: "draft", stmt: `CREATE INDEX IF NOT EXISTS idx_tickets_draft ON tickets(draft)`},
 		{table: "tickets", column: "complete", stmt: `CREATE INDEX IF NOT EXISTS idx_tickets_complete ON tickets(complete)`},
 		{table: "tickets", column: "archived", stmt: `CREATE INDEX IF NOT EXISTS idx_tickets_archived ON tickets(archived)`},
@@ -1723,12 +1684,8 @@ CREATE TABLE user_notifications (
 		}
 	}
 
-	// Add pr_url to tickets (developer agent stores PR link after completing).
-	if !columnExists(ctx, db, "tickets", "pr_url") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN pr_url TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
+	// pr_url moved into the attrs bag (TK-111); its legacy ADD COLUMN was removed
+	// and the column is migrated and dropped by the attrs-consolidation step below.
 
 	// Add started_at to tickets: when a ticket enters the active state (TK-88).
 	if !columnExists(ctx, db, "tickets", "started_at") {
@@ -1754,6 +1711,61 @@ CREATE TABLE user_notifications (
 			if _, err := db.ExecContext(ctx, `ALTER TABLE `+table+` ADD COLUMN attrs TEXT NOT NULL DEFAULT '{}'`); err != nil {
 				return err
 			}
+		}
+	}
+
+	// Consolidate tickets soft columns into the attrs bag and drop them (TK-111).
+	// json_set only fills a key that is currently absent, so re-running this never
+	// clobbers a value written through the bag; the column is dropped once its data
+	// is preserved. Runs before the row-reading backfills below so they see the
+	// narrowed shape.
+	for _, col := range []string{"git_repository", "git_branch", "estimate_complete", "pr_url"} {
+		if columnExists(ctx, db, "tickets", col) {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE tickets SET attrs = json_set(attrs, '$.%s', %s) `+
+					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) <> ''`,
+				col, col, col, col)); err != nil {
+				return err
+			}
+			if _, err := db.ExecContext(ctx, `ALTER TABLE tickets DROP COLUMN `+col); err != nil {
+				return err
+			}
+		}
+	}
+	if columnExists(ctx, db, "tickets", "health_score") {
+		if _, err := db.ExecContext(ctx, `UPDATE tickets SET attrs = json_set(attrs, '$.health_score', health_score) `+
+			`WHERE json_extract(attrs, '$.health_score') IS NULL AND COALESCE(health_score, 0) <> 0`); err != nil {
+			return err
+		}
+		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets DROP COLUMN health_score`); err != nil {
+			return err
+		}
+	}
+	if columnExists(ctx, db, "tickets", "author") {
+		// Preserve an explicit author, else backfill from the creator's username
+		// (the behaviour the old author column migration had), all into attrs.
+		if _, err := db.ExecContext(ctx, `UPDATE tickets SET attrs = json_set(attrs, '$.author', author) `+
+			`WHERE json_extract(attrs, '$.author') IS NULL AND TRIM(COALESCE(author, '')) <> ''`); err != nil {
+			return err
+		}
+		if _, err := db.ExecContext(ctx, `UPDATE tickets SET attrs = json_set(attrs, '$.author', `+
+			`(SELECT u.username FROM users u WHERE u.user_id = tickets.created_by)) `+
+			`WHERE json_extract(attrs, '$.author') IS NULL `+
+			`AND TRIM(COALESCE((SELECT u.username FROM users u WHERE u.user_id = tickets.created_by), '')) <> ''`); err != nil {
+			return err
+		}
+		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets DROP COLUMN author`); err != nil {
+			return err
+		}
+	}
+	// The legacy `open` column is dead (superseded by complete/archived). Drop its
+	// index (a column cannot be dropped while indexed) and the column itself.
+	if columnExists(ctx, db, "tickets", "open") {
+		if _, err := db.ExecContext(ctx, `DROP INDEX IF EXISTS idx_tickets_open`); err != nil {
+			return err
+		}
+		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets DROP COLUMN open`); err != nil {
+			return err
 		}
 	}
 

--- a/internal/store/ticket.go
+++ b/internal/store/ticket.go
@@ -285,14 +285,16 @@ func CreateTicket(ctx context.Context, db *sql.DB, params TicketCreateParams) (T
 	if err != nil {
 		return Ticket{}, err
 	}
-	attrsJSON, err := marshalAttrs(params.Attrs)
+	// git_repository, git_branch, estimate_complete, author (and health_score,
+	// pr_url which default to 0/"") now live in the attrs bag (TK-111).
+	attrsJSON, err := ticketAttrsForWrite(params.Attrs, params.GitRepository, params.GitBranch, params.EstimateComplete, params.Author, "", 0)
 	if err != nil {
 		return Ticket{}, err
 	}
 	_, err = tx.ExecContext(ctx, `
-		INSERT INTO tickets (ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, author, draft, created_by, attrs)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, key, params.ProjectID, nullableString(params.ParentID), nullableString(params.CloneOf), params.Type, params.Title, params.Description, acceptanceCriteria, dorJSON, dodJSON, acJSON, strings.TrimSpace(params.GitRepository), strings.TrimSpace(params.GitBranch), nullableInt64(ticketWorkflowID), nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), priority, order, params.EstimateEffort, strings.TrimSpace(params.EstimateComplete), 0, strings.TrimSpace(params.Assignee), strings.TrimSpace(params.Author), 1, nullableUserID(params.CreatedBy), attrsJSON)
+		INSERT INTO tickets (ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, assignee, draft, created_by, attrs)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, key, params.ProjectID, nullableString(params.ParentID), nullableString(params.CloneOf), params.Type, params.Title, params.Description, acceptanceCriteria, dorJSON, dodJSON, acJSON, nullableInt64(ticketWorkflowID), nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), priority, order, params.EstimateEffort, strings.TrimSpace(params.Assignee), 1, nullableUserID(params.CreatedBy), attrsJSON)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -561,12 +563,15 @@ writeTicket:
 	if !reopened && current.Complete {
 		completeVal = 1
 	}
-	// attrs: preserve the existing bag unless the caller supplies a replacement.
-	attrsToWrite := current.Attrs
+	// attrs: start from the existing extra bag (or a caller-supplied replacement)
+	// and fold the bag-backed soft fields in (TK-111). git_repository/git_branch/
+	// estimate_complete follow this update's values; author/pr_url/health_score are
+	// not edited here, so the current values are preserved.
+	baseAttrs := current.Attrs
 	if params.Attrs != nil {
-		attrsToWrite = params.Attrs
+		baseAttrs = params.Attrs
 	}
-	attrsJSON, err := marshalAttrs(attrsToWrite)
+	attrsJSON, err := ticketAttrsForWrite(baseAttrs, nextGitRepository, nextGitBranch, strings.TrimSpace(params.EstimateComplete), current.Author, current.PrURL, current.HealthScore)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -574,10 +579,10 @@ writeTicket:
 	// active state; otherwise preserve the existing value (TK-88).
 	result, err := db.ExecContext(ctx, `
 		UPDATE tickets
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, git_branch = ?, parent_id = ?, assignee = ?, workflow_stage_id = ?, role_id = ?, stage = ?, state = ?, status = ?, priority = ?, sort_order = ?, estimate_effort = ?, estimate_complete = ?, complete = ?, type = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP,
+		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, parent_id = ?, assignee = ?, workflow_stage_id = ?, role_id = ?, stage = ?, state = ?, status = ?, priority = ?, sort_order = ?, estimate_effort = ?, complete = ?, type = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP,
 			started_at = CASE WHEN ? = 'active' AND ? != 'active' THEN CURRENT_TIMESTAMP ELSE ? END
 		WHERE ticket_id = ?
-	`, title, params.Description, nextAcceptanceCriteria, dorJSON, dodJSON, acJSON, nextGitRepository, nextGitBranch, nullableString(params.ParentID), assignee, nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), params.Priority, params.Order, params.EstimateEffort, strings.TrimSpace(params.EstimateComplete), completeVal, nextType, attrsJSON, state, current.State, current.StartedAt, id)
+	`, title, params.Description, nextAcceptanceCriteria, dorJSON, dodJSON, acJSON, nullableString(params.ParentID), assignee, nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), params.Priority, params.Order, params.EstimateEffort, completeVal, nextType, attrsJSON, state, current.State, current.StartedAt, id)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -819,7 +824,7 @@ func MarkTicketReady(ctx context.Context, db *sql.DB, id, actorUsername, actorID
 // SetTicketPrURL stores the PR URL on a ticket after a developer agent creates it.
 func SetTicketPrURL(ctx context.Context, db *sql.DB, id, prURL string) (Ticket, error) {
 	result, err := db.ExecContext(ctx, `
-		UPDATE tickets SET pr_url = ?, updated_at = CURRENT_TIMESTAMP WHERE ticket_id = ?
+		UPDATE tickets SET attrs = json_set(attrs, '$.pr_url', ?), updated_at = CURRENT_TIMESTAMP WHERE ticket_id = ?
 	`, strings.TrimSpace(prURL), id)
 	if err != nil {
 		return Ticket{}, err
@@ -1201,7 +1206,7 @@ func SetTicketHealth(ctx context.Context, db *sql.DB, id string, score int) (Tic
 	}
 	result, err := db.ExecContext(ctx, `
 		UPDATE tickets
-		SET health_score = ?, updated_at = CURRENT_TIMESTAMP
+		SET attrs = json_set(attrs, '$.health_score', ?), updated_at = CURRENT_TIMESTAMP
 		WHERE ticket_id = ?
 	`, score, id)
 	if err != nil {
@@ -1485,22 +1490,61 @@ type scanner interface {
 var ticketColumnNames = []string{
 	"ticket_id", "project_id", "parent_id", "clone_of", "type", "title",
 	"description", "acceptance_criteria", "dor_map", "dod_map", "ac_map",
-	"git_repository", "git_branch", "workflow_id", "workflow_stage_id", "role_id",
+	"workflow_id", "workflow_stage_id", "role_id",
 	"stage", "state", "status", "priority", "sort_order", "estimate_effort",
-	"estimate_complete", "health_score", "assignee", "author", "draft", "complete",
+	"assignee", "draft", "complete",
 	"archived", "deleted", "previous_workflow_stage_id", "previous_role_id",
 	"release_id", "created_by", "created_at", "updated_at", "recommended_ready",
-	"pr_url", "started_at", "attrs",
+	"started_at", "attrs",
 }
 
 // ticketColumnCoalesce maps nullable columns to the SQL literal substituted via
 // COALESCE when selecting them, so scanTicket can scan into non-pointer fields.
 var ticketColumnCoalesce = map[string]string{
-	"author":            "''",
 	"created_by":        "''",
 	"recommended_ready": "0",
-	"pr_url":            "''",
 	"started_at":        "''",
+}
+
+// ticketAttrStringKeys are the soft string fields that now live in the attrs bag
+// (TK-111) and are surfaced as typed Ticket fields for back-compat.
+var ticketAttrStringKeys = []string{"git_repository", "git_branch", "estimate_complete", "author", "pr_url"}
+
+const ticketAttrHealthScoreKey = "health_score"
+
+// hydrateTicketAttrs copies the bag-backed soft fields out of t.Attrs into their
+// typed Ticket fields and removes them from the user-visible bag (so they are not
+// duplicated). It is the read-side of the attrs consolidation.
+func hydrateTicketAttrs(t *Ticket) {
+	t.GitRepository = t.Attrs.GetString("git_repository")
+	t.GitBranch = t.Attrs.GetString("git_branch")
+	t.EstimateComplete = t.Attrs.GetString("estimate_complete")
+	t.Author = t.Attrs.GetString("author")
+	t.PrURL = t.Attrs.GetString("pr_url")
+	t.HealthScore = t.Attrs.GetInt(ticketAttrHealthScoreKey)
+	for _, k := range ticketAttrStringKeys {
+		delete(t.Attrs, k)
+	}
+	delete(t.Attrs, ticketAttrHealthScoreKey)
+	if len(t.Attrs) == 0 {
+		t.Attrs = nil
+	}
+}
+
+// ticketAttrsForWrite merges the bag-backed typed fields into a base bag and
+// returns the JSON text to store. It is the write-side of the attrs consolidation.
+func ticketAttrsForWrite(base Attrs, gitRepository, gitBranch, estimateComplete, author, prURL string, healthScore int) (string, error) {
+	merged := Attrs{}
+	for k, v := range base {
+		merged[k] = v
+	}
+	merged.SetString("git_repository", strings.TrimSpace(gitRepository))
+	merged.SetString("git_branch", strings.TrimSpace(gitBranch))
+	merged.SetString("estimate_complete", strings.TrimSpace(estimateComplete))
+	merged.SetString("author", strings.TrimSpace(author))
+	merged.SetString("pr_url", strings.TrimSpace(prURL))
+	merged.SetInt(ticketAttrHealthScoreKey, healthScore)
+	return marshalAttrs(merged)
 }
 
 // ticketSelectColumns returns the comma-separated SELECT expressions for reading a
@@ -1562,8 +1606,6 @@ func scanTicket(s scanner) (Ticket, error) {
 		&dorJSON,
 		&dodJSON,
 		&acJSON,
-		&ticket.GitRepository,
-		&ticket.GitBranch,
 		&workflowID,
 		&workflowStageID,
 		&roleID,
@@ -1573,10 +1615,7 @@ func scanTicket(s scanner) (Ticket, error) {
 		&ticket.Priority,
 		&ticket.Order,
 		&ticket.EstimateEffort,
-		&ticket.EstimateComplete,
-		&ticket.HealthScore,
 		&ticket.Assignee,
-		&ticket.Author,
 		&draft,
 		&complete,
 		&archived,
@@ -1588,7 +1627,6 @@ func scanTicket(s scanner) (Ticket, error) {
 		&ticket.CreatedAt,
 		&ticket.UpdatedAt,
 		&recommendedReady,
-		&ticket.PrURL,
 		&ticket.StartedAt,
 		&attrsJSON,
 	); err != nil {
@@ -1645,6 +1683,7 @@ func scanTicket(s scanner) (Ticket, error) {
 	ticket.Archived = archived == 1
 	ticket.Deleted = deleted == 1
 	ticket.RecommendedReady = recommendedReady == 1
+	hydrateTicketAttrs(&ticket)
 	return ticket, nil
 }
 


### PR DESCRIPTION
S6a of epic TK-105 (refs TK-111). Proves the physical-drop consolidation template on the highest-traffic entity.

## What
Moves **git_repository, git_branch, estimate_complete, health_score, author, pr_url** from dedicated `tickets` columns into the `attrs` bag and **drops them**; also drops the dead legacy **`open`** column. **Schema version 11 → 12.**

- **Migration** (`store.go`): removed the 4 base `CREATE TABLE` columns and the per-column `ADD COLUMN` migrations (including the *destructive* `open` backfill that reset `archived`, and the `author` backfill); added one idempotent, **non-clobbering** consolidation step (`json_set` only fills an absent key, then `DROP COLUMN`, all `columnExists`-guarded) that runs in **both** upgrade paths (in-place repair and snapshot rebuild). Author is backfilled from `created_by` into the bag. The `idx_tickets_open` index is dropped before the column.
- **Go** (`ticket.go`): the 6 columns left the centralized column list/scan; `hydrateTicketAttrs` (bag→typed fields, stripped from the visible bag) and `ticketAttrsForWrite` (typed fields→bag) added; `CreateTicket`/`UpdateTicket` and the `SetTicketPrURL` / health-score setters rewired to the bag.
- **`agent.go`**: `ListAgentStatuses` used the dropped `open` column → replaced `t.open = 1` with the equivalent `t.archived = 0`.

The typed `Ticket` fields (`GitRepository`, etc.) are unchanged → **CLI/API contract preserved**.

## Tests
No-data-loss migration from a simulated v11 shape (every value preserved, columns gone); typed round-trip with no attrs duplication; setter-through-bag. `store/server/client/contract/cmd` green except the pre-existing `TestFailureEscalationInboxLifecycle` (also red on main). Lint clean.

## Scope note
The `dor_map`/`dod_map`/`ac_map` **Fold** from the S1 classification is deferred to **TK-115** (filed) — it's cross-cutting through the guidance-resolution machinery shared across tickets/projects/roles, so it warrants its own story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)