### PR TITLE
TK-113: Fold roles guidance columns into attrs (physical drop)

### DIFF
--- a/internal/store/attrs.go
+++ b/internal/store/attrs.go
@@ -48,6 +48,26 @@ func parseAttrs(text string) (Attrs, error) {
 	return a, nil
 }
 
+// guidanceMapFromAttr converts a decoded attrs value (a nested JSON object) into a
+// GuidanceMap. Used when a guidance map (dor/dod/ac) is folded into the bag as a
+// nested object (TK-113/TK-115). Returns nil for a missing or non-object value.
+func guidanceMapFromAttr(v any) GuidanceMap {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make(GuidanceMap, len(m))
+	for k, val := range m {
+		if s, ok := val.(string); ok {
+			out[k] = s
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // GetString returns the value at key as a string, or "" if absent or not a string.
 func (a Attrs) GetString(key string) string {
 	if v, ok := a[key].(string); ok {

--- a/internal/store/consolidate_roles_test.go
+++ b/internal/store/consolidate_roles_test.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"reflect"
+	"testing"
+)
+
+// TestConsolidateRolesMigrationNoDataLoss simulates the pre-consolidation roles
+// shape (guidance columns present and populated) and verifies the upgrade folds the
+// values into attrs with no loss, drops the columns, and the values remain readable
+// via the typed Role fields.
+func TestConsolidateRolesMigrationNoDataLoss(t *testing.T) {
+	// Not parallel: manipulates schema_version and raw columns.
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+	r, err := CreateRoleWithParams(ctx, db, RoleCreateParams{Title: "Engineer"})
+	if err != nil {
+		t.Fatalf("CreateRoleWithParams() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	for _, stmt := range []string{
+		`ALTER TABLE roles ADD COLUMN description TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE roles ADD COLUMN acceptance_criteria TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE roles ADD COLUMN dor_map TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE roles ADD COLUMN dod_map TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE roles ADD COLUMN ac_map TEXT NOT NULL DEFAULT '{}'`,
+	} {
+		if _, execErr := raw.Exec(stmt); execErr != nil {
+			_ = raw.Close()
+			t.Fatalf("setup %q error = %v", stmt, execErr)
+		}
+	}
+	if _, execErr := raw.Exec(
+		`UPDATE roles SET description=?, acceptance_criteria=?, dor_map=?, dod_map=?, ac_map=?, attrs='{}' WHERE role_id=?`,
+		"builds the thing", "compiles", `{"default":"branch exists"}`, `{"develop":"tests pass"}`, `{"default":"meets AC"}`, r.ID,
+	); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("populate error = %v", execErr)
+	}
+	if _, execErr := raw.Exec(`UPDATE schema_meta SET value='11' WHERE key='schema_version'`); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("set version error = %v", execErr)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw.Close() error = %v", err)
+	}
+
+	if _, err := UpgradeInPlace(ctx, path); err != nil {
+		t.Fatalf("UpgradeInPlace() error = %v", err)
+	}
+
+	db2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() after upgrade error = %v", err)
+	}
+	defer db2.Close()
+
+	got, err := GetRoleByID(ctx, db2, r.ID)
+	if err != nil {
+		t.Fatalf("GetRoleByID() error = %v", err)
+	}
+	if got.Description != "builds the thing" {
+		t.Errorf("Description = %q, want preserved", got.Description)
+	}
+	if got.AcceptanceCriteria != "compiles" {
+		t.Errorf("AcceptanceCriteria = %q, want preserved", got.AcceptanceCriteria)
+	}
+	if !reflect.DeepEqual(got.DORMap, GuidanceMap{"default": "branch exists"}) {
+		t.Errorf("DORMap = %#v, want preserved", got.DORMap)
+	}
+	if got.DODMap["develop"] != "tests pass" {
+		t.Errorf("DODMap = %#v, want preserved", got.DODMap)
+	}
+	for _, col := range []string{"description", "acceptance_criteria", "dor_map", "dod_map", "ac_map"} {
+		if columnExists(ctx, db2, "roles", col) {
+			t.Errorf("roles.%s still exists after consolidation", col)
+		}
+	}
+}
+
+// TestConsolidatedRoleRoundTrip verifies role guidance still round-trips through
+// the typed fields after consolidation, with the extra bag preserved.
+func TestConsolidatedRoleRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	r, err := CreateRoleWithParams(ctx, db, RoleCreateParams{
+		Title: "QA", Description: "tests things", AcceptanceCriteria: "all green",
+		DORMap: GuidanceMap{"default": "ready"},
+		Attrs:  Attrs{"color": "purple"},
+	})
+	if err != nil {
+		t.Fatalf("CreateRoleWithParams() error = %v", err)
+	}
+	got, err := GetRoleByID(ctx, db, r.ID)
+	if err != nil {
+		t.Fatalf("GetRoleByID() error = %v", err)
+	}
+	if got.Description != "tests things" || got.AcceptanceCriteria != "all green" {
+		t.Fatalf("role text fields not round-tripped: %+v", got)
+	}
+	if got.DORMap["default"] != "ready" {
+		t.Fatalf("DORMap not round-tripped: %#v", got.DORMap)
+	}
+	if got.Attrs.GetString("color") != "purple" {
+		t.Fatalf("extra attr lost: %#v", got.Attrs)
+	}
+	for _, k := range []string{"description", "acceptance_criteria", "dor_map", "dod_map", "ac_map"} {
+		if _, dup := got.Attrs[k]; dup {
+			t.Fatalf("attrs duplicates typed field %q: %#v", k, got.Attrs)
+		}
+	}
+}

--- a/internal/store/role.go
+++ b/internal/store/role.go
@@ -66,36 +66,25 @@ func CreateRoleWithParams(ctx context.Context, db *sql.DB, params RoleCreatePara
 	if err != nil {
 		return Role{}, err
 	}
-	dorJSON, err := guidanceMapJSON(params.DORMap)
-	if err != nil {
-		return Role{}, err
-	}
-	dodJSON, err := guidanceMapJSON(params.DODMap)
-	if err != nil {
-		return Role{}, err
-	}
 	acMap := withLegacyAcceptanceCriteria(params.AcceptanceCriteria, params.ACMap)
-	acJSON, err := guidanceMapJSON(acMap)
-	if err != nil {
-		return Role{}, err
-	}
 	acceptanceCriteria := strings.TrimSpace(params.AcceptanceCriteria)
 	if acceptanceCriteria == "" && acMap != nil {
 		acceptanceCriteria = acMap[DefaultGuidanceStageKey]
 	}
-	attrsJSON, err := marshalAttrs(params.Attrs)
+	// description/acceptance_criteria and dor/dod/ac maps live in the attrs bag (TK-113).
+	attrsJSON, err := roleAttrsForWrite(params.Attrs, params.Description, acceptanceCriteria, params.DORMap, params.DODMap, acMap)
 	if err != nil {
 		return Role{}, err
 	}
 	query := `
-		INSERT INTO roles (workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, attrs, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		INSERT INTO roles (workflow_id, title, attrs, updated_at)
+		VALUES (?, ?, ?, CURRENT_TIMESTAMP)
 	`
-	args := []any{nullableInt64(params.WorkflowID), title, strings.TrimSpace(params.Description), acceptanceCriteria, dorJSON, dodJSON, acJSON, attrsJSON}
+	args := []any{nullableInt64(params.WorkflowID), title, attrsJSON}
 	if hasExplicitID {
 		query = `
-			INSERT INTO roles (role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, attrs, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+			INSERT INTO roles (role_id, workflow_id, title, attrs, updated_at)
+			VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
 		`
 		args = append([]any{explicitID}, args...)
 	}
@@ -113,12 +102,51 @@ func CreateRoleWithParams(ctx context.Context, db *sql.DB, params RoleCreatePara
 	return GetRoleByID(ctx, db, id)
 }
 
+// setGuidanceAttr stores a guidance map as a nested object in the bag, or removes
+// the key when the map is empty (keeping the stored bag sparse).
+func setGuidanceAttr(a Attrs, key string, m GuidanceMap) {
+	if len(m) == 0 {
+		delete(a, key)
+		return
+	}
+	a[key] = map[string]string(m)
+}
+
+// hydrateRoleAttrs copies the bag-backed guidance fields into typed Role fields and
+// strips them from the visible bag (TK-113).
+func hydrateRoleAttrs(r *Role) {
+	r.Description = r.Attrs.GetString("description")
+	r.AcceptanceCriteria = r.Attrs.GetString("acceptance_criteria")
+	r.DORMap = guidanceMapFromAttr(r.Attrs["dor_map"])
+	r.DODMap = guidanceMapFromAttr(r.Attrs["dod_map"])
+	r.ACMap = withLegacyAcceptanceCriteria(r.AcceptanceCriteria, guidanceMapFromAttr(r.Attrs["ac_map"]))
+	for _, k := range []string{"description", "acceptance_criteria", "dor_map", "dod_map", "ac_map"} {
+		delete(r.Attrs, k)
+	}
+	if len(r.Attrs) == 0 {
+		r.Attrs = nil
+	}
+}
+
+// roleAttrsForWrite folds the bag-backed guidance fields into a base bag (TK-113).
+func roleAttrsForWrite(base Attrs, description, acceptanceCriteria string, dor, dod, ac GuidanceMap) (string, error) {
+	merged := Attrs{}
+	for k, v := range base {
+		merged[k] = v
+	}
+	merged.SetString("description", strings.TrimSpace(description))
+	merged.SetString("acceptance_criteria", strings.TrimSpace(acceptanceCriteria))
+	setGuidanceAttr(merged, "dor_map", dor)
+	setGuidanceAttr(merged, "dod_map", dod)
+	setGuidanceAttr(merged, "ac_map", ac)
+	return marshalAttrs(merged)
+}
+
 func scanRoleValues(scan func(dest ...any) error) (Role, error) {
 	var role Role
 	var workflowID sql.NullInt64
-	var dorJSON, dodJSON, acJSON string
 	var attrsJSON sql.NullString
-	if err := scan(&role.ID, &workflowID, &role.Title, &role.Description, &role.AcceptanceCriteria, &dorJSON, &dodJSON, &acJSON, &role.CreatedAt, &role.UpdatedAt, &attrsJSON); err != nil {
+	if err := scan(&role.ID, &workflowID, &role.Title, &role.CreatedAt, &role.UpdatedAt, &attrsJSON); err != nil {
 		return Role{}, err
 	}
 	var err error
@@ -126,19 +154,7 @@ func scanRoleValues(scan func(dest ...any) error) (Role, error) {
 	if err != nil {
 		return Role{}, err
 	}
-	role.DORMap, err = parseGuidanceMap(dorJSON)
-	if err != nil {
-		return Role{}, err
-	}
-	role.DODMap, err = parseGuidanceMap(dodJSON)
-	if err != nil {
-		return Role{}, err
-	}
-	role.ACMap, err = parseGuidanceMap(acJSON)
-	if err != nil {
-		return Role{}, err
-	}
-	role.ACMap = withLegacyAcceptanceCriteria(role.AcceptanceCriteria, role.ACMap)
+	hydrateRoleAttrs(&role)
 	if workflowID.Valid {
 		role.WorkflowID = &workflowID.Int64
 	}
@@ -186,31 +202,19 @@ func UpdateRoleWithParams(ctx context.Context, db *sql.DB, id int64, params Role
 		nextACMap = withLegacyAcceptanceCriteria(params.AcceptanceCriteria, current.ACMap)
 	}
 	nextACMap = withLegacyAcceptanceCriteria(acceptanceCriteria, nextACMap)
-	dorJSON, err := guidanceMapJSON(nextDORMap)
-	if err != nil {
-		return Role{}, err
-	}
-	dodJSON, err := guidanceMapJSON(nextDODMap)
-	if err != nil {
-		return Role{}, err
-	}
-	acJSON, err := guidanceMapJSON(nextACMap)
-	if err != nil {
-		return Role{}, err
-	}
-	attrsToWrite := current.Attrs
+	baseAttrs := current.Attrs
 	if params.Attrs != nil {
-		attrsToWrite = params.Attrs
+		baseAttrs = params.Attrs
 	}
-	attrsJSON, err := marshalAttrs(attrsToWrite)
+	attrsJSON, err := roleAttrsForWrite(baseAttrs, description, acceptanceCriteria, nextDORMap, nextDODMap, nextACMap)
 	if err != nil {
 		return Role{}, err
 	}
 	result, err := db.ExecContext(ctx, `
 		UPDATE roles
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
+		SET title = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE role_id = ?
-	`, title, description, acceptanceCriteria, dorJSON, dodJSON, acJSON, attrsJSON, id)
+	`, title, attrsJSON, id)
 	if err != nil {
 		return Role{}, err
 	}
@@ -229,7 +233,7 @@ func ListRoles(ctx context.Context, db *sql.DB, limit int) ([]Role, error) {
 		limit = 1000
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
+		SELECT role_id, workflow_id, title, created_at, updated_at, attrs
 		FROM roles
 		ORDER BY title
 		LIMIT ?
@@ -243,7 +247,7 @@ func ListRoles(ctx context.Context, db *sql.DB, limit int) ([]Role, error) {
 
 func ListRolesByWorkflow(ctx context.Context, db *sql.DB, workflowID int64) ([]Role, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
+		SELECT role_id, workflow_id, title, created_at, updated_at, attrs
 		FROM roles
 		WHERE workflow_id = ?
 		ORDER BY title
@@ -269,7 +273,7 @@ func scanRoles(rows *sql.Rows) ([]Role, error) {
 
 func GetRoleByID(ctx context.Context, db *sql.DB, id int64) (Role, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
+		SELECT role_id, workflow_id, title, created_at, updated_at, attrs
 		FROM roles
 		WHERE role_id = ?
 	`, id)
@@ -278,7 +282,7 @@ func GetRoleByID(ctx context.Context, db *sql.DB, id int64) (Role, error) {
 
 func GetRoleByTitle(ctx context.Context, db *sql.DB, title string) (Role, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
+		SELECT role_id, workflow_id, title, created_at, updated_at, attrs
 		FROM roles
 		WHERE title = ?
 	`, strings.TrimSpace(title))
@@ -287,7 +291,7 @@ func GetRoleByTitle(ctx context.Context, db *sql.DB, title string) (Role, error)
 
 func getRoleByTitleTx(ctx context.Context, tx *sql.Tx, title string) (Role, error) {
 	row := tx.QueryRowContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
+		SELECT role_id, workflow_id, title, created_at, updated_at, attrs
 		FROM roles
 		WHERE title = ?
 	`, strings.TrimSpace(title))
@@ -356,7 +360,7 @@ func ReorderWorkflowStageRoles(ctx context.Context, db *sql.DB, workflowID, stag
 
 func ListWorkflowStageRoles(ctx context.Context, db *sql.DB, workflowID, stageID int64) ([]Role, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT r.role_id, r.workflow_id, r.title, r.description, r.acceptance_criteria, r.dor_map, r.dod_map, r.ac_map, r.created_at, r.updated_at, r.attrs
+		SELECT r.role_id, r.workflow_id, r.title, r.created_at, r.updated_at, r.attrs
 		FROM workflow_stage_roles sr
 		JOIN roles r ON r.role_id = sr.role_id
 		WHERE sr.workflow_id = ? AND sr.stage_id = ?

--- a/internal/store/sdlc.go
+++ b/internal/store/sdlc.go
@@ -980,7 +980,7 @@ func listWorkflowStages(ctx context.Context, db *sql.DB, workflowID int64) ([]Wo
 // given workflowID in a single query and returns them grouped by stage_id.
 func listWorkflowStageRolesBatch(ctx context.Context, db *sql.DB, workflowID int64) (map[int64][]Role, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT sr.stage_id, r.role_id, r.workflow_id, r.title, r.description, r.acceptance_criteria, r.dor_map, r.dod_map, r.ac_map, r.created_at, r.updated_at, r.attrs
+		SELECT sr.stage_id, r.role_id, r.workflow_id, r.title, r.created_at, r.updated_at, r.attrs
 		FROM workflow_stage_roles sr
 		JOIN roles r ON r.role_id = sr.role_id
 		WHERE sr.workflow_id = ?

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -276,11 +276,6 @@ CREATE TABLE IF NOT EXISTS roles (
 	role_id INTEGER PRIMARY KEY AUTOINCREMENT,
 	workflow_id INTEGER,
 	title TEXT NOT NULL,
-	description TEXT NOT NULL DEFAULT '',
-	acceptance_criteria TEXT NOT NULL DEFAULT '',
-	dor_map TEXT NOT NULL DEFAULT '{}',
-	dod_map TEXT NOT NULL DEFAULT '{}',
-	ac_map TEXT NOT NULL DEFAULT '{}',
 	attrs TEXT NOT NULL DEFAULT '{}',
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -1093,21 +1088,9 @@ CREATE TABLE user_notifications (
 			return err
 		}
 	}
-	if !columnExists(ctx, db, "roles", "dor_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE roles ADD COLUMN dor_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "roles", "dod_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE roles ADD COLUMN dod_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "roles", "ac_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE roles ADD COLUMN ac_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
+	// roles description/acceptance_criteria/dor_map/dod_map/ac_map are folded into
+	// the roles attrs bag (TK-113); their legacy ADD COLUMN migrations were removed
+	// and the columns are migrated and dropped by the attrs-consolidation step below.
 	if _, err := db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_tickets_workflow_stage_id ON tickets(workflow_stage_id)`); err != nil {
 		return err
 	}
@@ -1759,6 +1742,37 @@ CREATE TABLE user_notifications (
 				return err
 			}
 			if _, err := db.ExecContext(ctx, `ALTER TABLE projects DROP COLUMN `+col); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Fold roles guidance columns into the attrs bag and drop them (TK-113). The
+	// scalar text fields (description, acceptance_criteria) are stored as strings;
+	// the guidance maps (dor_map/dod_map/ac_map) are embedded as nested JSON objects
+	// via json(col). Non-clobbering and idempotent.
+	for _, col := range []string{"description", "acceptance_criteria"} {
+		if columnExists(ctx, db, "roles", col) {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE roles SET attrs = json_set(attrs, '$.%s', %s) `+
+					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) <> ''`,
+				col, col, col, col)); err != nil {
+				return err
+			}
+			if _, err := db.ExecContext(ctx, `ALTER TABLE roles DROP COLUMN `+col); err != nil {
+				return err
+			}
+		}
+	}
+	for _, col := range []string{"dor_map", "dod_map", "ac_map"} {
+		if columnExists(ctx, db, "roles", col) {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE roles SET attrs = json_set(attrs, '$.%s', json(%s)) `+
+					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) NOT IN ('', '{}')`,
+				col, col, col, col)); err != nil {
+				return err
+			}
+			if _, err := db.ExecContext(ctx, `ALTER TABLE roles DROP COLUMN `+col); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
S6c of epic TK-105 (refs TK-113). Proves the guidance-fold pattern on the simplest entity.

## What
Folds **description, acceptance_criteria, dor_map, dod_map, ac_map** into the roles `attrs` bag and drops the columns — `roles` is now `role_id/workflow_id/title/created_at/updated_at/attrs`.

- `attrs.go`: `guidanceMapFromAttr` (decoded nested object → `GuidanceMap`).
- `store.go`: removed the 5 guidance columns from the base roles `CREATE TABLE` + the dor/dod/ac ADD migrations; added an idempotent roles fold step — text via `json_set`, guidance maps embedded as nested objects via `json(col)`, then `DROP COLUMN`.
- `role.go` / `sdlc.go`: removed the columns from all role select lists + `scanRoleValues`; added `hydrateRoleAttrs` / `roleAttrsForWrite` / `setGuidanceAttr`; rewired create/update.

Typed `Role` fields (`Description`/`AcceptanceCriteria`/`DORMap`/`DODMap`/`ACMap`) are hydrated from the bag, so `resolveGuidance` / `withLegacyAcceptanceCriteria` and prompt generation are unaffected.

## Tests
No-data-loss migration from a simulated pre-fold shape (text + guidance maps preserved); typed round-trip with no attrs duplication. `store/server/client/contract/cmd` green except the pre-existing inbox failure. Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)