### PR TITLE
TK-115: Fold dor/dod/ac guidance maps into attrs (tickets + projects)

### DIFF
--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -341,5 +341,6 @@ PRs into `main` only once all stories land.
 | roles | description, acceptance_criteria, dor_map, dod_map, ac_map | TK-113 |
 | workflow_stages | description, acceptance_criteria, definition_of_ready, definition_of_done | TK-114 |
 
-Remaining deferred: the `dor_map`/`dod_map`/`ac_map` fold for **tickets** and
-**projects** (TK-115). `projects.git_repository`/`notes` reclassified Keep.
+All `dor_map`/`dod_map`/`ac_map` folds are complete across tickets, projects,
+roles and workflow_stages (tickets+projects via TK-115; roles+stages via
+TK-113/TK-114). `projects.git_repository`/`notes` reclassified Keep.

--- a/internal/store/fold_guidance_maps_test.go
+++ b/internal/store/fold_guidance_maps_test.go
@@ -1,0 +1,164 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// TestFoldTicketGuidanceMapsMigration simulates a pre-fold tickets table with
+// dor_map/dod_map/ac_map columns populated, and verifies the upgrade embeds them
+// into attrs as nested objects with no loss, drops the columns, and the maps remain
+// readable via the typed Ticket fields.
+func TestFoldTicketGuidanceMapsMigration(t *testing.T) {
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+	tk, err := CreateTicket(ctx, db, TicketCreateParams{ProjectID: 1, Type: "task", Title: "g"})
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	for _, stmt := range []string{
+		`ALTER TABLE tickets ADD COLUMN dor_map TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE tickets ADD COLUMN dod_map TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE tickets ADD COLUMN ac_map TEXT NOT NULL DEFAULT '{}'`,
+	} {
+		if _, e := raw.Exec(stmt); e != nil {
+			_ = raw.Close()
+			t.Fatalf("setup %q error = %v", stmt, e)
+		}
+	}
+	if _, e := raw.Exec(`UPDATE tickets SET dor_map=?, dod_map=?, ac_map=?, attrs='{}' WHERE ticket_id=?`,
+		`{"default":"ready"}`, `{"develop":"done"}`, `{"default":"ac"}`, tk.ID); e != nil {
+		_ = raw.Close()
+		t.Fatalf("populate error = %v", e)
+	}
+	if _, e := raw.Exec(`UPDATE schema_meta SET value='11' WHERE key='schema_version'`); e != nil {
+		_ = raw.Close()
+		t.Fatalf("set version error = %v", e)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw.Close() error = %v", err)
+	}
+
+	if _, err := UpgradeInPlace(ctx, path); err != nil {
+		t.Fatalf("UpgradeInPlace() error = %v", err)
+	}
+	db2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() after upgrade error = %v", err)
+	}
+	defer db2.Close()
+	got, err := GetTicket(ctx, db2, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if got.DORMap["default"] != "ready" || got.DODMap["develop"] != "done" || got.ACMap["default"] != "ac" {
+		t.Fatalf("guidance maps not preserved: dor=%#v dod=%#v ac=%#v", got.DORMap, got.DODMap, got.ACMap)
+	}
+	for _, col := range []string{"dor_map", "dod_map", "ac_map"} {
+		if columnExists(ctx, db2, "tickets", col) {
+			t.Errorf("tickets.%s still exists after fold", col)
+		}
+	}
+}
+
+// TestFoldProjectGuidanceMapsMigration is the projects counterpart.
+func TestFoldProjectGuidanceMapsMigration(t *testing.T) {
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+	p, err := CreateProjectWithParams(ctx, db, ProjectCreateParams{Title: "P", Prefix: "PFG"})
+	if err != nil {
+		t.Fatalf("CreateProjectWithParams() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	for _, stmt := range []string{
+		`ALTER TABLE projects ADD COLUMN dor_map TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE projects ADD COLUMN dod_map TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE projects ADD COLUMN ac_map TEXT NOT NULL DEFAULT '{}'`,
+	} {
+		if _, e := raw.Exec(stmt); e != nil {
+			_ = raw.Close()
+			t.Fatalf("setup %q error = %v", stmt, e)
+		}
+	}
+	if _, e := raw.Exec(`UPDATE projects SET dor_map=?, dod_map=?, ac_map=?, attrs='{}' WHERE project_id=?`,
+		`{"default":"pready"}`, `{"default":"pdone"}`, `{"default":"pac"}`, p.ID); e != nil {
+		_ = raw.Close()
+		t.Fatalf("populate error = %v", e)
+	}
+	if _, e := raw.Exec(`UPDATE schema_meta SET value='11' WHERE key='schema_version'`); e != nil {
+		_ = raw.Close()
+		t.Fatalf("set version error = %v", e)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw.Close() error = %v", err)
+	}
+
+	if _, err := UpgradeInPlace(ctx, path); err != nil {
+		t.Fatalf("UpgradeInPlace() error = %v", err)
+	}
+	db2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() after upgrade error = %v", err)
+	}
+	defer db2.Close()
+	got, err := GetProjectByID(ctx, db2, p.ID)
+	if err != nil {
+		t.Fatalf("GetProjectByID() error = %v", err)
+	}
+	if got.DORMap["default"] != "pready" || got.DODMap["default"] != "pdone" || got.ACMap["default"] != "pac" {
+		t.Fatalf("project guidance maps not preserved: dor=%#v dod=%#v ac=%#v", got.DORMap, got.DODMap, got.ACMap)
+	}
+	for _, col := range []string{"dor_map", "dod_map", "ac_map"} {
+		if columnExists(ctx, db2, "projects", col) {
+			t.Errorf("projects.%s still exists after fold", col)
+		}
+	}
+}
+
+// TestFoldGuidanceMapsRoundTrip checks create/read of guidance maps via typed
+// fields after the fold, with no attrs duplication.
+func TestFoldGuidanceMapsRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	tk, err := CreateTicket(ctx, db, TicketCreateParams{
+		ProjectID: 1, Type: "task", Title: "rt",
+		DORMap: GuidanceMap{"default": "x"}, ACMap: GuidanceMap{"default": "y"},
+		Attrs: Attrs{"k": "v"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+	got, err := GetTicket(ctx, db, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if got.DORMap["default"] != "x" || got.ACMap["default"] != "y" {
+		t.Fatalf("guidance maps not round-tripped: %#v / %#v", got.DORMap, got.ACMap)
+	}
+	if got.Attrs.GetString("k") != "v" {
+		t.Fatalf("extra attr lost: %#v", got.Attrs)
+	}
+	for _, k := range []string{"dor_map", "dod_map", "ac_map"} {
+		if _, dup := got.Attrs[k]; dup {
+			t.Fatalf("attrs duplicates guidance map %q: %#v", k, got.Attrs)
+		}
+	}
+}

--- a/internal/store/guidance.go
+++ b/internal/store/guidance.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"encoding/json"
 	"strings"
 )
 
@@ -57,30 +56,6 @@ func withLegacyAcceptanceCriteria(acceptanceCriteria string, acMap GuidanceMap) 
 		normalized[DefaultGuidanceStageKey] = legacy
 	}
 	return normalized
-}
-
-func guidanceMapJSON(m GuidanceMap) (string, error) {
-	normalized := normalizeGuidanceMap(m)
-	if len(normalized) == 0 {
-		return "{}", nil
-	}
-	data, err := json.Marshal(normalized)
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
-}
-
-func parseGuidanceMap(raw string) (GuidanceMap, error) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return nil, nil
-	}
-	var parsed map[string]string
-	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		return nil, err
-	}
-	return normalizeGuidanceMap(GuidanceMap(parsed)), nil
 }
 
 func (m GuidanceMap) Resolve(stage string) (string, bool) {

--- a/internal/store/project.go
+++ b/internal/store/project.go
@@ -138,41 +138,29 @@ func CreateProjectWithParams(ctx context.Context, db *sql.DB, params ProjectCrea
 	if err != nil {
 		return Project{}, err
 	}
-	dorJSON, err := guidanceMapJSON(params.DORMap)
-	if err != nil {
-		return Project{}, err
-	}
-	dodJSON, err := guidanceMapJSON(params.DODMap)
-	if err != nil {
-		return Project{}, err
-	}
 	acMap := withLegacyAcceptanceCriteria(params.AcceptanceCriteria, params.ACMap)
-	acJSON, err := guidanceMapJSON(acMap)
-	if err != nil {
-		return Project{}, err
-	}
 	acceptanceCriteria := strings.TrimSpace(params.AcceptanceCriteria)
 	if acceptanceCriteria == "" && acMap != nil {
 		acceptanceCriteria = acMap[DefaultGuidanceStageKey]
 	}
-	// agent_model_* now live in the attrs bag (TK-112).
-	attrsJSON, err := projectAttrsForWrite(params.Attrs, params.AgentModelProvider, params.AgentModelName, params.AgentModelURL, params.AgentModelAPIKey)
+	// agent_model_* (TK-112) and dor/dod/ac guidance maps (TK-115) live in attrs.
+	attrsJSON, err := projectAttrsForWrite(params.Attrs, params.AgentModelProvider, params.AgentModelName, params.AgentModelURL, params.AgentModelAPIKey, params.DORMap, params.DODMap, acMap)
 	if err != nil {
 		return Project{}, err
 	}
 	query := `
-		INSERT INTO projects (prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, attrs)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?)
+		INSERT INTO projects (prefix, title, description, acceptance_criteria, git_repository, notes, status, visibility, created_by, workflow_id, attrs)
+		VALUES (?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?)
 	`
 	args := []any{
-		uniquePrefix, title, strings.TrimSpace(params.Description), acceptanceCriteria, dorJSON, dodJSON, acJSON,
+		uniquePrefix, title, strings.TrimSpace(params.Description), acceptanceCriteria,
 		strings.TrimSpace(params.GitRepository), strings.TrimSpace(params.Notes), visibility, nullableUserID(params.CreatedBy), workflowID,
 		attrsJSON,
 	}
 	if hasExplicitID {
 		query = `
-			INSERT INTO projects (project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, attrs)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?)
+			INSERT INTO projects (project_id, prefix, title, description, acceptance_criteria, git_repository, notes, status, visibility, created_by, workflow_id, attrs)
+			VALUES (?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?)
 		`
 		args = append([]any{explicitID}, args...)
 	}
@@ -214,7 +202,14 @@ func hydrateProjectAttrs(p *Project) {
 	p.AgentModelName = p.Attrs.GetString("agent_model_name")
 	p.AgentModelURL = p.Attrs.GetString("agent_model_url")
 	p.AgentModelAPIKey = p.Attrs.GetString("agent_model_api_key")
+	// Guidance maps folded into the bag (TK-115).
+	p.DORMap = guidanceMapFromAttr(p.Attrs["dor_map"])
+	p.DODMap = guidanceMapFromAttr(p.Attrs["dod_map"])
+	p.ACMap = withLegacyAcceptanceCriteria(p.AcceptanceCriteria, guidanceMapFromAttr(p.Attrs["ac_map"]))
 	for _, k := range projectAttrAgentModelKeys {
+		delete(p.Attrs, k)
+	}
+	for _, k := range []string{"dor_map", "dod_map", "ac_map"} {
 		delete(p.Attrs, k)
 	}
 	if len(p.Attrs) == 0 {
@@ -222,8 +217,9 @@ func hydrateProjectAttrs(p *Project) {
 	}
 }
 
-// projectAttrsForWrite merges the bag-backed agent-model fields into a base bag.
-func projectAttrsForWrite(base Attrs, provider, name, url, apiKey string) (string, error) {
+// projectAttrsForWrite merges the bag-backed agent-model fields and guidance maps
+// into a base bag (TK-112, TK-115).
+func projectAttrsForWrite(base Attrs, provider, name, url, apiKey string, dor, dod, ac GuidanceMap) (string, error) {
 	merged := Attrs{}
 	for k, v := range base {
 		merged[k] = v
@@ -232,6 +228,9 @@ func projectAttrsForWrite(base Attrs, provider, name, url, apiKey string) (strin
 	merged.SetString("agent_model_name", strings.TrimSpace(name))
 	merged.SetString("agent_model_url", strings.TrimSpace(url))
 	merged.SetString("agent_model_api_key", strings.TrimSpace(apiKey))
+	setGuidanceAttr(merged, "dor_map", dor)
+	setGuidanceAttr(merged, "dod_map", dod)
+	setGuidanceAttr(merged, "ac_map", ac)
 	return marshalAttrs(merged)
 }
 
@@ -239,11 +238,10 @@ func scanProject(s scanner) (Project, error) {
 	var project Project
 	var workflowID sql.NullInt64
 	var programmeID sql.NullInt64
-	var dorJSON, dodJSON, acJSON string
 	var attrsJSON sql.NullString
 	if err := s.Scan(
 		&project.ID, &project.Prefix, &project.Title, &project.Description, &project.AcceptanceCriteria,
-		&dorJSON, &dodJSON, &acJSON, &project.GitRepository, &project.Notes, &project.Status, &project.Visibility,
+		&project.GitRepository, &project.Notes, &project.Status, &project.Visibility,
 		&project.DefaultDraft, &project.CreatedBy, &project.CreatedAt, &project.UpdatedAt, &workflowID,
 		&programmeID, &attrsJSON,
 	); err != nil {
@@ -255,19 +253,6 @@ func scanProject(s scanner) (Project, error) {
 		return Project{}, err
 	}
 	hydrateProjectAttrs(&project)
-	project.DORMap, err = parseGuidanceMap(dorJSON)
-	if err != nil {
-		return Project{}, err
-	}
-	project.DODMap, err = parseGuidanceMap(dodJSON)
-	if err != nil {
-		return Project{}, err
-	}
-	project.ACMap, err = parseGuidanceMap(acJSON)
-	if err != nil {
-		return Project{}, err
-	}
-	project.ACMap = withLegacyAcceptanceCriteria(project.AcceptanceCriteria, project.ACMap)
 	if workflowID.Valid {
 		project.WorkflowID = &workflowID.Int64
 	}
@@ -285,7 +270,7 @@ func ListProjects(ctx context.Context, db *sql.DB, limit int) ([]Project, error)
 		limit = 1000
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		ORDER BY created_at, project_id
 		LIMIT ?
@@ -334,7 +319,7 @@ func ListProjectsVisibleToUser(ctx context.Context, db *sql.DB, user User) ([]Pr
 			FROM teams parent
 			JOIN team_scope ts ON ts.parent_team_id = parent.team_id
 		)
-		SELECT DISTINCT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs
+		SELECT DISTINCT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs
 		FROM projects p
 		LEFT JOIN project_members pm ON pm.project_id = p.project_id AND pm.user_id = ?
 		LEFT JOIN project_teams pt ON pt.project_id = p.project_id
@@ -380,7 +365,7 @@ func GetProject(ctx context.Context, db *sql.DB, rawID string) (Project, error) 
 		return GetProjectByID(ctx, db, id)
 	}
 	row := db.QueryRowContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		WHERE prefix = ?
 	`, strings.ToUpper(rawID))
@@ -403,7 +388,7 @@ func GetProjectByID(ctx context.Context, db *sql.DB, id int64) (Project, error) 
 		return Project{}, err
 	}
 	row := db.QueryRowContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		WHERE project_id = ?
 	`, id)
@@ -433,7 +418,7 @@ func GetProjectByGitRepository(ctx context.Context, db *sql.DB, gitRepository st
 		return Project{}, err
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs,
+		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs,
 		       r.repository
 		FROM projects p
 		JOIN project_git_repositories r ON r.project_id = p.project_id
@@ -493,11 +478,10 @@ func scanProjectWithWorkflowIDAndRepository(s scanner) (projectWithRepository, e
 	var result projectWithRepository
 	var workflowID sql.NullInt64
 	var programmeID sql.NullInt64
-	var dorJSON, dodJSON, acJSON string
 	var attrsJSON sql.NullString
 	if err := s.Scan(
 		&result.project.ID, &result.project.Prefix, &result.project.Title, &result.project.Description, &result.project.AcceptanceCriteria,
-		&dorJSON, &dodJSON, &acJSON, &result.project.GitRepository, &result.project.Notes, &result.project.Status, &result.project.Visibility,
+		&result.project.GitRepository, &result.project.Notes, &result.project.Status, &result.project.Visibility,
 		&result.project.DefaultDraft, &result.project.CreatedBy, &result.project.CreatedAt, &result.project.UpdatedAt, &workflowID,
 		&programmeID, &attrsJSON,
 		&result.repository,
@@ -510,19 +494,6 @@ func scanProjectWithWorkflowIDAndRepository(s scanner) (projectWithRepository, e
 		return projectWithRepository{}, err
 	}
 	hydrateProjectAttrs(&result.project)
-	result.project.DORMap, err = parseGuidanceMap(dorJSON)
-	if err != nil {
-		return projectWithRepository{}, err
-	}
-	result.project.DODMap, err = parseGuidanceMap(dodJSON)
-	if err != nil {
-		return projectWithRepository{}, err
-	}
-	result.project.ACMap, err = parseGuidanceMap(acJSON)
-	if err != nil {
-		return projectWithRepository{}, err
-	}
-	result.project.ACMap = withLegacyAcceptanceCriteria(result.project.AcceptanceCriteria, result.project.ACMap)
 	if workflowID.Valid {
 		id := workflowID.Int64
 		result.project.WorkflowID = &id
@@ -616,31 +587,19 @@ func UpdateProjectWithParams(ctx context.Context, db *sql.DB, id int64, params P
 	if nextAgentModelAPIKey == "" {
 		nextAgentModelAPIKey = current.AgentModelAPIKey
 	}
-	dorJSON, err := guidanceMapJSON(nextDORMap)
-	if err != nil {
-		return Project{}, err
-	}
-	dodJSON, err := guidanceMapJSON(nextDODMap)
-	if err != nil {
-		return Project{}, err
-	}
-	acJSON, err := guidanceMapJSON(nextACMap)
-	if err != nil {
-		return Project{}, err
-	}
 	baseAttrs := current.Attrs
 	if params.Attrs != nil {
 		baseAttrs = params.Attrs
 	}
-	attrsJSON, err := projectAttrsForWrite(baseAttrs, nextAgentModelProvider, nextAgentModelName, nextAgentModelURL, nextAgentModelAPIKey)
+	attrsJSON, err := projectAttrsForWrite(baseAttrs, nextAgentModelProvider, nextAgentModelName, nextAgentModelURL, nextAgentModelAPIKey, nextDORMap, nextDODMap, nextACMap)
 	if err != nil {
 		return Project{}, err
 	}
 	_, err = db.ExecContext(ctx, `
 		UPDATE projects
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, notes = ?, status = ?, visibility = ?, workflow_id = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
+		SET title = ?, description = ?, acceptance_criteria = ?, git_repository = ?, notes = ?, status = ?, visibility = ?, workflow_id = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE project_id = ?
-	`, nextTitle, nextDescription, nextAC, dorJSON, dodJSON, acJSON, nextRepo, nextNotes, nextStatus, nextVisibility, nextWorkflowID, attrsJSON, id)
+	`, nextTitle, nextDescription, nextAC, nextRepo, nextNotes, nextStatus, nextVisibility, nextWorkflowID, attrsJSON, id)
 	if err != nil {
 		return Project{}, err
 	}
@@ -670,7 +629,7 @@ func validProjectVisibility(visibility string) bool {
 
 func getProjectByTitle(ctx context.Context, db *sql.DB, title string) (Project, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		WHERE LOWER(title) = LOWER(?)
 		ORDER BY project_id

--- a/internal/store/project_alias.go
+++ b/internal/store/project_alias.go
@@ -34,7 +34,7 @@ func GetProjectByAlias(ctx context.Context, db *sql.DB, alias, userID string) (P
 	}
 	trimmedUserID := strings.TrimSpace(userID)
 	query := `
-		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs
+		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs
 		FROM project_aliases pa
 		JOIN projects p ON p.project_id = pa.project_id
 		WHERE pa.alias_name = ? AND ((pa.user_id IS NULL AND ? = '') OR pa.user_id = ?)

--- a/internal/store/role.go
+++ b/internal/store/role.go
@@ -105,11 +105,12 @@ func CreateRoleWithParams(ctx context.Context, db *sql.DB, params RoleCreatePara
 // setGuidanceAttr stores a guidance map as a nested object in the bag, or removes
 // the key when the map is empty (keeping the stored bag sparse).
 func setGuidanceAttr(a Attrs, key string, m GuidanceMap) {
-	if len(m) == 0 {
+	n := normalizeGuidanceMap(m)
+	if len(n) == 0 {
 		delete(a, key)
 		return
 	}
-	a[key] = map[string]string(m)
+	a[key] = map[string]string(n)
 }
 
 // hydrateRoleAttrs copies the bag-backed guidance fields into typed Role fields and

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -289,9 +289,6 @@ CREATE TABLE IF NOT EXISTS projects (
 	title TEXT NOT NULL,
 	description TEXT NOT NULL DEFAULT '',
 	acceptance_criteria TEXT NOT NULL DEFAULT '',
-	dor_map TEXT NOT NULL DEFAULT '{}',
-	dod_map TEXT NOT NULL DEFAULT '{}',
-	ac_map TEXT NOT NULL DEFAULT '{}',
 	git_repository TEXT NOT NULL DEFAULT '',
 	notes TEXT NOT NULL DEFAULT '',
 	status TEXT NOT NULL DEFAULT 'open',
@@ -352,9 +349,6 @@ CREATE TABLE IF NOT EXISTS tickets (
 	title TEXT NOT NULL,
 	description TEXT NOT NULL DEFAULT '',
 	acceptance_criteria TEXT NOT NULL DEFAULT '',
-	dor_map TEXT NOT NULL DEFAULT '{}',
-	dod_map TEXT NOT NULL DEFAULT '{}',
-	ac_map TEXT NOT NULL DEFAULT '{}',
 	workflow_stage_id INTEGER,
 	role_id INTEGER,
 	stage TEXT NOT NULL DEFAULT 'develop',
@@ -921,21 +915,9 @@ func migrateSchema(ctx context.Context, db *sql.DB) error {
 			return err
 		}
 	}
-	if !columnExists(ctx, db, "projects", "dor_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN dor_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "projects", "dod_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN dod_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "projects", "ac_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN ac_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
+	// projects dor_map/dod_map/ac_map are folded into the attrs bag (TK-115); their
+	// legacy ADD COLUMN migrations were removed and the columns are migrated and
+	// dropped by the attrs-consolidation step below.
 	if columnExists(ctx, db, "projects", "git_branch") {
 		if _, err := db.ExecContext(ctx, `ALTER TABLE projects DROP COLUMN git_branch`); err != nil {
 			return err
@@ -1044,21 +1026,9 @@ CREATE TABLE user_notifications (
 	// estimate_complete and git_repository moved into the attrs bag (TK-111); their
 	// legacy ADD COLUMN migrations were removed and the columns are dropped by the
 	// attrs-consolidation step below.
-	if !columnExists(ctx, db, "tickets", "dor_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN dor_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "tickets", "dod_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN dod_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "tickets", "ac_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN ac_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
+	// tickets dor_map/dod_map/ac_map are folded into the attrs bag (TK-115); their
+	// legacy ADD COLUMN migrations were removed and the columns are migrated and
+	// dropped by the attrs-consolidation step below.
 	// git_branch and health_score moved into the attrs bag (TK-111); the legacy
 	// `open` column is dropped entirely. See the attrs-consolidation step below.
 	if !columnExists(ctx, db, "tickets", "deleted") {
@@ -1721,6 +1691,21 @@ CREATE TABLE user_notifications (
 			return err
 		}
 	}
+	// Fold tickets guidance maps into the attrs bag and drop them (TK-115); embedded
+	// as nested JSON objects via json(col). Non-clobbering and idempotent.
+	for _, col := range []string{"dor_map", "dod_map", "ac_map"} {
+		if columnExists(ctx, db, "tickets", col) {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE tickets SET attrs = json_set(attrs, '$.%s', json(%s)) `+
+					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) NOT IN ('', '{}')`,
+				col, col, col, col)); err != nil {
+				return err
+			}
+			if _, err := db.ExecContext(ctx, `ALTER TABLE tickets DROP COLUMN `+col); err != nil {
+				return err
+			}
+		}
+	}
 
 	// Consolidate projects agent-model config columns into the attrs bag and drop
 	// them (TK-112). Same idempotent, non-clobbering pattern as tickets above.
@@ -1729,6 +1714,20 @@ CREATE TABLE user_notifications (
 			if _, err := db.ExecContext(ctx, fmt.Sprintf(
 				`UPDATE projects SET attrs = json_set(attrs, '$.%s', %s) `+
 					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) <> ''`,
+				col, col, col, col)); err != nil {
+				return err
+			}
+			if _, err := db.ExecContext(ctx, `ALTER TABLE projects DROP COLUMN `+col); err != nil {
+				return err
+			}
+		}
+	}
+	// Fold projects guidance maps into the attrs bag and drop them (TK-115).
+	for _, col := range []string{"dor_map", "dod_map", "ac_map"} {
+		if columnExists(ctx, db, "projects", col) {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE projects SET attrs = json_set(attrs, '$.%s', json(%s)) `+
+					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) NOT IN ('', '{}')`,
 				col, col, col, col)); err != nil {
 				return err
 			}

--- a/internal/store/ticket.go
+++ b/internal/store/ticket.go
@@ -198,19 +198,7 @@ func CreateTicket(ctx context.Context, db *sql.DB, params TicketCreateParams) (T
 	if state == StateActive && strings.TrimSpace(params.Assignee) == "" {
 		return Ticket{}, errors.New("active ticket requires assignee")
 	}
-	dorJSON, err := guidanceMapJSON(params.DORMap)
-	if err != nil {
-		return Ticket{}, err
-	}
-	dodJSON, err := guidanceMapJSON(params.DODMap)
-	if err != nil {
-		return Ticket{}, err
-	}
 	acMap := withLegacyAcceptanceCriteria(params.AcceptanceCriteria, params.ACMap)
-	acJSON, err := guidanceMapJSON(acMap)
-	if err != nil {
-		return Ticket{}, err
-	}
 	acceptanceCriteria := strings.TrimSpace(params.AcceptanceCriteria)
 	if acceptanceCriteria == "" && acMap != nil {
 		acceptanceCriteria = acMap[DefaultGuidanceStageKey]
@@ -287,14 +275,14 @@ func CreateTicket(ctx context.Context, db *sql.DB, params TicketCreateParams) (T
 	}
 	// git_repository, git_branch, estimate_complete, author (and health_score,
 	// pr_url which default to 0/"") now live in the attrs bag (TK-111).
-	attrsJSON, err := ticketAttrsForWrite(params.Attrs, params.GitRepository, params.GitBranch, params.EstimateComplete, params.Author, "", 0)
+	attrsJSON, err := ticketAttrsForWrite(params.Attrs, params.GitRepository, params.GitBranch, params.EstimateComplete, params.Author, "", 0, params.DORMap, params.DODMap, acMap)
 	if err != nil {
 		return Ticket{}, err
 	}
 	_, err = tx.ExecContext(ctx, `
-		INSERT INTO tickets (ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, assignee, draft, created_by, attrs)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, key, params.ProjectID, nullableString(params.ParentID), nullableString(params.CloneOf), params.Type, params.Title, params.Description, acceptanceCriteria, dorJSON, dodJSON, acJSON, nullableInt64(ticketWorkflowID), nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), priority, order, params.EstimateEffort, strings.TrimSpace(params.Assignee), 1, nullableUserID(params.CreatedBy), attrsJSON)
+		INSERT INTO tickets (ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, assignee, draft, created_by, attrs)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, key, params.ProjectID, nullableString(params.ParentID), nullableString(params.CloneOf), params.Type, params.Title, params.Description, acceptanceCriteria, nullableInt64(ticketWorkflowID), nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), priority, order, params.EstimateEffort, strings.TrimSpace(params.Assignee), 1, nullableUserID(params.CreatedBy), attrsJSON)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -407,18 +395,6 @@ func UpdateTicket(ctx context.Context, db *sql.DB, id string, params TicketUpdat
 		nextACMap = withLegacyAcceptanceCriteria(params.AcceptanceCriteria, current.ACMap)
 	}
 	nextACMap = withLegacyAcceptanceCriteria(nextAcceptanceCriteria, nextACMap)
-	dorJSON, err := guidanceMapJSON(nextDORMap)
-	if err != nil {
-		return Ticket{}, err
-	}
-	dodJSON, err := guidanceMapJSON(nextDODMap)
-	if err != nil {
-		return Ticket{}, err
-	}
-	acJSON, err := guidanceMapJSON(nextACMap)
-	if err != nil {
-		return Ticket{}, err
-	}
 	if assignmentErr := validateTicketAssignmentChange(current.Assignee, assignee, params.ActorUsername, params.ActorRole); assignmentErr != nil {
 		return Ticket{}, assignmentErr
 	}
@@ -571,7 +547,8 @@ writeTicket:
 	if params.Attrs != nil {
 		baseAttrs = params.Attrs
 	}
-	attrsJSON, err := ticketAttrsForWrite(baseAttrs, nextGitRepository, nextGitBranch, strings.TrimSpace(params.EstimateComplete), current.Author, current.PrURL, current.HealthScore)
+	// Guidance maps (dor/dod/ac) are also folded into the bag (TK-115).
+	attrsJSON, err := ticketAttrsForWrite(baseAttrs, nextGitRepository, nextGitBranch, strings.TrimSpace(params.EstimateComplete), current.Author, current.PrURL, current.HealthScore, nextDORMap, nextDODMap, nextACMap)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -579,10 +556,10 @@ writeTicket:
 	// active state; otherwise preserve the existing value (TK-88).
 	result, err := db.ExecContext(ctx, `
 		UPDATE tickets
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, parent_id = ?, assignee = ?, workflow_stage_id = ?, role_id = ?, stage = ?, state = ?, status = ?, priority = ?, sort_order = ?, estimate_effort = ?, complete = ?, type = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP,
+		SET title = ?, description = ?, acceptance_criteria = ?, parent_id = ?, assignee = ?, workflow_stage_id = ?, role_id = ?, stage = ?, state = ?, status = ?, priority = ?, sort_order = ?, estimate_effort = ?, complete = ?, type = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP,
 			started_at = CASE WHEN ? = 'active' AND ? != 'active' THEN CURRENT_TIMESTAMP ELSE ? END
 		WHERE ticket_id = ?
-	`, title, params.Description, nextAcceptanceCriteria, dorJSON, dodJSON, acJSON, nullableString(params.ParentID), assignee, nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), params.Priority, params.Order, params.EstimateEffort, completeVal, nextType, attrsJSON, state, current.State, current.StartedAt, id)
+	`, title, params.Description, nextAcceptanceCriteria, nullableString(params.ParentID), assignee, nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), params.Priority, params.Order, params.EstimateEffort, completeVal, nextType, attrsJSON, state, current.State, current.StartedAt, id)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -1492,7 +1469,7 @@ type scanner interface {
 // SELECT in this package.
 var ticketColumnNames = []string{
 	"ticket_id", "project_id", "parent_id", "clone_of", "type", "title",
-	"description", "acceptance_criteria", "dor_map", "dod_map", "ac_map",
+	"description", "acceptance_criteria",
 	"workflow_id", "workflow_stage_id", "role_id",
 	"stage", "state", "status", "priority", "sort_order", "estimate_effort",
 	"assignee", "draft", "complete",
@@ -1525,10 +1502,17 @@ func hydrateTicketAttrs(t *Ticket) {
 	t.Author = t.Attrs.GetString("author")
 	t.PrURL = t.Attrs.GetString("pr_url")
 	t.HealthScore = t.Attrs.GetInt(ticketAttrHealthScoreKey)
+	// Guidance maps folded into the bag (TK-115).
+	t.DORMap = guidanceMapFromAttr(t.Attrs["dor_map"])
+	t.DODMap = guidanceMapFromAttr(t.Attrs["dod_map"])
+	t.ACMap = withLegacyAcceptanceCriteria(t.AcceptanceCriteria, guidanceMapFromAttr(t.Attrs["ac_map"]))
 	for _, k := range ticketAttrStringKeys {
 		delete(t.Attrs, k)
 	}
 	delete(t.Attrs, ticketAttrHealthScoreKey)
+	for _, k := range []string{"dor_map", "dod_map", "ac_map"} {
+		delete(t.Attrs, k)
+	}
 	if len(t.Attrs) == 0 {
 		t.Attrs = nil
 	}
@@ -1536,7 +1520,7 @@ func hydrateTicketAttrs(t *Ticket) {
 
 // ticketAttrsForWrite merges the bag-backed typed fields into a base bag and
 // returns the JSON text to store. It is the write-side of the attrs consolidation.
-func ticketAttrsForWrite(base Attrs, gitRepository, gitBranch, estimateComplete, author, prURL string, healthScore int) (string, error) {
+func ticketAttrsForWrite(base Attrs, gitRepository, gitBranch, estimateComplete, author, prURL string, healthScore int, dor, dod, ac GuidanceMap) (string, error) {
 	merged := Attrs{}
 	for k, v := range base {
 		merged[k] = v
@@ -1547,6 +1531,9 @@ func ticketAttrsForWrite(base Attrs, gitRepository, gitBranch, estimateComplete,
 	merged.SetString("author", strings.TrimSpace(author))
 	merged.SetString("pr_url", strings.TrimSpace(prURL))
 	merged.SetInt(ticketAttrHealthScoreKey, healthScore)
+	setGuidanceAttr(merged, "dor_map", dor)
+	setGuidanceAttr(merged, "dod_map", dod)
+	setGuidanceAttr(merged, "ac_map", ac)
 	return marshalAttrs(merged)
 }
 
@@ -1584,9 +1571,6 @@ func scanTicket(s scanner) (Ticket, error) {
 	var workflowID sql.NullInt64
 	var workflowStageID sql.NullInt64
 	var roleID sql.NullInt64
-	var dorJSON string
-	var dodJSON string
-	var acJSON string
 	var storedStatus string
 	var draft int
 	var complete int
@@ -1606,9 +1590,6 @@ func scanTicket(s scanner) (Ticket, error) {
 		&ticket.Title,
 		&ticket.Description,
 		&ticket.AcceptanceCriteria,
-		&dorJSON,
-		&dodJSON,
-		&acJSON,
 		&workflowID,
 		&workflowStageID,
 		&roleID,
@@ -1665,21 +1646,6 @@ func scanTicket(s scanner) (Ticket, error) {
 		v := int(releaseID.Int64)
 		ticket.ReleaseID = &v
 	}
-	dorMap, err := parseGuidanceMap(dorJSON)
-	if err != nil {
-		return Ticket{}, err
-	}
-	dodMap, err := parseGuidanceMap(dodJSON)
-	if err != nil {
-		return Ticket{}, err
-	}
-	acMap, err := parseGuidanceMap(acJSON)
-	if err != nil {
-		return Ticket{}, err
-	}
-	ticket.DORMap = dorMap
-	ticket.DODMap = dodMap
-	ticket.ACMap = withLegacyAcceptanceCriteria(ticket.AcceptanceCriteria, acMap)
 	ticket.Status = RenderLifecycleStatus(ticket.Stage, ticket.State)
 	ticket.Draft = draft == 1
 	ticket.Complete = complete == 1


### PR DESCRIPTION
Completes the S1 per-column classification (refs TK-115). The `dor_map`/`dod_map`/`ac_map` guidance maps are folded into the `attrs` bag (as nested JSON objects) and the columns dropped for **tickets** and **projects**, matching roles (TK-113) and stages (TK-114). All four entities are now fully consolidated.

## What
- `store.go`: removed dor/dod/ac from the base tickets + projects `CREATE TABLE` and their ADD migrations; added idempotent fold steps (`json_set(attrs,'$.x',json(col))`) for both.
- `ticket.go` / `project.go`: removed the columns from the centralized column list, scans, INSERT and UPDATE; extended `ticketAttrsForWrite`/`projectAttrsForWrite` and `hydrateTicketAttrs`/`hydrateProjectAttrs` to carry the maps; `withLegacyAcceptanceCriteria` preserved.
- `setGuidanceAttr` normalizes maps on write (matching the old column normalization). Removed the now-unused `guidanceMapJSON`/`parseGuidanceMap`.
- Fixed a projects INSERT placeholder off-by-one that the tests caught (dropped guidance columns had shifted the `'open'` status literal).

## Tests
Tickets + projects fold migrations (no data loss, columns dropped) and a typed round-trip with no attrs duplication. `store/server/client/contract/cmd` green except the pre-existing inbox failure. `make lint`: 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)