### PR TITLE
TK-112: Consolidate projects agent-model config into attrs (physical drop)

### DIFF
--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -274,6 +274,14 @@ Conservative bias: anything filtered / sorted / FK'd / aggregated stays **Keep**
 
 ### 9.2 `projects`
 
+> **Status (TK-112):** the four `agent_model_*` config columns have been
+> consolidated into `attrs` and dropped (typed `Project` fields retained). After
+> implementation, `git_repository` and `notes` were reclassified **Keep**:
+> `git_repository` is entangled with the `project_git_repositories` sync table and
+> the `GetProjectByGitRepository` query, and `notes` is interleaved with kept
+> columns in many statements — both better left as columns. The `dor/dod/ac` Fold
+> is part of TK-115.
+
 | Column | Decision | Rationale |
 |--------|----------|-----------|
 | project_id, prefix, title | Keep | PK / identity / displayed |

--- a/internal/store/consolidate_projects_test.go
+++ b/internal/store/consolidate_projects_test.go
@@ -1,0 +1,116 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// TestConsolidateProjectsMigrationNoDataLoss simulates the pre-consolidation
+// projects shape (agent_model_* columns present and populated) and verifies the
+// upgrade moves the values into attrs with no loss, drops the columns, and the
+// values remain readable via the typed Project fields.
+func TestConsolidateProjectsMigrationNoDataLoss(t *testing.T) {
+	// Not parallel: manipulates schema_version and raw columns.
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+	p, err := CreateProjectWithParams(ctx, db, ProjectCreateParams{Title: "P", Prefix: "PMG"})
+	if err != nil {
+		t.Fatalf("CreateProjectWithParams() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	for _, stmt := range []string{
+		`ALTER TABLE projects ADD COLUMN agent_model_provider TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE projects ADD COLUMN agent_model_name TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE projects ADD COLUMN agent_model_url TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE projects ADD COLUMN agent_model_api_key TEXT NOT NULL DEFAULT ''`,
+	} {
+		if _, execErr := raw.Exec(stmt); execErr != nil {
+			_ = raw.Close()
+			t.Fatalf("setup %q error = %v", stmt, execErr)
+		}
+	}
+	if _, execErr := raw.Exec(
+		`UPDATE projects SET agent_model_provider=?, agent_model_name=?, agent_model_url=?, agent_model_api_key=?, attrs='{}' WHERE project_id=?`,
+		"anthropic", "claude-opus-4-8", "https://api", "sk-secret", p.ID,
+	); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("populate error = %v", execErr)
+	}
+	if _, execErr := raw.Exec(`UPDATE schema_meta SET value='11' WHERE key='schema_version'`); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("set version error = %v", execErr)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw.Close() error = %v", err)
+	}
+
+	if _, err := UpgradeInPlace(ctx, path); err != nil {
+		t.Fatalf("UpgradeInPlace() error = %v", err)
+	}
+
+	db2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() after upgrade error = %v", err)
+	}
+	defer db2.Close()
+
+	got, err := GetProjectByID(ctx, db2, p.ID)
+	if err != nil {
+		t.Fatalf("GetProjectByID() error = %v", err)
+	}
+	if got.AgentModelProvider != "anthropic" || got.AgentModelName != "claude-opus-4-8" ||
+		got.AgentModelURL != "https://api" || got.AgentModelAPIKey != "sk-secret" {
+		t.Fatalf("agent-model config not preserved: %+v", got)
+	}
+	for _, col := range []string{"agent_model_provider", "agent_model_name", "agent_model_url", "agent_model_api_key"} {
+		if columnExists(ctx, db2, "projects", col) {
+			t.Errorf("projects.%s still exists after consolidation", col)
+		}
+	}
+}
+
+// TestConsolidatedProjectAgentModelRoundTrip verifies the agent-model config still
+// works through the typed fields and the dedicated setter after consolidation.
+func TestConsolidatedProjectAgentModelRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	p, err := CreateProjectWithParams(ctx, db, ProjectCreateParams{
+		Title: "P", Prefix: "PRT",
+		AgentModelProvider: "anthropic", AgentModelName: "claude",
+		Attrs: Attrs{"jira": "X-1"},
+	})
+	if err != nil {
+		t.Fatalf("CreateProjectWithParams() error = %v", err)
+	}
+	got, err := GetProjectByID(ctx, db, p.ID)
+	if err != nil {
+		t.Fatalf("GetProjectByID() error = %v", err)
+	}
+	if got.AgentModelProvider != "anthropic" || got.AgentModelName != "claude" {
+		t.Fatalf("agent-model fields not round-tripped: %+v", got)
+	}
+	if got.Attrs.GetString("jira") != "X-1" {
+		t.Fatalf("extra attr lost: %#v", got.Attrs)
+	}
+	if _, dup := got.Attrs["agent_model_provider"]; dup {
+		t.Fatalf("attrs duplicates a typed field: %#v", got.Attrs)
+	}
+
+	updated, err := SetProjectAgentModelConfig(ctx, db, p.ID, AgentModelConfig{Provider: "openai", Model: "gpt", URL: "u", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("SetProjectAgentModelConfig() error = %v", err)
+	}
+	if updated.AgentModelProvider != "openai" || updated.AgentModelName != "gpt" || updated.AgentModelURL != "u" || updated.AgentModelAPIKey != "k" {
+		t.Fatalf("setter did not write through bag: %+v", updated)
+	}
+}

--- a/internal/store/project.go
+++ b/internal/store/project.go
@@ -155,24 +155,24 @@ func CreateProjectWithParams(ctx context.Context, db *sql.DB, params ProjectCrea
 	if acceptanceCriteria == "" && acMap != nil {
 		acceptanceCriteria = acMap[DefaultGuidanceStageKey]
 	}
-	attrsJSON, err := marshalAttrs(params.Attrs)
+	// agent_model_* now live in the attrs bag (TK-112).
+	attrsJSON, err := projectAttrsForWrite(params.Attrs, params.AgentModelProvider, params.AgentModelName, params.AgentModelURL, params.AgentModelAPIKey)
 	if err != nil {
 		return Project{}, err
 	}
 	query := `
-		INSERT INTO projects (prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, attrs)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO projects (prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, attrs)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?)
 	`
 	args := []any{
 		uniquePrefix, title, strings.TrimSpace(params.Description), acceptanceCriteria, dorJSON, dodJSON, acJSON,
 		strings.TrimSpace(params.GitRepository), strings.TrimSpace(params.Notes), visibility, nullableUserID(params.CreatedBy), workflowID,
-		strings.TrimSpace(params.AgentModelProvider), strings.TrimSpace(params.AgentModelName), strings.TrimSpace(params.AgentModelURL), strings.TrimSpace(params.AgentModelAPIKey),
 		attrsJSON,
 	}
 	if hasExplicitID {
 		query = `
-			INSERT INTO projects (project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, attrs)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?, ?)
+			INSERT INTO projects (project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, attrs)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?)
 		`
 		args = append([]any{explicitID}, args...)
 	}
@@ -203,6 +203,38 @@ func CreateProjectWithParams(ctx context.Context, db *sql.DB, params ProjectCrea
 	return GetProjectByID(ctx, db, id)
 }
 
+// projectAttrAgentModelKeys are the agent-model config fields that now live in the
+// projects attrs bag (TK-112), surfaced as typed Project fields for back-compat.
+var projectAttrAgentModelKeys = []string{"agent_model_provider", "agent_model_name", "agent_model_url", "agent_model_api_key"}
+
+// hydrateProjectAttrs copies the bag-backed agent-model fields into typed Project
+// fields and strips them from the visible bag.
+func hydrateProjectAttrs(p *Project) {
+	p.AgentModelProvider = p.Attrs.GetString("agent_model_provider")
+	p.AgentModelName = p.Attrs.GetString("agent_model_name")
+	p.AgentModelURL = p.Attrs.GetString("agent_model_url")
+	p.AgentModelAPIKey = p.Attrs.GetString("agent_model_api_key")
+	for _, k := range projectAttrAgentModelKeys {
+		delete(p.Attrs, k)
+	}
+	if len(p.Attrs) == 0 {
+		p.Attrs = nil
+	}
+}
+
+// projectAttrsForWrite merges the bag-backed agent-model fields into a base bag.
+func projectAttrsForWrite(base Attrs, provider, name, url, apiKey string) (string, error) {
+	merged := Attrs{}
+	for k, v := range base {
+		merged[k] = v
+	}
+	merged.SetString("agent_model_provider", strings.TrimSpace(provider))
+	merged.SetString("agent_model_name", strings.TrimSpace(name))
+	merged.SetString("agent_model_url", strings.TrimSpace(url))
+	merged.SetString("agent_model_api_key", strings.TrimSpace(apiKey))
+	return marshalAttrs(merged)
+}
+
 func scanProject(s scanner) (Project, error) {
 	var project Project
 	var workflowID sql.NullInt64
@@ -213,7 +245,6 @@ func scanProject(s scanner) (Project, error) {
 		&project.ID, &project.Prefix, &project.Title, &project.Description, &project.AcceptanceCriteria,
 		&dorJSON, &dodJSON, &acJSON, &project.GitRepository, &project.Notes, &project.Status, &project.Visibility,
 		&project.DefaultDraft, &project.CreatedBy, &project.CreatedAt, &project.UpdatedAt, &workflowID,
-		&project.AgentModelProvider, &project.AgentModelName, &project.AgentModelURL, &project.AgentModelAPIKey,
 		&programmeID, &attrsJSON,
 	); err != nil {
 		return Project{}, err
@@ -223,6 +254,7 @@ func scanProject(s scanner) (Project, error) {
 	if err != nil {
 		return Project{}, err
 	}
+	hydrateProjectAttrs(&project)
 	project.DORMap, err = parseGuidanceMap(dorJSON)
 	if err != nil {
 		return Project{}, err
@@ -253,7 +285,7 @@ func ListProjects(ctx context.Context, db *sql.DB, limit int) ([]Project, error)
 		limit = 1000
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		ORDER BY created_at, project_id
 		LIMIT ?
@@ -302,7 +334,7 @@ func ListProjectsVisibleToUser(ctx context.Context, db *sql.DB, user User) ([]Pr
 			FROM teams parent
 			JOIN team_scope ts ON ts.parent_team_id = parent.team_id
 		)
-		SELECT DISTINCT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id, p.attrs
+		SELECT DISTINCT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs
 		FROM projects p
 		LEFT JOIN project_members pm ON pm.project_id = p.project_id AND pm.user_id = ?
 		LEFT JOIN project_teams pt ON pt.project_id = p.project_id
@@ -348,7 +380,7 @@ func GetProject(ctx context.Context, db *sql.DB, rawID string) (Project, error) 
 		return GetProjectByID(ctx, db, id)
 	}
 	row := db.QueryRowContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		WHERE prefix = ?
 	`, strings.ToUpper(rawID))
@@ -371,7 +403,7 @@ func GetProjectByID(ctx context.Context, db *sql.DB, id int64) (Project, error) 
 		return Project{}, err
 	}
 	row := db.QueryRowContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		WHERE project_id = ?
 	`, id)
@@ -401,7 +433,7 @@ func GetProjectByGitRepository(ctx context.Context, db *sql.DB, gitRepository st
 		return Project{}, err
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id, p.attrs,
+		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs,
 		       r.repository
 		FROM projects p
 		JOIN project_git_repositories r ON r.project_id = p.project_id
@@ -467,7 +499,6 @@ func scanProjectWithWorkflowIDAndRepository(s scanner) (projectWithRepository, e
 		&result.project.ID, &result.project.Prefix, &result.project.Title, &result.project.Description, &result.project.AcceptanceCriteria,
 		&dorJSON, &dodJSON, &acJSON, &result.project.GitRepository, &result.project.Notes, &result.project.Status, &result.project.Visibility,
 		&result.project.DefaultDraft, &result.project.CreatedBy, &result.project.CreatedAt, &result.project.UpdatedAt, &workflowID,
-		&result.project.AgentModelProvider, &result.project.AgentModelName, &result.project.AgentModelURL, &result.project.AgentModelAPIKey,
 		&programmeID, &attrsJSON,
 		&result.repository,
 	); err != nil {
@@ -478,6 +509,7 @@ func scanProjectWithWorkflowIDAndRepository(s scanner) (projectWithRepository, e
 	if err != nil {
 		return projectWithRepository{}, err
 	}
+	hydrateProjectAttrs(&result.project)
 	result.project.DORMap, err = parseGuidanceMap(dorJSON)
 	if err != nil {
 		return projectWithRepository{}, err
@@ -596,19 +628,19 @@ func UpdateProjectWithParams(ctx context.Context, db *sql.DB, id int64, params P
 	if err != nil {
 		return Project{}, err
 	}
-	attrsToWrite := current.Attrs
+	baseAttrs := current.Attrs
 	if params.Attrs != nil {
-		attrsToWrite = params.Attrs
+		baseAttrs = params.Attrs
 	}
-	attrsJSON, err := marshalAttrs(attrsToWrite)
+	attrsJSON, err := projectAttrsForWrite(baseAttrs, nextAgentModelProvider, nextAgentModelName, nextAgentModelURL, nextAgentModelAPIKey)
 	if err != nil {
 		return Project{}, err
 	}
 	_, err = db.ExecContext(ctx, `
 		UPDATE projects
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, notes = ?, status = ?, visibility = ?, workflow_id = ?, agent_model_provider = ?, agent_model_name = ?, agent_model_url = ?, agent_model_api_key = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
+		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, notes = ?, status = ?, visibility = ?, workflow_id = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE project_id = ?
-	`, nextTitle, nextDescription, nextAC, dorJSON, dodJSON, acJSON, nextRepo, nextNotes, nextStatus, nextVisibility, nextWorkflowID, nextAgentModelProvider, nextAgentModelName, nextAgentModelURL, nextAgentModelAPIKey, attrsJSON, id)
+	`, nextTitle, nextDescription, nextAC, dorJSON, dodJSON, acJSON, nextRepo, nextNotes, nextStatus, nextVisibility, nextWorkflowID, attrsJSON, id)
 	if err != nil {
 		return Project{}, err
 	}
@@ -638,7 +670,7 @@ func validProjectVisibility(visibility string) bool {
 
 func getProjectByTitle(ctx context.Context, db *sql.DB, title string) (Project, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		WHERE LOWER(title) = LOWER(?)
 		ORDER BY project_id
@@ -716,7 +748,14 @@ func SetProjectDefaultDraft(ctx context.Context, db *sql.DB, projectID int64, dr
 func SetProjectAgentModelConfig(ctx context.Context, db *sql.DB, projectID int64, cfg AgentModelConfig) (Project, error) {
 	result, err := db.ExecContext(ctx, `
 		UPDATE projects
-		SET agent_model_provider = ?, agent_model_name = ?, agent_model_url = ?, agent_model_api_key = ?, updated_at = CURRENT_TIMESTAMP
+		SET attrs = json_set(
+			json_set(
+				json_set(
+					json_set(attrs, '$.agent_model_provider', ?),
+					'$.agent_model_name', ?),
+				'$.agent_model_url', ?),
+			'$.agent_model_api_key', ?),
+			updated_at = CURRENT_TIMESTAMP
 		WHERE project_id = ?
 	`, strings.TrimSpace(cfg.Provider), strings.TrimSpace(cfg.Model), strings.TrimSpace(cfg.URL), strings.TrimSpace(cfg.APIKey), projectID)
 	if err != nil {

--- a/internal/store/project_alias.go
+++ b/internal/store/project_alias.go
@@ -34,7 +34,7 @@ func GetProjectByAlias(ctx context.Context, db *sql.DB, alias, userID string) (P
 	}
 	trimmedUserID := strings.TrimSpace(userID)
 	query := `
-		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id, p.attrs
+		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs
 		FROM project_aliases pa
 		JOIN projects p ON p.project_id = pa.project_id
 		WHERE pa.alias_name = ? AND ((pa.user_id IS NULL AND ? = '') OR pa.user_id = ?)

--- a/internal/store/schema_version.go
+++ b/internal/store/schema_version.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	LegacySchemaVersion  = 1
-	CurrentSchemaVersion = 11
+	CurrentSchemaVersion = 12
 	schemaMetaTable      = "schema_meta"
 	schemaVersionKey     = "schema_version"
 	// DefaultBackupRetention is the number of timestamped pre-upgrade backups

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -307,10 +307,6 @@ CREATE TABLE IF NOT EXISTS projects (
 	ticket_sequence INTEGER NOT NULL DEFAULT 0,
 	default_draft INTEGER NOT NULL DEFAULT 0,
 	workflow_id INTEGER,
-	agent_model_provider TEXT NOT NULL DEFAULT '',
-	agent_model_name TEXT NOT NULL DEFAULT '',
-	agent_model_url TEXT NOT NULL DEFAULT '',
-	agent_model_api_key TEXT NOT NULL DEFAULT '',
 	attrs TEXT NOT NULL DEFAULT '{}',
 	FOREIGN KEY(created_by) REFERENCES users(user_id),
 	FOREIGN KEY(workflow_id) REFERENCES workflows(workflow_id)
@@ -972,26 +968,9 @@ func migrateSchema(ctx context.Context, db *sql.DB) error {
 			return err
 		}
 	}
-	if !columnExists(ctx, db, "projects", "agent_model_provider") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN agent_model_provider TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "projects", "agent_model_name") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN agent_model_name TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "projects", "agent_model_url") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN agent_model_url TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "projects", "agent_model_api_key") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN agent_model_api_key TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
+	// agent_model_provider/name/url/api_key moved into the projects attrs bag
+	// (TK-112); their legacy ADD COLUMN migrations were removed and the columns are
+	// migrated and dropped by the attrs-consolidation step below.
 	if _, err := db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_projects_workflow_id ON projects(workflow_id)`); err != nil {
 		return err
 	}
@@ -1766,6 +1745,22 @@ CREATE TABLE user_notifications (
 		}
 		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets DROP COLUMN open`); err != nil {
 			return err
+		}
+	}
+
+	// Consolidate projects agent-model config columns into the attrs bag and drop
+	// them (TK-112). Same idempotent, non-clobbering pattern as tickets above.
+	for _, col := range []string{"agent_model_provider", "agent_model_name", "agent_model_url", "agent_model_api_key"} {
+		if columnExists(ctx, db, "projects", col) {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE projects SET attrs = json_set(attrs, '$.%s', %s) `+
+					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) <> ''`,
+				col, col, col, col)); err != nil {
+				return err
+			}
+			if _, err := db.ExecContext(ctx, `ALTER TABLE projects DROP COLUMN `+col); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
S6b of epic TK-105 (refs TK-112).

## What
Moves **agent_model_provider/name/url/api_key** from dedicated `projects` columns into the `attrs` bag and **drops them**. Also **corrects the schema version**: S6a omitted the bump, so this sets `CurrentSchemaVersion` **11 → 12** — existing v11 DBs now auto-upgrade and run both the tickets (TK-111) and projects consolidation.

- `store.go`: removed the 4 `agent_model_*` base columns + their ADD migrations; added an idempotent, non-clobbering projects consolidation step alongside the tickets one.
- `project.go` / `project_alias.go`: removed the 4 columns from every select list + both scan functions; added `hydrateProjectAttrs` / `projectAttrsForWrite`; rewired create/update and `SetProjectAgentModelConfig` (now `json_set` into the bag).

**Reclassified Keep** (after implementation): `git_repository` (entangled with the `project_git_repositories` sync table + `GetProjectByGitRepository`) and `notes` (interleaved with kept columns in many statements). Typed `Project` fields unchanged → API/CLI preserved.

## Tests
No-data-loss migration from a simulated pre-consolidation shape; typed round-trip with no attrs duplication; setter-through-bag. `store/server/client/contract/cmd` green except the pre-existing inbox failure. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)