### PR TITLE
TK-114: Fold workflow_stages guidance text into attrs (physical drop)

### DIFF
--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -331,3 +331,15 @@ introduce `attrs` (TK-109) → queryable bag (TK-110) → per-entity consolidati
 TK-111 (tickets, first/riskiest) → TK-112/113/114 (projects/roles/stages). Each
 story branches from the epic tip and PRs into `epic/extensible-schema`; the epic
 PRs into `main` only once all stories land.
+
+### 9.5 Consolidation status summary
+
+| Entity | Consolidated into `attrs` (dropped) | Story |
+|--------|--------------------------------------|-------|
+| tickets | git_repository, git_branch, estimate_complete, health_score, author, pr_url (+ dead `open`) | TK-111 |
+| projects | agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key | TK-112 |
+| roles | description, acceptance_criteria, dor_map, dod_map, ac_map | TK-113 |
+| workflow_stages | description, acceptance_criteria, definition_of_ready, definition_of_done | TK-114 |
+
+Remaining deferred: the `dor_map`/`dod_map`/`ac_map` fold for **tickets** and
+**projects** (TK-115). `projects.git_repository`/`notes` reclassified Keep.

--- a/internal/store/consolidate_stages_test.go
+++ b/internal/store/consolidate_stages_test.go
@@ -1,0 +1,136 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// TestConsolidateStagesMigrationNoDataLoss simulates the pre-consolidation
+// workflow_stages shape (guidance text columns present and populated) and verifies
+// the upgrade folds the values into attrs with no loss, drops the columns, and the
+// values remain readable via the typed WorkflowStage fields.
+func TestConsolidateStagesMigrationNoDataLoss(t *testing.T) {
+	// Not parallel: manipulates schema_version and raw columns.
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+	wf, err := CreateWorkflow(ctx, db, "wf-mig", "")
+	if err != nil {
+		t.Fatalf("CreateWorkflow() error = %v", err)
+	}
+	stage, err := AddWorkflowStageWithDefinitions(ctx, db, wf.ID, "design", "", "", "", 0)
+	if err != nil {
+		t.Fatalf("AddWorkflowStageWithDefinitions() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	for _, stmt := range []string{
+		`ALTER TABLE workflow_stages ADD COLUMN description TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE workflow_stages ADD COLUMN acceptance_criteria TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE workflow_stages ADD COLUMN definition_of_ready TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE workflow_stages ADD COLUMN definition_of_done TEXT NOT NULL DEFAULT ''`,
+	} {
+		if _, execErr := raw.Exec(stmt); execErr != nil {
+			_ = raw.Close()
+			t.Fatalf("setup %q error = %v", stmt, execErr)
+		}
+	}
+	if _, execErr := raw.Exec(
+		`UPDATE workflow_stages SET description=?, acceptance_criteria=?, definition_of_ready=?, definition_of_done=?, attrs='{}' WHERE workflow_stage_id=?`,
+		"design phase", "approved design", "brief ready", "design signed off", stage.ID,
+	); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("populate error = %v", execErr)
+	}
+	if _, execErr := raw.Exec(`UPDATE schema_meta SET value='11' WHERE key='schema_version'`); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("set version error = %v", execErr)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw.Close() error = %v", err)
+	}
+
+	if _, err := UpgradeInPlace(ctx, path); err != nil {
+		t.Fatalf("UpgradeInPlace() error = %v", err)
+	}
+
+	db2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() after upgrade error = %v", err)
+	}
+	defer db2.Close()
+
+	got, err := GetWorkflowStage(ctx, db2, stage.ID)
+	if err != nil {
+		t.Fatalf("GetWorkflowStage() error = %v", err)
+	}
+	if got.Description != "design phase" || got.AcceptanceCriteria != "approved design" ||
+		got.DefinitionOfReady != "brief ready" || got.DefinitionOfDone != "design signed off" {
+		t.Fatalf("stage guidance not preserved: %+v", got)
+	}
+	for _, col := range []string{"description", "acceptance_criteria", "definition_of_ready", "definition_of_done"} {
+		if columnExists(ctx, db2, "workflow_stages", col) {
+			t.Errorf("workflow_stages.%s still exists after consolidation", col)
+		}
+	}
+}
+
+// TestConsolidatedStageRoundTripAndExport verifies stage guidance round-trips via
+// typed fields after consolidation, that SetWorkflowStageAttrs preserves guidance,
+// and that workflow export/import still carries the stage description.
+func TestConsolidatedStageRoundTripAndExport(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	wf, err := CreateWorkflow(ctx, db, "wf-rt", "")
+	if err != nil {
+		t.Fatalf("CreateWorkflow() error = %v", err)
+	}
+	stage, err := AddWorkflowStageWithDefinitions(ctx, db, wf.ID, "build", "build it", "branch", "merged", 0)
+	if err != nil {
+		t.Fatalf("AddWorkflowStageWithDefinitions() error = %v", err)
+	}
+	if stage.Description != "build it" || stage.DefinitionOfDone != "merged" {
+		t.Fatalf("stage guidance not round-tripped on create: %+v", stage)
+	}
+
+	// Setting extra attrs must preserve the guidance text.
+	updated, err := SetWorkflowStageAttrs(ctx, db, stage.ID, Attrs{"board_color": "green"})
+	if err != nil {
+		t.Fatalf("SetWorkflowStageAttrs() error = %v", err)
+	}
+	if updated.Description != "build it" {
+		t.Fatalf("SetWorkflowStageAttrs wiped guidance: %+v", updated)
+	}
+	if updated.Attrs.GetString("board_color") != "green" {
+		t.Fatalf("extra attr lost: %#v", updated.Attrs)
+	}
+	if _, dup := updated.Attrs["description"]; dup {
+		t.Fatalf("attrs duplicates guidance field: %#v", updated.Attrs)
+	}
+
+	// Workflow export/import must still carry the stage description.
+	export, err := ExportWorkflow(ctx, db, wf.ID)
+	if err != nil {
+		t.Fatalf("ExportWorkflow() error = %v", err)
+	}
+	export.Name = "wf-rt-copy"
+	imported, err := ImportWorkflow(ctx, db, export)
+	if err != nil {
+		t.Fatalf("ImportWorkflow() error = %v", err)
+	}
+	stages, err := ListWorkflowStages(ctx, db, imported.ID)
+	if err != nil {
+		t.Fatalf("ListWorkflowStages() error = %v", err)
+	}
+	if len(stages) == 0 || stages[0].Description != "build it" {
+		t.Fatalf("export/import did not preserve stage description: %+v", stages)
+	}
+}

--- a/internal/store/sdlc.go
+++ b/internal/store/sdlc.go
@@ -246,10 +246,16 @@ func AddWorkflowStageWithDefinitions(ctx context.Context, db *sql.DB, workflowID
 	if stageName == "" {
 		return WorkflowStage{}, errors.New("stage name is required")
 	}
+	// guidance text lives in the attrs bag (TK-114); preserve the prior mapping
+	// (description=wow, acceptance_criteria=definition_of_ready=dor, ...).
+	attrsJSON, err := stageAttrsForWrite(nil, wow, dor, dor, dod)
+	if err != nil {
+		return WorkflowStage{}, err
+	}
 	result, err := db.ExecContext(ctx, `
-		INSERT INTO workflow_stages (workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, attrs, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, '{}', CURRENT_TIMESTAMP)
-	`, workflowID, stageName, strings.TrimSpace(wow), strings.TrimSpace(dor), strings.TrimSpace(dor), strings.TrimSpace(dod), sortOrder)
+		INSERT INTO workflow_stages (workflow_id, stage_name, sort_order, attrs, updated_at)
+		VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+	`, workflowID, stageName, sortOrder, attrsJSON)
 	if err != nil {
 		return WorkflowStage{}, err
 	}
@@ -275,7 +281,13 @@ func SetWorkflowStageBacklog(ctx context.Context, db *sql.DB, stageID int64, isB
 // stage updates do not touch attrs, so the bag is preserved across them; this is
 // the explicit way to write it.
 func SetWorkflowStageAttrs(ctx context.Context, db *sql.DB, stageID int64, attrs Attrs) (WorkflowStage, error) {
-	attrsJSON, err := marshalAttrs(attrs)
+	// The guidance-text fields also live in the bag (TK-114), so replace only the
+	// extra keys and fold the stage's existing guidance text back in.
+	current, err := getWorkflowStageRow(ctx, db, stageID)
+	if err != nil {
+		return WorkflowStage{}, err
+	}
+	attrsJSON, err := stageAttrsForWrite(attrs, current.Description, current.AcceptanceCriteria, current.DefinitionOfReady, current.DefinitionOfDone)
 	if err != nil {
 		return WorkflowStage{}, err
 	}
@@ -305,29 +317,24 @@ func UpdateWorkflowStageWithDefinitions(ctx context.Context, db *sql.DB, stageID
 	if name == "" {
 		return WorkflowStage{}, errors.New("stage name is required")
 	}
-	if isBacklogStage != nil {
-		result, err := db.ExecContext(ctx, `
-			UPDATE workflow_stages
-			SET stage_name = ?, description = ?, acceptance_criteria = ?, definition_of_ready = ?, definition_of_done = ?, is_backlog_stage = ?, updated_at = CURRENT_TIMESTAMP
-			WHERE workflow_stage_id = ?
-		`, name, strings.TrimSpace(wow), strings.TrimSpace(dor), strings.TrimSpace(dor), strings.TrimSpace(dod), *isBacklogStage, stageID)
-		if err != nil {
-			return WorkflowStage{}, err
-		}
-		affected, err := result.RowsAffected()
-		if err != nil {
-			return WorkflowStage{}, err
-		}
-		if affected == 0 {
-			return WorkflowStage{}, sql.ErrNoRows
-		}
-		return getWorkflowStageRow(ctx, db, stageID)
+	// Guidance text lives in the attrs bag (TK-114); fold it in over the stage's
+	// existing extra bag, preserving the prior column mapping
+	// (description=wow, acceptance_criteria=definition_of_ready=dor, ...).
+	current, err := getWorkflowStageRow(ctx, db, stageID)
+	if err != nil {
+		return WorkflowStage{}, err
 	}
-	result, err := db.ExecContext(ctx, `
-		UPDATE workflow_stages
-		SET stage_name = ?, description = ?, acceptance_criteria = ?, definition_of_ready = ?, definition_of_done = ?, updated_at = CURRENT_TIMESTAMP
-		WHERE workflow_stage_id = ?
-	`, name, strings.TrimSpace(wow), strings.TrimSpace(dor), strings.TrimSpace(dor), strings.TrimSpace(dod), stageID)
+	attrsJSON, err := stageAttrsForWrite(current.Attrs, wow, dor, dor, dod)
+	if err != nil {
+		return WorkflowStage{}, err
+	}
+	query := `UPDATE workflow_stages SET stage_name = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP WHERE workflow_stage_id = ?`
+	args := []any{name, attrsJSON, stageID}
+	if isBacklogStage != nil {
+		query = `UPDATE workflow_stages SET stage_name = ?, attrs = ?, is_backlog_stage = ?, updated_at = CURRENT_TIMESTAMP WHERE workflow_stage_id = ?`
+		args = []any{name, attrsJSON, *isBacklogStage, stageID}
+	}
+	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
 		return WorkflowStage{}, err
 	}
@@ -599,10 +606,14 @@ func ImportWorkflow(ctx context.Context, db *sql.DB, export WorkflowExport) (Wor
 		if stageName == "" {
 			return Workflow{}, errors.New("workflow stage name is required")
 		}
+		stageAttrsJSON, attrsErr := stageAttrsForWrite(nil, s.Description, "", "", "")
+		if attrsErr != nil {
+			return Workflow{}, attrsErr
+		}
 		stageResult, err := tx.ExecContext(ctx, `
-			INSERT INTO workflow_stages (workflow_id, stage_name, description, sort_order, updated_at)
+			INSERT INTO workflow_stages (workflow_id, stage_name, sort_order, attrs, updated_at)
 			VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
-		`, workflowID, stageName, strings.TrimSpace(s.Description), s.SortOrder)
+		`, workflowID, stageName, s.SortOrder, stageAttrsJSON)
 		if err != nil {
 			return Workflow{}, err
 		}
@@ -895,16 +906,44 @@ func getWorkflowRow(ctx context.Context, db *sql.DB, id int64) (Workflow, error)
 	return w, nil
 }
 
+// hydrateStageAttrs copies the bag-backed guidance-text fields into typed
+// WorkflowStage fields and strips them from the visible bag (TK-114).
+func hydrateStageAttrs(s *WorkflowStage) {
+	s.Description = s.Attrs.GetString("description")
+	s.AcceptanceCriteria = s.Attrs.GetString("acceptance_criteria")
+	s.DefinitionOfReady = s.Attrs.GetString("definition_of_ready")
+	s.DefinitionOfDone = s.Attrs.GetString("definition_of_done")
+	for _, k := range []string{"description", "acceptance_criteria", "definition_of_ready", "definition_of_done"} {
+		delete(s.Attrs, k)
+	}
+	if len(s.Attrs) == 0 {
+		s.Attrs = nil
+	}
+}
+
+// stageAttrsForWrite folds the bag-backed guidance-text fields into a base bag.
+func stageAttrsForWrite(base Attrs, description, acceptanceCriteria, definitionOfReady, definitionOfDone string) (string, error) {
+	merged := Attrs{}
+	for k, v := range base {
+		merged[k] = v
+	}
+	merged.SetString("description", strings.TrimSpace(description))
+	merged.SetString("acceptance_criteria", strings.TrimSpace(acceptanceCriteria))
+	merged.SetString("definition_of_ready", strings.TrimSpace(definitionOfReady))
+	merged.SetString("definition_of_done", strings.TrimSpace(definitionOfDone))
+	return marshalAttrs(merged)
+}
+
 func getWorkflowStageRow(ctx context.Context, db *sql.DB, id int64) (WorkflowStage, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT workflow_stage_id, workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at, attrs
+		SELECT workflow_stage_id, workflow_id, stage_name, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at, attrs
 		FROM workflow_stages
 		WHERE workflow_stage_id = ?
 	`, id)
 	var s WorkflowStage
 	var attrsJSON sql.NullString
-	if err := row.Scan(&s.ID, &s.WorkflowID, &s.StageName, &s.Description,
-		&s.AcceptanceCriteria, &s.DefinitionOfReady, &s.DefinitionOfDone, &s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt, &attrsJSON); err != nil {
+	if err := row.Scan(&s.ID, &s.WorkflowID, &s.StageName,
+		&s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt, &attrsJSON); err != nil {
 		return WorkflowStage{}, err
 	}
 	attrs, err := parseAttrs(attrsJSON.String)
@@ -912,6 +951,7 @@ func getWorkflowStageRow(ctx context.Context, db *sql.DB, id int64) (WorkflowSta
 		return WorkflowStage{}, err
 	}
 	s.Attrs = attrs
+	hydrateStageAttrs(&s)
 	roles, err := ListWorkflowStageRoles(ctx, db, s.WorkflowID, s.ID)
 	if err != nil {
 		return WorkflowStage{}, err
@@ -928,7 +968,7 @@ func getWorkflowStageRow(ctx context.Context, db *sql.DB, id int64) (WorkflowSta
 
 func listWorkflowStages(ctx context.Context, db *sql.DB, workflowID int64) ([]WorkflowStage, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT workflow_stage_id, workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at, attrs
+		SELECT workflow_stage_id, workflow_id, stage_name, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at, attrs
 		FROM workflow_stages
 		WHERE workflow_id = ?
 		ORDER BY sort_order, workflow_stage_id
@@ -941,8 +981,8 @@ func listWorkflowStages(ctx context.Context, db *sql.DB, workflowID int64) ([]Wo
 	for rows.Next() {
 		var s WorkflowStage
 		var attrsJSON sql.NullString
-		if scanErr := rows.Scan(&s.ID, &s.WorkflowID, &s.StageName, &s.Description,
-			&s.AcceptanceCriteria, &s.DefinitionOfReady, &s.DefinitionOfDone, &s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt, &attrsJSON); scanErr != nil {
+		if scanErr := rows.Scan(&s.ID, &s.WorkflowID, &s.StageName,
+			&s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt, &attrsJSON); scanErr != nil {
 			return nil, scanErr
 		}
 		attrs, parseErr := parseAttrs(attrsJSON.String)
@@ -950,6 +990,7 @@ func listWorkflowStages(ctx context.Context, db *sql.DB, workflowID int64) ([]Wo
 			return nil, parseErr
 		}
 		s.Attrs = attrs
+		hydrateStageAttrs(&s)
 		stages = append(stages, s)
 	}
 	if rowsErr := rows.Err(); rowsErr != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -590,8 +590,6 @@ CREATE TABLE IF NOT EXISTS workflow_stages (
 	workflow_stage_id INTEGER PRIMARY KEY AUTOINCREMENT,
 	workflow_id INTEGER NOT NULL,
 	stage_name TEXT NOT NULL,
-	description TEXT NOT NULL DEFAULT '',
-	acceptance_criteria TEXT NOT NULL DEFAULT '',
 	sort_order INTEGER NOT NULL DEFAULT 0,
 	is_backlog_stage INTEGER NOT NULL DEFAULT 0,
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -1216,17 +1214,10 @@ CREATE TABLE user_notifications (
 	if err := backfillTicketWorkflowStages(ctx, db); err != nil {
 		return err
 	}
-	// Add DoR/DoD to workflow stages
-	if !columnExists(ctx, db, "workflow_stages", "definition_of_ready") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE workflow_stages ADD COLUMN definition_of_ready TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "workflow_stages", "definition_of_done") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE workflow_stages ADD COLUMN definition_of_done TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
+	// workflow_stages description/acceptance_criteria/definition_of_ready/
+	// definition_of_done are folded into the stage attrs bag (TK-114); their legacy
+	// ADD COLUMN migrations were removed and the columns are migrated and dropped by
+	// the attrs-consolidation step below.
 	// Add new columns to users for merged agent support
 	if !columnExists(ctx, db, "users", "user_type") {
 		if _, err := db.ExecContext(ctx, `ALTER TABLE users ADD COLUMN user_type TEXT NOT NULL DEFAULT 'user'`); err != nil {
@@ -1773,6 +1764,22 @@ CREATE TABLE user_notifications (
 				return err
 			}
 			if _, err := db.ExecContext(ctx, `ALTER TABLE roles DROP COLUMN `+col); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Fold workflow_stages guidance text columns into the attrs bag and drop them
+	// (TK-114). All four are scalar text. Non-clobbering and idempotent.
+	for _, col := range []string{"description", "acceptance_criteria", "definition_of_ready", "definition_of_done"} {
+		if columnExists(ctx, db, "workflow_stages", col) {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE workflow_stages SET attrs = json_set(attrs, '$.%s', %s) `+
+					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) <> ''`,
+				col, col, col, col)); err != nil {
+				return err
+			}
+			if _, err := db.ExecContext(ctx, `ALTER TABLE workflow_stages DROP COLUMN `+col); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
S6d of epic TK-105 (refs TK-114) — final per-entity consolidation.

## What
Folds **description, acceptance_criteria, definition_of_ready, definition_of_done** into the workflow_stages `attrs` bag and drops the columns — `workflow_stages` is now identity + `sort_order`/`is_backlog_stage`/`attrs`.

- `store.go`: removed the 2 guidance columns from base `CREATE TABLE` + the `definition_of_ready/done` ADD migrations; added an idempotent stages fold step.
- `sdlc.go`: removed the columns from both stage select lists + both scans; added `hydrateStageAttrs` / `stageAttrsForWrite`; rewired `AddWorkflowStageWithDefinitions`, both `UpdateWorkflowStageWithDefinitions` variants, the `ImportWorkflow` stage INSERT, and `SetWorkflowStageAttrs` (now preserves guidance text while replacing the extra bag).

Typed `WorkflowStage` fields hydrate from the bag → prompt/guidance and workflow export/import unaffected.

## Tests
No-data-loss migration from a simulated pre-fold shape; typed round-trip; `SetWorkflowStageAttrs` preserves guidance; **workflow export/import round-trip** carrying the stage description. `store/server/client/contract/cmd` green except the pre-existing inbox failure. Lint clean.

Completes the per-entity consolidation (S6a–d). The `dor/dod/ac` fold for tickets+projects remains as TK-115.

🤖 Generated with [Claude Code](https://claude.com/claude-code)