### PR TITLE
Epic TK-105: Extensible schema — JSON attribute bags + reinforced migration safety

### DIFF
--- a/cmd/tk/cmd_setup.go
+++ b/cmd/tk/cmd_setup.go
@@ -821,15 +821,13 @@ func autoUpgradeDatabase(dbPath string) error {
 	if version >= store.CurrentSchemaVersion {
 		return nil
 	}
-	backup := fmt.Sprintf("%s.bak-%s", dbPath, time.Now().Format("20060102-150405"))
-	if backupErr := store.BackupDatabase(dbPath, backup); backupErr != nil {
-		return fmt.Errorf("pre-upgrade backup failed: %w", backupErr)
-	}
-	from, upErr := store.UpgradeInPlace(context.Background(), dbPath)
+	// UpgradeInPlaceWithBackup takes a WAL-checkpointed, integrity-verified backup
+	// before mutating the database and rolls back automatically on failure.
+	res, upErr := store.UpgradeInPlaceWithBackup(context.Background(), dbPath)
 	if upErr != nil {
 		return fmt.Errorf("database upgrade failed: %w", upErr)
 	}
-	fmt.Printf("auto-upgraded database %s (schema version %d -> %d); backup: %s\n", dbPath, from, store.CurrentSchemaVersion, backup)
+	fmt.Printf("auto-upgraded database %s (schema version %d -> %d); backup: %s\n", dbPath, res.From, res.To, res.BackupPath)
 	return nil
 }
 

--- a/cmd/tk/cmd_version.go
+++ b/cmd/tk/cmd_version.go
@@ -57,7 +57,7 @@ func runUpgradeDatabase(args []string) error {
 	fs := flag.NewFlagSet("upgrade-database", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 	dbPath := fs.String("f", "", "SQLite database file (default: resolved/local database)")
-	noBackup := fs.Bool("no-backup", false, "skip the safety backup taken before upgrading")
+	noBackup := fs.Bool("no-backup", false, "do not retain the verified pre-upgrade backup on success (a backup is always taken and used for rollback)")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -85,22 +85,28 @@ func runUpgradeDatabase(args []string) error {
 		return fmt.Errorf("database not found at %s: %w", path, err)
 	}
 
-	if !*noBackup {
-		backup := fmt.Sprintf("%s.bak-%s", path, time.Now().Format("20060102-150405"))
-		if err := store.BackupDatabase(path, backup); err != nil {
-			return fmt.Errorf("backup failed: %w", err)
-		}
-		fmt.Printf("backup written: %s\n", backup)
-	}
-
-	from, err := store.UpgradeInPlace(context.Background(), path)
+	// The upgrade always takes a WAL-checkpointed, integrity-verified backup
+	// internally and rolls back from it if the migration fails, so a safety
+	// backup can no longer be skipped. The -no-backup flag is retained for
+	// compatibility and now only suppresses retention of that backup on success.
+	res, err := store.UpgradeInPlaceWithBackup(context.Background(), path)
 	if err != nil {
 		return err
 	}
-	if from == store.CurrentSchemaVersion {
+	if res.BackupPath != "" {
+		if *noBackup {
+			_ = os.Remove(res.BackupPath)
+			for _, suffix := range []string{"-wal", "-shm"} {
+				_ = os.Remove(res.BackupPath + suffix)
+			}
+		} else {
+			fmt.Printf("backup written: %s\n", res.BackupPath)
+		}
+	}
+	if res.From == store.CurrentSchemaVersion {
 		fmt.Printf("upgraded %s in place (schema version %d; re-applied pending column migrations)\n", path, store.CurrentSchemaVersion)
 	} else {
-		fmt.Printf("upgraded %s in place (schema version %d -> %d)\n", path, from, store.CurrentSchemaVersion)
+		fmt.Printf("upgraded %s in place (schema version %d -> %d)\n", path, res.From, res.To)
 	}
 	fmt.Println("restart the tk server to pick up the upgraded database")
 	return nil

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1146,7 +1146,7 @@ Outcomes:
 ## Schema evolution (extensible attributes)
 
 Schema change in `tk` is governed by a three-tier model (epic TK-105): typed
-first-class columns for queried/constrained data, a per-entity `attrs` JSONB
+first-class columns for queried/constrained data, a per-entity `attrs` JSON (TEXT)
 attribute bag as the default home for new optional/sparse/per-type fields (added
 in Go with no migration), and promotion of bag fields to expression indexes when
 they need to be queried. Migrations take a WAL-checkpointed, integrity-verified

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1142,3 +1142,13 @@ Outcomes:
 - **same version** — `You are on the latest version (VERSION)`
 - **newer available** — `A newer version of ticket is available, upgrade using: go install github.com/simonski/ticket@latest`
 - **local is newer** — `Your local copy is newer than the repo`
+
+## Schema evolution (extensible attributes)
+
+Schema change in `tk` is governed by a three-tier model (epic TK-105): typed
+first-class columns for queried/constrained data, a per-entity `attrs` JSONB
+attribute bag as the default home for new optional/sparse/per-type fields (added
+in Go with no migration), and promotion of bag fields to expression indexes when
+they need to be queried. Migrations take a WAL-checkpointed, integrity-verified
+backup and auto-rollback on failure. See `docs/design/extensible-schema.md` and
+`docs/adr/0001-json-attribute-bags.md`.

--- a/docs/ENTITY_MODEL.md
+++ b/docs/ENTITY_MODEL.md
@@ -1116,3 +1116,27 @@ This example is intentionally small, but it shows the principle:
 
 > `tk prompt <id>` is where the entity model becomes operational by turning
 > project + lineage + workflow + guidance into one coherent work brief.
+
+---
+
+## Extensible attributes (`attrs` JSON bag)
+
+> Added by epic TK-105. Full design: `docs/design/extensible-schema.md`;
+> decision record: `docs/adr/0001-json-attribute-bags.md`.
+
+To lower the likelihood and blast radius of schema change, the high-churn
+entities (TICKET, PROJECT, ROLE, STAGE) each carry an `attrs` **JSONB** column —
+a governed attribute bag. Fields are classified into three tiers:
+
+1. **Tier 1 — first-class columns.** Anything needing a foreign key, `NOT NULL`,
+   a hot-path `WHERE`/`ORDER BY`, or aggregation. Unchanged.
+2. **Tier 2 — the `attrs` bag.** The default home for optional, sparse,
+   display-only, and per-type fields. Adding a Tier-2 field is a pure-Go change
+   to a typed accessor struct — **no SQL migration, no schema-version bump**.
+3. **Tier 3 — promotion.** A bag field that needs to be queried is promoted via
+   an idempotent expression index (`json_extract(attrs,'$.field')`) or, rarely, a
+   generated column.
+
+This means the *default* way to add a field no longer changes the schema. See the
+design document for the per-column classification of which existing fields are
+kept as columns, folded into the bag, or moved.

--- a/docs/ENTITY_MODEL.md
+++ b/docs/ENTITY_MODEL.md
@@ -1125,7 +1125,7 @@ This example is intentionally small, but it shows the principle:
 > decision record: `docs/adr/0001-json-attribute-bags.md`.
 
 To lower the likelihood and blast radius of schema change, the high-churn
-entities (TICKET, PROJECT, ROLE, STAGE) each carry an `attrs` **JSONB** column —
+entities (TICKET, PROJECT, ROLE, STAGE) each carry an `attrs` **JSON (TEXT)** column —
 a governed attribute bag. Fields are classified into three tiers:
 
 1. **Tier 1 — first-class columns.** Anything needing a foreign key, `NOT NULL`,

--- a/docs/RUNBOOKS.md
+++ b/docs/RUNBOOKS.md
@@ -193,6 +193,39 @@ tk project ls
 > **Note:** `tk import` replaces the local database contents with the snapshot
 > in the file you pass via `-i`.
 
+### Pre-upgrade backups and automatic rollback
+
+Schema upgrades (`tk admin upgrade-database` and the automatic upgrade the server
+performs on startup) are self-protecting:
+
+1. The write-ahead log is checkpointed and the database file (plus `-wal`/`-shm`
+   sidecars) is copied to a timestamped backup next to it:
+   `ticket.db.bak-YYYYMMDD-HHMMSS.nnnnnnnnn`.
+2. That backup is verified (`PRAGMA integrity_check` + schema-version read)
+   **before** the live database is touched. If verification fails, the upgrade
+   aborts without modifying the database.
+3. If the migration fails partway, the database is automatically restored from the
+   verified backup and a clear error is returned — the original database is left
+   intact.
+4. On success, backups older than the most recent `5` (`DefaultBackupRetention`)
+   are pruned.
+
+To restore manually from a pre-upgrade backup (e.g. if both migration and the
+automatic rollback failed, which the error message will tell you):
+
+```bash
+# Stop the server first, then for database ticket.db and backup suffix <STAMP>:
+rm -f ticket.db ticket.db-wal ticket.db-shm
+cp ticket.db.bak-<STAMP> ticket.db
+# copy sidecars too if present
+[ -f ticket.db.bak-<STAMP>-wal ] && cp ticket.db.bak-<STAMP>-wal ticket.db-wal
+[ -f ticket.db.bak-<STAMP>-shm ] && cp ticket.db.bak-<STAMP>-shm ticket.db-shm
+```
+
+`tk admin upgrade-database -no-backup` does not skip this safety backup (it is
+always taken and used for rollback); it only declines to *retain* the backup
+after a successful upgrade.
+
 ### Client/server restore checklist
 
 1. Stop any running `tk server` process pointed at the same local database.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1499,7 +1499,7 @@ Tests must cover:
 ## Extensible attributes (`attrs`)
 
 High-churn entities (tickets, projects, roles, workflow_stages) carry an `attrs`
-JSONB column — a governed attribute bag for optional, sparse, display-only and
+JSON (TEXT) column — a governed attribute bag for optional, sparse, display-only and
 per-type fields. New Tier-2 fields are added without a schema migration or
 version bump; fields are promoted to expression indexes (`json_extract`) when
 they must be queried. Authoritative design: `docs/design/extensible-schema.md`.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1495,3 +1495,11 @@ Tests must cover:
 - Export/import round-trip fidelity
 - Context graph: edge CRUD, node validation, graph assembly, and text search
 - Decomposition reordering: permutation validation and persisted child order
+
+## Extensible attributes (`attrs`)
+
+High-churn entities (tickets, projects, roles, workflow_stages) carry an `attrs`
+JSONB column — a governed attribute bag for optional, sparse, display-only and
+per-type fields. New Tier-2 fields are added without a schema migration or
+version bump; fields are promoted to expression indexes (`json_extract`) when
+they must be queried. Authoritative design: `docs/design/extensible-schema.md`.

--- a/docs/adr/0001-json-attribute-bags.md
+++ b/docs/adr/0001-json-attribute-bags.md
@@ -1,0 +1,64 @@
+# ADR 0001: JSON attribute bags for extensible schema
+
+- Status: Accepted (epic TK-105 / story TK-106)
+- Date: 2026-06-22
+- Deciders: Simon Gauld
+
+## Context
+
+`tk` stores all data in a single SQLite database with a monolithic, additive
+migration system (`internal/store/store.go`, `internal/store/schema_version.go`).
+Adding a field to a core entity (tickets/projects/roles/workflow_stages) is
+costly out of proportion to its value: every addition needs a schema-version bump
+and ripples positionally through ~10 hand-written `SELECT`s plus a 41-arg
+`scanTicket`. We want to lower both the likelihood and the blast radius of schema
+change without losing queryability or migration safety.
+
+## Decision
+
+Adopt a **governed three-tier model**:
+
+1. **Tier 1 — first-class columns** for anything needing FK / NOT NULL / hot
+   WHERE-ORDER BY / aggregation. Unchanged.
+2. **Tier 2 — a per-entity `attrs` JSONB bag** as the default home for optional,
+   sparse, display-only, and per-type fields. Adding a Tier-2 field is a pure-Go
+   change to a typed accessor struct — no SQL, no version bump.
+3. **Tier 3 — promotion** of a bag field to query-grade via an idempotent
+   expression index (`json_extract`) or, rarely, a generated column.
+
+Store the bag as **JSONB (BLOB)** using SQLite 3.45+ binary JSON, available via
+`modernc.org/sqlite v1.48.0`. Centralize the ticket column list + scan to remove
+the fan-out. Harden migrations with checkpointed, integrity-verified backups and
+automatic rollback.
+
+## Alternatives considered
+
+### A. Status quo — keep adding typed columns
+Rejected. This is exactly the churn the epic exists to remove. ALTER TABLE is
+cheap, but the code fan-out and version coupling are not.
+
+### B. EAV side table (`ticket_attributes(ticket_id, key, value, type)`)
+Rejected for core fields. Pros: never ALTER, fully dynamic. Cons: every read
+becomes a join or pivot, the atomic row is lost, reporting/sorting is painful,
+and type-safety evaporates. Classic anti-pattern for first-class entity data.
+
+### C. Plain TEXT JSON column
+Partially accepted but superseded. The existing `dor_map`/`dod_map`/`ac_map`
+columns already use TEXT JSON and work. JSONB is more compact and faster to parse
+while remaining queryable by the same `json_*` functions, so new storage uses
+JSONB; TEXT JSON is retained only transitionally until S6 folds those columns in.
+
+### D. Generated columns for everything
+Rejected as the default. Generated columns are useful for promotion (Tier 3) but
+defining one per field reintroduces per-field DDL. Reserved for the rare case
+that needs a real column surface over a bag field.
+
+## Consequences
+
+- Adding an optional field becomes a no-migration, no-version-bump Go change.
+- Querying a bag field requires an explicit promotion step (expression index),
+  making "is this field queryable?" an intentional decision rather than a default.
+- The `attrs` blob is opaque in raw SQLite shells (mitigated: read via
+  `json(attrs)`); slightly higher write cost to encode JSONB.
+- Migration safety is materially improved for ALL migration paths, not just the
+  consolidation in this epic.

--- a/docs/adr/0001-json-attribute-bags.md
+++ b/docs/adr/0001-json-attribute-bags.md
@@ -20,16 +20,21 @@ Adopt a **governed three-tier model**:
 
 1. **Tier 1 — first-class columns** for anything needing FK / NOT NULL / hot
    WHERE-ORDER BY / aggregation. Unchanged.
-2. **Tier 2 — a per-entity `attrs` JSONB bag** as the default home for optional,
+2. **Tier 2 — a per-entity `attrs` JSON bag** as the default home for optional,
    sparse, display-only, and per-type fields. Adding a Tier-2 field is a pure-Go
    change to a typed accessor struct — no SQL, no version bump.
 3. **Tier 3 — promotion** of a bag field to query-grade via an idempotent
    expression index (`json_extract`) or, rarely, a generated column.
 
-Store the bag as **JSONB (BLOB)** using SQLite 3.45+ binary JSON, available via
-`modernc.org/sqlite v1.48.0`. Centralize the ticket column list + scan to remove
-the fan-out. Harden migrations with checkpointed, integrity-verified backups and
-automatic rollback.
+Store the bag as **TEXT JSON** (`TEXT NOT NULL DEFAULT '{}'`). Binary JSONB
+(SQLite 3.45+, available via `modernc.org/sqlite v1.48.0`) was the original
+choice for compactness but was rejected during implementation because binary
+JSONB does not survive the generic snapshot export/import that backs both
+backup/restore and the migration rebuild path (binary bytes are not valid UTF-8
+and round-trip as "malformed JSON"). `json_extract` and expression indexes work
+identically on TEXT, so queryability is unaffected. Centralize the ticket column
+list + scan to remove the fan-out. Harden migrations with checkpointed,
+integrity-verified backups and automatic rollback.
 
 ## Alternatives considered
 
@@ -44,9 +49,9 @@ and type-safety evaporates. Classic anti-pattern for first-class entity data.
 
 ### C. Plain TEXT JSON column
 Partially accepted but superseded. The existing `dor_map`/`dod_map`/`ac_map`
-columns already use TEXT JSON and work. JSONB is more compact and faster to parse
-while remaining queryable by the same `json_*` functions, so new storage uses
-JSONB; TEXT JSON is retained only transitionally until S6 folds those columns in.
+columns already use TEXT JSON and work. Binary JSONB would be more compact but
+does not survive snapshot export/import (see Decision), so TEXT JSON is the
+chosen storage for `attrs` as well — consistent with the existing guidance maps.
 
 ### D. Generated columns for everything
 Rejected as the default. Generated columns are useful for promotion (Tier 3) but
@@ -58,7 +63,7 @@ that needs a real column surface over a bag field.
 - Adding an optional field becomes a no-migration, no-version-bump Go change.
 - Querying a bag field requires an explicit promotion step (expression index),
   making "is this field queryable?" an intentional decision rather than a default.
-- The `attrs` blob is opaque in raw SQLite shells (mitigated: read via
-  `json(attrs)`); slightly higher write cost to encode JSONB.
+- `attrs` is human-readable TEXT JSON in raw SQLite shells and round-trips
+  cleanly through snapshot export/import.
 - Migration safety is materially improved for ALL migration paths, not just the
   consolidation in this epic.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -252,6 +252,12 @@ components:
         updated_at:
           type: string
           format: date-time
+        attrs:
+          type: object
+          additionalProperties: true
+          description: >-
+            Extensible attribute bag (epic TK-105). Optional/sparse fields stored
+            without a schema migration. Omitting attrs on update preserves it.
 
     PullRequest:
       type: object
@@ -493,6 +499,13 @@ components:
         started_at:
           type: string
           description: When the ticket last entered the active state (in-progress since).
+        attrs:
+          type: object
+          additionalProperties: true
+          description: >-
+            Extensible attribute bag (epic TK-105). Home for optional, sparse,
+            display-only and per-type fields; new fields are added without a schema
+            migration. On update, omitting attrs preserves the existing bag.
 
     ResolvedGuidance:
       type: object
@@ -697,6 +710,12 @@ components:
         updated_at:
           type: string
           format: date-time
+        attrs:
+          type: object
+          additionalProperties: true
+          description: >-
+            Extensible attribute bag (epic TK-105). Set via the stage attrs setter;
+            preserved across normal stage updates.
 
     InterventionState:
       type: object
@@ -948,6 +967,12 @@ components:
         updated_at:
           type: string
           format: date-time
+        attrs:
+          type: object
+          additionalProperties: true
+          description: >-
+            Extensible attribute bag (epic TK-105). Optional/sparse fields stored
+            without a schema migration. Omitting attrs on update preserves it.
 
     Label:
       type: object

--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -245,6 +245,13 @@ Conservative bias: anything filtered / sorted / FK'd / aggregated stays **Keep**
 
 ### 9.1 `tickets`
 
+> **Status (TK-111):** the Move columns below (`git_repository`, `git_branch`,
+> `estimate_complete`, `health_score`, `author`, `pr_url`) and the dead `open`
+> column have been consolidated into `attrs` and physically dropped. They remain
+> typed `Ticket` fields, hydrated from the bag. The `dor_map`/`dod_map`/`ac_map`
+> **Fold** is tracked as a separate cross-cutting follow-up (it spans the guidance
+> resolution used by tickets, projects and roles).
+
 | Column | Decision | Rationale |
 |--------|----------|-----------|
 | ticket_id, project_id, parent_id, clone_of | Keep | PK / FKs |

--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -274,6 +274,14 @@ Conservative bias: anything filtered / sorted / FK'd / aggregated stays **Keep**
 
 ### 9.2 `projects`
 
+> **Status (TK-112):** the four `agent_model_*` config columns have been
+> consolidated into `attrs` and dropped (typed `Project` fields retained). After
+> implementation, `git_repository` and `notes` were reclassified **Keep**:
+> `git_repository` is entangled with the `project_git_repositories` sync table and
+> the `GetProjectByGitRepository` query, and `notes` is interleaved with kept
+> columns in many statements — both better left as columns. The `dor/dod/ac` Fold
+> is part of TK-115.
+
 | Column | Decision | Rationale |
 |--------|----------|-----------|
 | project_id, prefix, title | Keep | PK / identity / displayed |

--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -331,3 +331,15 @@ introduce `attrs` (TK-109) → queryable bag (TK-110) → per-entity consolidati
 TK-111 (tickets, first/riskiest) → TK-112/113/114 (projects/roles/stages). Each
 story branches from the epic tip and PRs into `epic/extensible-schema`; the epic
 PRs into `main` only once all stories land.
+
+### 9.5 Consolidation status summary
+
+| Entity | Consolidated into `attrs` (dropped) | Story |
+|--------|--------------------------------------|-------|
+| tickets | git_repository, git_branch, estimate_complete, health_score, author, pr_url (+ dead `open`) | TK-111 |
+| projects | agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key | TK-112 |
+| roles | description, acceptance_criteria, dor_map, dod_map, ac_map | TK-113 |
+| workflow_stages | description, acceptance_criteria, definition_of_ready, definition_of_done | TK-114 |
+
+Remaining deferred: the `dor_map`/`dod_map`/`ac_map` fold for **tickets** and
+**projects** (TK-115). `projects.git_repository`/`notes` reclassified Keep.

--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -1,0 +1,296 @@
+# Extensible Schema: JSON Attribute Bags + Reinforced Migration Safety
+
+> Status: **Design (S1 / TK-106)** — sign-off gate for epic **TK-105**.
+> Implementation stories: TK-107 (migration safety), TK-108 (column-list
+> centralization), TK-109 (introduce `attrs`), TK-110 (queryable bag),
+> TK-111–TK-114 (per-entity consolidation).
+
+## 1. Problem
+
+Adding a single field to a core entity is disproportionately expensive today.
+The cost is **not** the `ALTER TABLE` — that is one idempotent line and the
+additive migration framework in `internal/store/store.go` already handles it.
+The cost is two-fold:
+
+1. **DDL churn / version coupling.** Every optional field needs a schema-version
+   bump (`CurrentSchemaVersion` in `internal/store/schema_version.go`) and a
+   migration guard, even when the field is sparse, display-only, or specific to
+   one ticket type.
+2. **Code fan-out.** Columns are listed *positionally* in ~10 hand-written
+   `SELECT` statements (`internal/store/ticket.go`, `internal/store/reorder.go`)
+   plus a 41-argument `scanTicket`. Adding `started_at` (TK-88) meant threading
+   `COALESCE(started_at,'')` through every one of those call sites in the correct
+   ordinal position, plus the struct, INSERT/UPDATE, OpenAPI and tests.
+
+We want to lower both the **likelihood** and the **blast radius** of future
+schema change, while keeping the schema queryable and safe to migrate.
+
+## 2. Goals & non-goals
+
+**Goals**
+- Make the *default* way to add an optional field require **no DDL and no schema
+  version bump**.
+- Eliminate the positional `SELECT`/scan fan-out so even genuine column changes
+  touch one place.
+- Keep fields queryable (filter/sort/index) when they need to be.
+- Make every migration self-protecting: a verified backup is always taken and a
+  failed migration auto-rolls-back.
+
+**Non-goals (this epic)**
+- No Postgres / non-SQLite backend.
+- No end-user "custom fields" UI (this epic builds the substrate, not the
+  feature).
+- No change to the lifecycle model (`docs/LIFECYCLE.md`).
+
+## 3. The three-tier model
+
+We deliberately do **not** turn everything into JSON. Untyped JSON bags become
+dumping grounds that defeat querying and constraints. Instead we define three
+tiers with explicit promotion rules.
+
+### Tier 1 — First-class columns (unchanged)
+Real typed columns. Used for anything that needs a **foreign key**, a
+**`NOT NULL` constraint**, a **hot-path `WHERE`/`ORDER BY`**, or **aggregation**.
+Examples: `state`, `stage`, `status`, `project_id`, `parent_id`, `priority`,
+`sort_order`, lifecycle flags (`draft`/`complete`/`archived`/`deleted`),
+timestamps.
+
+### Tier 2 — The attribute bag (`attrs`, JSONB)
+One `attrs` column per high-churn entity, storing a JSON object. This is the
+**default home** for:
+- new optional / sparse fields,
+- display-only or rarely-queried fields,
+- **per-type** fields (a `bug`'s repro steps, a `spike`'s timebox) that would
+  otherwise be sparse wide columns.
+
+Adding a Tier-2 field = **add a field to a typed Go accessor struct**. No SQL, no
+migration, no version bump.
+
+### Tier 3 — Promotion
+When a Tier-2 field starts needing to be filtered / sorted / indexed, it is
+*promoted* without a destructive migration:
+
+1. **Expression index** (preferred) — idempotent, no table rewrite:
+   ```sql
+   CREATE INDEX IF NOT EXISTS idx_tickets_attrs_severity
+     ON tickets (json_extract(attrs, '$.severity'));
+   ```
+2. **Generated column** (heavier, only when a real column surface is required):
+   a `GENERATED ALWAYS AS (json_extract(attrs,'$.x')) VIRTUAL` column. Documented
+   as the fallback; not implemented unless a concrete need arises.
+
+### Promotion decision tree
+
+```mermaid
+flowchart TD
+  A[New or evolving field] --> B{Needs FK / NOT NULL / hot WHERE-ORDER BY / aggregation?}
+  B -- Yes --> C[Tier 1: real column]
+  B -- No --> D[Tier 2: attrs bag - no DDL]
+  D --> E{Later needs filter / sort / index?}
+  E -- No --> D
+  E -- Yes, light --> F[Tier 3: expression index on json_extract]
+  E -- Yes, needs column surface --> G[Tier 3: generated column]
+```
+
+## 4. Storage format: JSONB
+
+SQLite has no `JSONB` *column type* (unlike Postgres). "JSONB" in SQLite is the
+binary on-disk encoding introduced in **SQLite 3.45** (Jan 2024), produced by
+`jsonb()` / `jsonb_extract()` and stored in a `BLOB`. Our driver
+`modernc.org/sqlite v1.48.0` embeds a SQLite new enough to support it.
+
+Decision: **store `attrs` as JSONB (BLOB)**, written via `jsonb(?)` and read via
+`json(attrs)` (which renders JSONB back to text for Go's `encoding/json`), with
+`json_extract(attrs,'$.path')` for queries. Rationale: more compact and faster to
+parse than TEXT JSON; `json_extract` works transparently on either encoding so
+expression indexes are unaffected.
+
+The column is declared `attrs BLOB NOT NULL DEFAULT (jsonb('{}'))` so existing
+rows and inserts that omit it get a valid empty object.
+
+> Coexistence: the existing `dor_map` / `dod_map` / `ac_map` TEXT-JSON columns
+> keep working unchanged until S6 folds them into `attrs`. Both encodings are
+> readable by the same `json_*` functions during the transition.
+
+## 5. Typed accessor layer
+
+The bag is **not** accessed as a raw `map[string]any` in business logic. Each
+entity gets a typed Go struct that marshals to/from `attrs`:
+
+```go
+// TicketAttrs is the typed view of tickets.attrs. Adding an optional field here
+// requires NO SQL and NO schema-version bump.
+type TicketAttrs struct {
+    GitRepository    string      `json:"git_repository,omitempty"`
+    GitBranch        string      `json:"git_branch,omitempty"`
+    EstimateComplete string      `json:"estimate_complete,omitempty"`
+    HealthScore      int         `json:"health_score,omitempty"`
+    Author           string      `json:"author,omitempty"`
+    PrURL            string      `json:"pr_url,omitempty"`
+    DOR              GuidanceMap `json:"dor_map,omitempty"`
+    DOD              GuidanceMap `json:"dod_map,omitempty"`
+    AC               GuidanceMap `json:"ac_map,omitempty"`
+    // future optional fields land here — no migration
+}
+```
+
+- `omitempty` keeps the stored object minimal/sparse.
+- Unknown keys are preserved on round-trip where practical (so an older binary
+  does not silently drop a newer field) — implemented by retaining a raw
+  `map[string]json.RawMessage` overflow alongside the typed struct.
+- A shared helper marshals/unmarshals (`encoding/json`) and is the single place
+  that talks to the `attrs` column.
+
+## 6. Killing the fan-out (TK-108)
+
+Independent of JSON, the ticket column list and scan are centralized into a
+single source of truth:
+
+- One canonical column-list constant/builder used by every read query.
+- One scan helper whose scan-target order is guaranteed consistent with that
+  list.
+
+After this, adding a Tier-1 column touches the list + struct + scan helper in one
+place instead of ~10 SELECTs, and adding `attrs` (TK-109) is a one-line change to
+the list.
+
+## 7. Migration safety (TK-107)
+
+Today `BackupDatabase()` does a plain file copy of `.db`/`-wal`/`-shm` before
+`UpgradeInPlace()`, but only from the server-startup path
+(`cmd/tk/cmd_setup.go:autoUpgradeDatabase`), with **no WAL checkpoint, no
+integrity verification, and no rollback**.
+
+Reinforcements:
+
+```mermaid
+flowchart TD
+  S[UpgradeInPlace start] --> CP[PRAGMA wal_checkpoint TRUNCATE]
+  CP --> BK[Copy db + sidecars to timestamped backup]
+  BK --> V{Verify backup: integrity_check + schema version}
+  V -- fail --> ABORT[Abort, do not touch live DB]
+  V -- ok --> MIG[Run migrations in tx]
+  MIG -- success --> DONE[Write new schema_version, keep backup per retention]
+  MIG -- failure --> RB[Restore live DB + sidecars from backup]
+  RB --> ERR[Return clear error, original DB intact]
+```
+
+1. `PRAGMA wal_checkpoint(TRUNCATE)` before copy → self-contained backup.
+2. Verify the backup (`PRAGMA integrity_check` + readable schema version) before
+   touching the live DB; abort if it fails.
+3. Take the backup **inside `UpgradeInPlace`** so every caller is protected.
+4. Auto-rollback: restore live DB + sidecars from the verified backup on failure.
+5. Timestamped backups with a documented retention policy.
+6. Test: inject a deliberately broken migration; assert original DB recovered,
+   schema version unchanged, error surfaced.
+
+## 8. Entity model — before & after
+
+```mermaid
+erDiagram
+  TICKETS {
+    string ticket_id PK
+    int    project_id FK
+    string state
+    string stage
+    blob   attrs "JSONB: soft + per-type fields"
+  }
+  PROJECTS {
+    int  project_id PK
+    string prefix
+    blob attrs "JSONB"
+  }
+  ROLES {
+    int role_id PK
+    int workflow_id FK
+    blob attrs "JSONB"
+  }
+  WORKFLOW_STAGES {
+    int workflow_stage_id PK
+    int workflow_id FK
+    blob attrs "JSONB"
+  }
+  PROJECTS ||--o{ TICKETS : has
+  WORKFLOWS ||--o{ ROLES : defines
+  WORKFLOWS ||--o{ WORKFLOW_STAGES : defines
+```
+
+## 9. Per-column classification
+
+Legend: **Keep** = stays a Tier-1 column. **Move** = relocate value into `attrs`.
+**Fold** = existing TEXT-JSON column merged as a nested key in `attrs`.
+Conservative bias: anything filtered / sorted / FK'd / aggregated stays **Keep**.
+
+### 9.1 `tickets`
+
+| Column | Decision | Rationale |
+|--------|----------|-----------|
+| ticket_id, project_id, parent_id, clone_of | Keep | PK / FKs |
+| type, title, description, acceptance_criteria | Keep | core, always present, displayed everywhere |
+| workflow_stage_id, role_id, stage, state, status | Keep | hot lifecycle filters |
+| priority, sort_order | Keep | sorted/ordered |
+| estimate_effort | Keep | aggregation candidate (sums/rollups) |
+| draft, complete, archived, deleted | Keep | hot boolean filters |
+| previous_workflow_stage_id, previous_role_id, release_id, workflow_id | Keep | FKs / lifecycle |
+| assignee, created_by | Keep | filtered |
+| recommended_ready, ready | Keep | filtered flags |
+| started_at, created_at, updated_at | Keep | sorted timestamps |
+| dor_map, dod_map, ac_map | **Fold** | already JSON; natural bag members |
+| git_repository, git_branch | **Move** | soft, rarely filtered |
+| estimate_complete | **Move** | display date string |
+| health_score | **Move** | display metric (promote via index if ever sorted) |
+| author | **Move** | soft, display |
+| pr_url | **Move** | soft, display |
+| `open` (legacy) | **Drop** | dead column, superseded by complete/archived |
+
+### 9.2 `projects`
+
+| Column | Decision | Rationale |
+|--------|----------|-----------|
+| project_id, prefix, title | Keep | PK / identity / displayed |
+| status, visibility | Keep | filtered |
+| workflow_id, programme_id, default_draft | Keep | FKs / behavior flags |
+| ticket_sequence | Keep | sequence counter (mutated atomically) |
+| created_by, created_at, updated_at | Keep | identity/sort |
+| description, acceptance_criteria | Keep | core, displayed |
+| dor_map, dod_map, ac_map | **Fold** | already JSON |
+| git_repository, notes | **Move** | soft, display |
+| agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key | **Move** | config sub-object → `attrs.agent_model` |
+
+### 9.3 `roles`
+
+| Column | Decision | Rationale |
+|--------|----------|-----------|
+| role_id, workflow_id, title | Keep | PK / FK / unique identity |
+| created_at, updated_at | Keep | sort |
+| dor_map, dod_map, ac_map | **Fold** | already JSON |
+| description, acceptance_criteria | **Move** | guidance text, never filtered |
+
+### 9.4 `workflow_stages`
+
+| Column | Decision | Rationale |
+|--------|----------|-----------|
+| workflow_stage_id, workflow_id, stage_name | Keep | PK / FK / unique identity |
+| sort_order | Keep | ordering |
+| is_backlog_stage | Keep | filtered flag |
+| created_at, updated_at | Keep | sort |
+| description, acceptance_criteria | **Move** | guidance text |
+| definition_of_ready, definition_of_done | **Move** | guidance text |
+
+> Workflow export/import (which serializes stages) must round-trip after the
+> move — see TK-114 acceptance criteria.
+
+## 10. Alternatives considered
+
+See ADR `docs/adr/0001-json-attribute-bags.md`. Summary: status-quo additive
+columns (rejected: the churn this epic exists to remove), an EAV side table
+(rejected: join cost, loss of atomic row, reporting pain), and plain TEXT JSON
+(rejected in favour of JSONB for size/speed; TEXT retained only transitionally).
+
+## 11. Rollout / sequencing
+
+Docs (this story) → migration safety (TK-107) + fan-out refactor (TK-108) →
+introduce `attrs` (TK-109) → queryable bag (TK-110) → per-entity consolidation
+TK-111 (tickets, first/riskiest) → TK-112/113/114 (projects/roles/stages). Each
+story branches from the epic tip and PRs into `epic/extensible-schema`; the epic
+PRs into `main` only once all stories land.

--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -92,6 +92,22 @@ flowchart TD
   E -- Yes, needs column surface --> G[Tier 3: generated column]
 ```
 
+### Querying the bag in practice (Tier-3 API)
+
+The promotion mechanism is implemented in `internal/store/attrs_query.go`:
+
+- `ValidAttrsKey(key)` — restricts attrs keys to `[A-Za-z0-9_]+` so a json path can
+  never inject SQL. All query/index helpers validate the key before it reaches SQL.
+- `EnsureAttrIndex(ctx, db, table, key)` — the promotion action. Idempotently
+  creates `idx_<table>_attrs_<key> ON <table>(json_extract(attrs,'$.<key>'))`. No
+  table rewrite, no schema-version bump; safe to call repeatedly.
+- `ListTicketsByAttr(ctx, db, projectID, key, value)` — a worked example that
+  filters and orders tickets on a bag field via `json_extract`; the expression
+  index above serves it (verified with `EXPLAIN QUERY PLAN` in the tests).
+
+A consolidation story (S6) that moves a queried column into the bag calls
+`EnsureAttrIndex` for that field so existing filters/sorts keep their index.
+
 ## 4. Storage format: TEXT JSON (not binary JSONB)
 
 SQLite has no `JSONB` *column type* (unlike Postgres). "JSONB" in SQLite is the

--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -92,25 +92,31 @@ flowchart TD
   E -- Yes, needs column surface --> G[Tier 3: generated column]
 ```
 
-## 4. Storage format: JSONB
+## 4. Storage format: TEXT JSON (not binary JSONB)
 
 SQLite has no `JSONB` *column type* (unlike Postgres). "JSONB" in SQLite is the
 binary on-disk encoding introduced in **SQLite 3.45** (Jan 2024), produced by
 `jsonb()` / `jsonb_extract()` and stored in a `BLOB`. Our driver
 `modernc.org/sqlite v1.48.0` embeds a SQLite new enough to support it.
 
-Decision: **store `attrs` as JSONB (BLOB)**, written via `jsonb(?)` and read via
-`json(attrs)` (which renders JSONB back to text for Go's `encoding/json`), with
-`json_extract(attrs,'$.path')` for queries. Rationale: more compact and faster to
-parse than TEXT JSON; `json_extract` works transparently on either encoding so
-expression indexes are unaffected.
+The original design (S1) proposed binary JSONB for compactness. During
+implementation (S4) we found a blocking problem: **binary JSONB does not survive
+the snapshot export/import** used by both the backup/restore feature
+(`tk export`/`tk import`) and the migration rebuild path (`UpgradeDatabase`). The
+snapshot serializes every column generically via `[]byte → string → JSON`, and
+binary JSONB bytes are not valid UTF-8, so a round-tripped value comes back as
+"malformed JSON". Data integrity of backups and migrations outranks the marginal
+size/speed win of binary encoding.
 
-The column is declared `attrs BLOB NOT NULL DEFAULT (jsonb('{}'))` so existing
-rows and inserts that omit it get a valid empty object.
+Decision (revised): **store `attrs` as `TEXT NOT NULL DEFAULT '{}'`**, written as
+plain JSON text (`attrs = ?`) and read as text. `json_extract(attrs,'$.path')`
+and expression indexes work identically on TEXT, so Tier-3 promotion (§3) is
+unchanged. The constant `'{}'` default is also permitted on
+`ALTER TABLE ADD COLUMN`, so the migration needs no backfill.
 
 > Coexistence: the existing `dor_map` / `dod_map` / `ac_map` TEXT-JSON columns
-> keep working unchanged until S6 folds them into `attrs`. Both encodings are
-> readable by the same `json_*` functions during the transition.
+> keep working unchanged until S6 folds them into `attrs`. All are TEXT JSON and
+> readable by the same `json_*` functions.
 
 ## 5. Typed accessor layer
 

--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -341,5 +341,6 @@ PRs into `main` only once all stories land.
 | roles | description, acceptance_criteria, dor_map, dod_map, ac_map | TK-113 |
 | workflow_stages | description, acceptance_criteria, definition_of_ready, definition_of_done | TK-114 |
 
-Remaining deferred: the `dor_map`/`dod_map`/`ac_map` fold for **tickets** and
-**projects** (TK-115). `projects.git_repository`/`notes` reclassified Keep.
+All `dor_map`/`dod_map`/`ac_map` folds are complete across tickets, projects,
+roles and workflow_stages (tickets+projects via TK-115; roles+stages via
+TK-113/TK-114). `projects.git_repository`/`notes` reclassified Keep.

--- a/internal/server/api_projects.go
+++ b/internal/server/api_projects.go
@@ -64,6 +64,7 @@ func (r *router) registerProjectHandlers() {
 				AgentModelName:     projectPayload.AgentModelName,
 				AgentModelURL:      projectPayload.AgentModelURL,
 				AgentModelAPIKey:   projectPayload.AgentModelAPIKey,
+				Attrs:              projectPayload.Attrs,
 			})
 			if err != nil {
 				writeStoreError(w, err)
@@ -1481,6 +1482,7 @@ func (r *router) registerProjectHandlers() {
 				AgentModelName:     projectPayload.AgentModelName,
 				AgentModelURL:      projectPayload.AgentModelURL,
 				AgentModelAPIKey:   projectPayload.AgentModelAPIKey,
+				Attrs:              projectPayload.Attrs,
 			})
 			if err != nil {
 				if errors.Is(err, store.ErrProjectNotFound) {

--- a/internal/server/api_roles.go
+++ b/internal/server/api_roles.go
@@ -47,6 +47,7 @@ func (r *router) registerRoleHandlers() {
 				DORMap:             payload.DORMap,
 				DODMap:             payload.DODMap,
 				ACMap:              payload.ACMap,
+				Attrs:              payload.Attrs,
 			})
 			if err != nil {
 				writeStoreError(w, err)
@@ -83,6 +84,7 @@ func (r *router) registerRoleHandlers() {
 				DORMap:             payload.DORMap,
 				DODMap:             payload.DODMap,
 				ACMap:              payload.ACMap,
+				Attrs:              payload.Attrs,
 			})
 			if err != nil {
 				if errors.Is(err, sql.ErrNoRows) {

--- a/internal/server/api_tickets.go
+++ b/internal/server/api_tickets.go
@@ -209,6 +209,7 @@ func (r *router) registerTicketHandlers() {
 			State:              state,
 			Author:             user.Username,
 			CreatedBy:          user.ID,
+			Attrs:              ticketPayload.Attrs,
 		})
 		if err != nil {
 			writeStoreError(w, err)
@@ -1813,6 +1814,7 @@ func (r *router) registerTicketHandlers() {
 					EstimateEffort:     ticketPayload.EstimateEffort,
 					EstimateComplete:   ticketPayload.EstimateComplete,
 					Type:               ticketPayload.Type,
+					Attrs:              ticketPayload.Attrs,
 					UpdatedBy:          user.ID,
 					ActorUsername:      user.Username,
 					ActorRole:          user.Role,

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -76,6 +76,7 @@ type projectRequest struct {
 	AgentModelName     string            `json:"agent_model_name"`
 	AgentModelURL      string            `json:"agent_model_url"`
 	AgentModelAPIKey   string            `json:"agent_model_api_key"`
+	Attrs              store.Attrs       `json:"attrs,omitempty"`
 }
 
 type pullRequestRequest struct {
@@ -103,6 +104,7 @@ type roleRequest struct {
 	DORMap             store.GuidanceMap `json:"dor_map,omitempty"`
 	DODMap             store.GuidanceMap `json:"dod_map,omitempty"`
 	ACMap              store.GuidanceMap `json:"ac_map,omitempty"`
+	Attrs              store.Attrs       `json:"attrs,omitempty"`
 }
 
 type agentModelConfigRequest struct {
@@ -196,6 +198,7 @@ type ticketRequest struct {
 	EstimateEffort     int               `json:"estimate_effort"`
 	EstimateComplete   string            `json:"estimate_complete,omitempty"`
 	Assignee           string            `json:"assignee"`
+	Attrs              store.Attrs       `json:"attrs,omitempty"`
 	Message            string            `json:"message,omitempty"`
 }
 

--- a/internal/store/agent.go
+++ b/internal/store/agent.go
@@ -328,7 +328,7 @@ func ListAgentStatuses(ctx context.Context, db *sql.DB) ([]AgentStatus, error) {
 			LEFT JOIN projects p ON p.project_id = t.project_id
 			LEFT JOIN workflows w ON w.workflow_id = t.workflow_id
 			LEFT JOIN roles r ON r.role_id = t.role_id
-			WHERE t.state = 'active' AND t.open = 1 AND t.assignee IS NOT NULL AND TRIM(t.assignee) <> ''
+			WHERE t.state = 'active' AND t.archived = 0 AND t.assignee IS NOT NULL AND TRIM(t.assignee) <> ''
 		)
 		WHERE rn = 1
 	`)

--- a/internal/store/attrs.go
+++ b/internal/store/attrs.go
@@ -48,6 +48,26 @@ func parseAttrs(text string) (Attrs, error) {
 	return a, nil
 }
 
+// guidanceMapFromAttr converts a decoded attrs value (a nested JSON object) into a
+// GuidanceMap. Used when a guidance map (dor/dod/ac) is folded into the bag as a
+// nested object (TK-113/TK-115). Returns nil for a missing or non-object value.
+func guidanceMapFromAttr(v any) GuidanceMap {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	out := make(GuidanceMap, len(m))
+	for k, val := range m {
+		if s, ok := val.(string); ok {
+			out[k] = s
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
 // GetString returns the value at key as a string, or "" if absent or not a string.
 func (a Attrs) GetString(key string) string {
 	if v, ok := a[key].(string); ok {

--- a/internal/store/attrs.go
+++ b/internal/store/attrs.go
@@ -1,0 +1,101 @@
+package store
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Attrs is the extensible attribute bag stored in the `attrs` column on the
+// high-churn entities (tickets, projects, roles, workflow_stages). It is the
+// default home for new optional, sparse, display-only, and per-type fields: such a
+// field can be added in Go without a schema migration or schema-version bump. See
+// docs/design/extensible-schema.md and docs/adr/0001-json-attribute-bags.md.
+//
+// The bag is stored as TEXT JSON (not binary JSONB) so it survives the generic
+// snapshot export/import used by backups and the migration rebuild path. It is
+// queryable via json_extract; fields that must be filtered/sorted are "promoted"
+// with an expression index rather than a new column.
+type Attrs map[string]any
+
+// marshalAttrs serializes an Attrs bag to compact JSON text for the TEXT attrs
+// column. A nil or empty bag yields "{}" so the column is never NULL when written.
+func marshalAttrs(a Attrs) (string, error) {
+	if len(a) == 0 {
+		return "{}", nil
+	}
+	b, err := json.Marshal(a)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// parseAttrs parses attrs JSON text (as returned by json(attrs)) into an Attrs
+// bag. Empty, whitespace-only, or SQL-NULL text yields an empty (non-nil) bag so
+// callers can always read and mutate the result safely.
+func parseAttrs(text string) (Attrs, error) {
+	t := strings.TrimSpace(text)
+	if t == "" || t == "null" {
+		return Attrs{}, nil
+	}
+	var a Attrs
+	if err := json.Unmarshal([]byte(t), &a); err != nil {
+		return nil, err
+	}
+	if a == nil {
+		a = Attrs{}
+	}
+	return a, nil
+}
+
+// GetString returns the value at key as a string, or "" if absent or not a string.
+func (a Attrs) GetString(key string) string {
+	if v, ok := a[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// GetInt returns the value at key as an int. JSON numbers decode to float64, which
+// is handled here. Returns 0 if absent or not numeric.
+func (a Attrs) GetInt(key string) int {
+	switch v := a[key].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case json.Number:
+		n, _ := v.Int64()
+		return int(n)
+	default:
+		return 0
+	}
+}
+
+// SetString sets key to a non-empty string value, deleting the key when val is
+// empty so the stored bag stays sparse. It is a no-op on a nil map.
+func (a Attrs) SetString(key, val string) {
+	if a == nil {
+		return
+	}
+	if val == "" {
+		delete(a, key)
+		return
+	}
+	a[key] = val
+}
+
+// SetInt sets key to a non-zero int value, deleting the key when val is zero so the
+// stored bag stays sparse. It is a no-op on a nil map.
+func (a Attrs) SetInt(key string, val int) {
+	if a == nil {
+		return
+	}
+	if val == 0 {
+		delete(a, key)
+		return
+	}
+	a[key] = val
+}

--- a/internal/store/attrs_query.go
+++ b/internal/store/attrs_query.go
@@ -1,0 +1,97 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"regexp"
+)
+
+// attrsKeyPattern restricts attrs JSON keys usable in SQL (json_extract paths and
+// index names) to a safe identifier alphabet. Keys come from a validated allowlist,
+// never raw user input concatenated into SQL — this keeps json_extract expressions
+// injection-safe.
+var attrsKeyPattern = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+
+// attrsIndexableTables is the set of tables that carry an attrs bag and may have
+// expression indexes created over it.
+var attrsIndexableTables = map[string]bool{
+	"tickets":         true,
+	"projects":        true,
+	"roles":           true,
+	"workflow_stages": true,
+}
+
+// ValidAttrsKey reports whether key is a safe top-level attrs key for use in a
+// json_extract path or an index name.
+func ValidAttrsKey(key string) bool {
+	return attrsKeyPattern.MatchString(key)
+}
+
+// attrsExtractExpr returns a json_extract SQL expression for a single top-level
+// attrs key, optionally prefixed by a table alias. The key must be validated with
+// ValidAttrsKey by the caller; this returns an error otherwise so a bad key can
+// never reach SQL.
+func attrsExtractExpr(alias, key string) (string, error) {
+	if !ValidAttrsKey(key) {
+		return "", fmt.Errorf("invalid attrs key %q", key)
+	}
+	column := "attrs"
+	if alias != "" {
+		column = alias + ".attrs"
+	}
+	return fmt.Sprintf("json_extract(%s, '$.%s')", column, key), nil
+}
+
+// EnsureAttrIndex creates, idempotently, an expression index over a single attrs
+// JSON key on a table. This is the Tier-3 "promotion" mechanism from
+// docs/design/extensible-schema.md: a bag field that needs to be filtered or sorted
+// is promoted to query-grade with an index and NO table rewrite or schema-version
+// bump. Safe to call repeatedly (CREATE INDEX IF NOT EXISTS).
+func EnsureAttrIndex(ctx context.Context, db *sql.DB, table, key string) error {
+	if !attrsIndexableTables[table] {
+		return fmt.Errorf("unknown attrs table %q", table)
+	}
+	if !ValidAttrsKey(key) {
+		return fmt.Errorf("invalid attrs key %q", key)
+	}
+	stmt := fmt.Sprintf(
+		"CREATE INDEX IF NOT EXISTS idx_%s_attrs_%s ON %s (json_extract(attrs, '$.%s'))",
+		table, key, table, key,
+	)
+	_, err := db.ExecContext(ctx, stmt)
+	return err
+}
+
+// ListTicketsByAttr returns the live tickets in a project whose attrs bag has the
+// given top-level key equal to value, ordered by that value. It demonstrates the
+// queryable bag end-to-end: filtering and sorting on a json_extract expression that
+// an EnsureAttrIndex expression index can serve. The key is validated, so the query
+// is injection-safe even though the path is interpolated.
+func ListTicketsByAttr(ctx context.Context, db *sql.DB, projectID int64, key, value string) ([]Ticket, error) {
+	if projectID == 0 {
+		return nil, fmt.Errorf("project is required")
+	}
+	expr, err := attrsExtractExpr("", key)
+	if err != nil {
+		return nil, err
+	}
+	query := `SELECT ` + ticketSelectColumns("") + `
+		FROM tickets
+		WHERE project_id = ? AND deleted = 0 AND ` + expr + ` = ?
+		ORDER BY ` + expr + `, ticket_id`
+	rows, err := db.QueryContext(ctx, query, projectID, value)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	tickets := make([]Ticket, 0)
+	for rows.Next() {
+		ticket, scanErr := scanTicket(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		tickets = append(tickets, ticket)
+	}
+	return tickets, rows.Err()
+}

--- a/internal/store/attrs_query.go
+++ b/internal/store/attrs_query.go
@@ -76,6 +76,7 @@ func ListTicketsByAttr(ctx context.Context, db *sql.DB, projectID int64, key, va
 	if err != nil {
 		return nil, err
 	}
+	// #nosec G202 -- ticketSelectColumns is a fixed column list and expr is built from an allowlist-validated key (ValidAttrsKey); the compared value is a bound parameter.
 	query := `SELECT ` + ticketSelectColumns("") + `
 		FROM tickets
 		WHERE project_id = ? AND deleted = 0 AND ` + expr + ` = ?

--- a/internal/store/attrs_query_test.go
+++ b/internal/store/attrs_query_test.go
@@ -1,0 +1,96 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestValidAttrsKey(t *testing.T) {
+	t.Parallel()
+	for _, k := range []string{"severity", "wip_limit", "Repro2"} {
+		if !ValidAttrsKey(k) {
+			t.Errorf("ValidAttrsKey(%q) = false, want true", k)
+		}
+	}
+	for _, k := range []string{"", "a.b", "a'b", "a b", "$.x", "a);DROP"} {
+		if ValidAttrsKey(k) {
+			t.Errorf("ValidAttrsKey(%q) = true, want false", k)
+		}
+	}
+}
+
+func TestEnsureAttrIndexRejectsBadInput(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+	if err := EnsureAttrIndex(ctx, db, "not_a_table", "x"); err == nil {
+		t.Fatal("EnsureAttrIndex with bad table = nil error, want error")
+	}
+	if err := EnsureAttrIndex(ctx, db, "tickets", "bad key"); err == nil {
+		t.Fatal("EnsureAttrIndex with bad key = nil error, want error")
+	}
+}
+
+// TestListTicketsByAttrUsesIndex demonstrates the queryable bag end-to-end: filter
+// and sort tickets on a bag field, and confirm the expression index is used.
+func TestListTicketsByAttrUsesIndex(t *testing.T) {
+	// Not parallel: creates an index on the shared schema of its own DB.
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	mk := func(title, sev string) {
+		if _, err := CreateTicket(ctx, db, TicketCreateParams{
+			ProjectID: 1, Type: "bug", Title: title, Attrs: Attrs{"severity": sev},
+		}); err != nil {
+			t.Fatalf("CreateTicket(%s) error = %v", title, err)
+		}
+	}
+	mk("a", "high")
+	mk("b", "low")
+	mk("c", "high")
+
+	// Promote the field with an expression index (idempotent; call twice).
+	if err := EnsureAttrIndex(ctx, db, "tickets", "severity"); err != nil {
+		t.Fatalf("EnsureAttrIndex() error = %v", err)
+	}
+	if err := EnsureAttrIndex(ctx, db, "tickets", "severity"); err != nil {
+		t.Fatalf("EnsureAttrIndex() second call error = %v", err)
+	}
+
+	got, err := ListTicketsByAttr(ctx, db, 1, "severity", "high")
+	if err != nil {
+		t.Fatalf("ListTicketsByAttr() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("ListTicketsByAttr() returned %d tickets, want 2", len(got))
+	}
+	for _, tk := range got {
+		if tk.Attrs.GetString("severity") != "high" {
+			t.Fatalf("unexpected ticket in result: %s severity=%s", tk.Title, tk.Attrs.GetString("severity"))
+		}
+	}
+
+	// Confirm the planner uses the expression index for the filter.
+	var planRows strings.Builder
+	rows, err := db.QueryContext(ctx, `EXPLAIN QUERY PLAN
+		SELECT ticket_id FROM tickets
+		WHERE project_id = ? AND deleted = 0 AND json_extract(attrs, '$.severity') = ?`, 1, "high")
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, parent, notused int
+		var detail string
+		if scanErr := rows.Scan(&id, &parent, &notused, &detail); scanErr != nil {
+			t.Fatalf("scan plan error = %v", scanErr)
+		}
+		planRows.WriteString(detail)
+		planRows.WriteString("\n")
+	}
+	plan := planRows.String()
+	if !strings.Contains(plan, "idx_tickets_attrs_severity") {
+		t.Fatalf("expression index not used by planner; plan:\n%s", plan)
+	}
+}

--- a/internal/store/attrs_test.go
+++ b/internal/store/attrs_test.go
@@ -1,0 +1,241 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func attrsTestDB(t *testing.T) (*sql.DB, string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "attrs.db")
+	if err := Init(path, "admin", "secret12"); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	return db, path
+}
+
+func TestTicketAttrsRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	// Empty bag: created without attrs reads back empty.
+	plain, err := CreateTicket(ctx, db, TicketCreateParams{ProjectID: 1, Type: "task", Title: "plain"})
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+	if len(plain.Attrs) != 0 {
+		t.Fatalf("new ticket attrs = %v, want empty", plain.Attrs)
+	}
+
+	// Populated + nested bag round-trips through create.
+	nested := Attrs{
+		"repro_steps": "open app; click; crash",
+		"severity":    "high",
+		"meta":        map[string]any{"count": float64(3), "tags": []any{"a", "b"}},
+	}
+	tk, err := CreateTicket(ctx, db, TicketCreateParams{ProjectID: 1, Type: "bug", Title: "bug", Attrs: nested})
+	if err != nil {
+		t.Fatalf("CreateTicket(with attrs) error = %v", err)
+	}
+	got, err := GetTicket(ctx, db, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if !reflect.DeepEqual(got.Attrs, nested) {
+		t.Fatalf("round-tripped attrs = %#v, want %#v", got.Attrs, nested)
+	}
+
+	// Update with nil Attrs preserves the existing bag.
+	if _, err := UpdateTicket(ctx, db, tk.ID, TicketUpdateParams{Title: "bug2", ActorUsername: "admin", ActorRole: "admin"}); err != nil {
+		t.Fatalf("UpdateTicket(preserve) error = %v", err)
+	}
+	preserved, err := GetTicket(ctx, db, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if !reflect.DeepEqual(preserved.Attrs, nested) {
+		t.Fatalf("after preserve update attrs = %#v, want %#v", preserved.Attrs, nested)
+	}
+
+	// Update with a new bag replaces it.
+	replacement := Attrs{"severity": "low"}
+	if _, err := UpdateTicket(ctx, db, tk.ID, TicketUpdateParams{Title: "bug2", Attrs: replacement, ActorUsername: "admin", ActorRole: "admin"}); err != nil {
+		t.Fatalf("UpdateTicket(replace) error = %v", err)
+	}
+	replaced, err := GetTicket(ctx, db, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if !reflect.DeepEqual(replaced.Attrs, replacement) {
+		t.Fatalf("after replace attrs = %#v, want %#v", replaced.Attrs, replacement)
+	}
+}
+
+func TestProjectAttrsRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	bag := Attrs{"jira_key": "ABC-1", "config": map[string]any{"x": float64(1)}}
+	p, err := CreateProjectWithParams(ctx, db, ProjectCreateParams{Title: "P", Prefix: "PX", Attrs: bag})
+	if err != nil {
+		t.Fatalf("CreateProjectWithParams() error = %v", err)
+	}
+	got, err := GetProjectByID(ctx, db, p.ID)
+	if err != nil {
+		t.Fatalf("GetProjectByID() error = %v", err)
+	}
+	if !reflect.DeepEqual(got.Attrs, bag) {
+		t.Fatalf("project attrs = %#v, want %#v", got.Attrs, bag)
+	}
+	// Preserve on update without Attrs.
+	if _, err := UpdateProjectWithParams(ctx, db, p.ID, ProjectUpdateParams{Title: "P2"}); err != nil {
+		t.Fatalf("UpdateProjectWithParams() error = %v", err)
+	}
+	pres, err := GetProjectByID(ctx, db, p.ID)
+	if err != nil {
+		t.Fatalf("GetProjectByID() error = %v", err)
+	}
+	if !reflect.DeepEqual(pres.Attrs, bag) {
+		t.Fatalf("project attrs after preserve = %#v, want %#v", pres.Attrs, bag)
+	}
+}
+
+func TestRoleAttrsRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	bag := Attrs{"color": "blue"}
+	r, err := CreateRoleWithParams(ctx, db, RoleCreateParams{Title: "Architect", Attrs: bag})
+	if err != nil {
+		t.Fatalf("CreateRoleWithParams() error = %v", err)
+	}
+	got, err := GetRoleByID(ctx, db, r.ID)
+	if err != nil {
+		t.Fatalf("GetRoleByID() error = %v", err)
+	}
+	if !reflect.DeepEqual(got.Attrs, bag) {
+		t.Fatalf("role attrs = %#v, want %#v", got.Attrs, bag)
+	}
+}
+
+func TestWorkflowStageAttrsRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	wf, err := CreateWorkflow(ctx, db, "wf-attrs", "")
+	if err != nil {
+		t.Fatalf("CreateWorkflow() error = %v", err)
+	}
+	stage, err := AddWorkflowStageWithDefinitions(ctx, db, wf.ID, "design", "", "", "", 0)
+	if err != nil {
+		t.Fatalf("AddWorkflowStageWithDefinitions() error = %v", err)
+	}
+	if len(stage.Attrs) != 0 {
+		t.Fatalf("new stage attrs = %v, want empty", stage.Attrs)
+	}
+	bag := Attrs{"board_color": "green", "wip_limit": float64(5)}
+	updated, err := SetWorkflowStageAttrs(ctx, db, stage.ID, bag)
+	if err != nil {
+		t.Fatalf("SetWorkflowStageAttrs() error = %v", err)
+	}
+	if !reflect.DeepEqual(updated.Attrs, bag) {
+		t.Fatalf("stage attrs = %#v, want %#v", updated.Attrs, bag)
+	}
+	// A normal stage update must preserve attrs (attrs is not in its SET clause).
+	if _, err := UpdateWorkflowStage(ctx, db, stage.ID, "design", "desc", "ac"); err != nil {
+		t.Fatalf("UpdateWorkflowStage() error = %v", err)
+	}
+	wfs, err := GetWorkflow(ctx, db, wf.ID)
+	if err != nil {
+		t.Fatalf("GetWorkflow() error = %v", err)
+	}
+	if len(wfs.Stages) == 0 || !reflect.DeepEqual(wfs.Stages[0].Attrs, bag) {
+		t.Fatalf("stage attrs after normal update not preserved: %+v", wfs.Stages)
+	}
+}
+
+// TestAttrsZeroDDLExtensibility demonstrates that a brand-new optional field can be
+// stored and read back with NO schema migration and NO schema-version bump — the
+// whole point of the bag. The schema version is identical before and after.
+func TestAttrsZeroDDLExtensibility(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+
+	before, err := DetectSchemaVersion(path)
+	if err != nil {
+		t.Fatalf("DetectSchemaVersion() error = %v", err)
+	}
+	// A field that does not exist anywhere in the schema today.
+	tk, err := CreateTicket(ctx, db, TicketCreateParams{
+		ProjectID: 1, Type: "spike", Title: "timeboxed",
+		Attrs: Attrs{"timebox_hours": float64(8), "spike_outcome": "spike-doc"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+	got, err := GetTicket(ctx, db, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if got.Attrs.GetInt("timebox_hours") != 8 || got.Attrs.GetString("spike_outcome") != "spike-doc" {
+		t.Fatalf("new field not stored/read: %#v", got.Attrs)
+	}
+	after, err := DetectSchemaVersion(path)
+	if err != nil {
+		t.Fatalf("DetectSchemaVersion() error = %v", err)
+	}
+	if before != after {
+		t.Fatalf("schema version changed (%d -> %d) for a new Tier-2 field; expected no migration", before, after)
+	}
+}
+
+// TestAttrsMigrationReaddsColumns exercises the additive attrs migration: dropping
+// the attrs columns and re-running the in-place upgrade restores them.
+func TestAttrsMigrationReaddsColumns(t *testing.T) {
+	// Not parallel: opens the DB with a second raw connection.
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+	_ = db.Close()
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	for _, table := range []string{"tickets", "projects", "roles", "workflow_stages"} {
+		if _, err := raw.Exec(`ALTER TABLE ` + table + ` DROP COLUMN attrs`); err != nil {
+			_ = raw.Close()
+			t.Fatalf("drop attrs from %s error = %v", table, err)
+		}
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw.Close() error = %v", err)
+	}
+
+	if _, err := UpgradeInPlace(ctx, path); err != nil {
+		t.Fatalf("UpgradeInPlace() error = %v", err)
+	}
+
+	check, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() after upgrade error = %v", err)
+	}
+	defer check.Close()
+	for _, table := range []string{"tickets", "projects", "roles", "workflow_stages"} {
+		if !columnExists(ctx, check, table, "attrs") {
+			t.Fatalf("attrs column not restored on %s", table)
+		}
+	}
+}

--- a/internal/store/consolidate_projects_test.go
+++ b/internal/store/consolidate_projects_test.go
@@ -1,0 +1,116 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// TestConsolidateProjectsMigrationNoDataLoss simulates the pre-consolidation
+// projects shape (agent_model_* columns present and populated) and verifies the
+// upgrade moves the values into attrs with no loss, drops the columns, and the
+// values remain readable via the typed Project fields.
+func TestConsolidateProjectsMigrationNoDataLoss(t *testing.T) {
+	// Not parallel: manipulates schema_version and raw columns.
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+	p, err := CreateProjectWithParams(ctx, db, ProjectCreateParams{Title: "P", Prefix: "PMG"})
+	if err != nil {
+		t.Fatalf("CreateProjectWithParams() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	for _, stmt := range []string{
+		`ALTER TABLE projects ADD COLUMN agent_model_provider TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE projects ADD COLUMN agent_model_name TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE projects ADD COLUMN agent_model_url TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE projects ADD COLUMN agent_model_api_key TEXT NOT NULL DEFAULT ''`,
+	} {
+		if _, execErr := raw.Exec(stmt); execErr != nil {
+			_ = raw.Close()
+			t.Fatalf("setup %q error = %v", stmt, execErr)
+		}
+	}
+	if _, execErr := raw.Exec(
+		`UPDATE projects SET agent_model_provider=?, agent_model_name=?, agent_model_url=?, agent_model_api_key=?, attrs='{}' WHERE project_id=?`,
+		"anthropic", "claude-opus-4-8", "https://api", "sk-secret", p.ID,
+	); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("populate error = %v", execErr)
+	}
+	if _, execErr := raw.Exec(`UPDATE schema_meta SET value='11' WHERE key='schema_version'`); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("set version error = %v", execErr)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw.Close() error = %v", err)
+	}
+
+	if _, err := UpgradeInPlace(ctx, path); err != nil {
+		t.Fatalf("UpgradeInPlace() error = %v", err)
+	}
+
+	db2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() after upgrade error = %v", err)
+	}
+	defer db2.Close()
+
+	got, err := GetProjectByID(ctx, db2, p.ID)
+	if err != nil {
+		t.Fatalf("GetProjectByID() error = %v", err)
+	}
+	if got.AgentModelProvider != "anthropic" || got.AgentModelName != "claude-opus-4-8" ||
+		got.AgentModelURL != "https://api" || got.AgentModelAPIKey != "sk-secret" {
+		t.Fatalf("agent-model config not preserved: %+v", got)
+	}
+	for _, col := range []string{"agent_model_provider", "agent_model_name", "agent_model_url", "agent_model_api_key"} {
+		if columnExists(ctx, db2, "projects", col) {
+			t.Errorf("projects.%s still exists after consolidation", col)
+		}
+	}
+}
+
+// TestConsolidatedProjectAgentModelRoundTrip verifies the agent-model config still
+// works through the typed fields and the dedicated setter after consolidation.
+func TestConsolidatedProjectAgentModelRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	p, err := CreateProjectWithParams(ctx, db, ProjectCreateParams{
+		Title: "P", Prefix: "PRT",
+		AgentModelProvider: "anthropic", AgentModelName: "claude",
+		Attrs: Attrs{"jira": "X-1"},
+	})
+	if err != nil {
+		t.Fatalf("CreateProjectWithParams() error = %v", err)
+	}
+	got, err := GetProjectByID(ctx, db, p.ID)
+	if err != nil {
+		t.Fatalf("GetProjectByID() error = %v", err)
+	}
+	if got.AgentModelProvider != "anthropic" || got.AgentModelName != "claude" {
+		t.Fatalf("agent-model fields not round-tripped: %+v", got)
+	}
+	if got.Attrs.GetString("jira") != "X-1" {
+		t.Fatalf("extra attr lost: %#v", got.Attrs)
+	}
+	if _, dup := got.Attrs["agent_model_provider"]; dup {
+		t.Fatalf("attrs duplicates a typed field: %#v", got.Attrs)
+	}
+
+	updated, err := SetProjectAgentModelConfig(ctx, db, p.ID, AgentModelConfig{Provider: "openai", Model: "gpt", URL: "u", APIKey: "k"})
+	if err != nil {
+		t.Fatalf("SetProjectAgentModelConfig() error = %v", err)
+	}
+	if updated.AgentModelProvider != "openai" || updated.AgentModelName != "gpt" || updated.AgentModelURL != "u" || updated.AgentModelAPIKey != "k" {
+		t.Fatalf("setter did not write through bag: %+v", updated)
+	}
+}

--- a/internal/store/consolidate_roles_test.go
+++ b/internal/store/consolidate_roles_test.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"reflect"
+	"testing"
+)
+
+// TestConsolidateRolesMigrationNoDataLoss simulates the pre-consolidation roles
+// shape (guidance columns present and populated) and verifies the upgrade folds the
+// values into attrs with no loss, drops the columns, and the values remain readable
+// via the typed Role fields.
+func TestConsolidateRolesMigrationNoDataLoss(t *testing.T) {
+	// Not parallel: manipulates schema_version and raw columns.
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+	r, err := CreateRoleWithParams(ctx, db, RoleCreateParams{Title: "Engineer"})
+	if err != nil {
+		t.Fatalf("CreateRoleWithParams() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	for _, stmt := range []string{
+		`ALTER TABLE roles ADD COLUMN description TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE roles ADD COLUMN acceptance_criteria TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE roles ADD COLUMN dor_map TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE roles ADD COLUMN dod_map TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE roles ADD COLUMN ac_map TEXT NOT NULL DEFAULT '{}'`,
+	} {
+		if _, execErr := raw.Exec(stmt); execErr != nil {
+			_ = raw.Close()
+			t.Fatalf("setup %q error = %v", stmt, execErr)
+		}
+	}
+	if _, execErr := raw.Exec(
+		`UPDATE roles SET description=?, acceptance_criteria=?, dor_map=?, dod_map=?, ac_map=?, attrs='{}' WHERE role_id=?`,
+		"builds the thing", "compiles", `{"default":"branch exists"}`, `{"develop":"tests pass"}`, `{"default":"meets AC"}`, r.ID,
+	); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("populate error = %v", execErr)
+	}
+	if _, execErr := raw.Exec(`UPDATE schema_meta SET value='11' WHERE key='schema_version'`); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("set version error = %v", execErr)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw.Close() error = %v", err)
+	}
+
+	if _, err := UpgradeInPlace(ctx, path); err != nil {
+		t.Fatalf("UpgradeInPlace() error = %v", err)
+	}
+
+	db2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() after upgrade error = %v", err)
+	}
+	defer db2.Close()
+
+	got, err := GetRoleByID(ctx, db2, r.ID)
+	if err != nil {
+		t.Fatalf("GetRoleByID() error = %v", err)
+	}
+	if got.Description != "builds the thing" {
+		t.Errorf("Description = %q, want preserved", got.Description)
+	}
+	if got.AcceptanceCriteria != "compiles" {
+		t.Errorf("AcceptanceCriteria = %q, want preserved", got.AcceptanceCriteria)
+	}
+	if !reflect.DeepEqual(got.DORMap, GuidanceMap{"default": "branch exists"}) {
+		t.Errorf("DORMap = %#v, want preserved", got.DORMap)
+	}
+	if got.DODMap["develop"] != "tests pass" {
+		t.Errorf("DODMap = %#v, want preserved", got.DODMap)
+	}
+	for _, col := range []string{"description", "acceptance_criteria", "dor_map", "dod_map", "ac_map"} {
+		if columnExists(ctx, db2, "roles", col) {
+			t.Errorf("roles.%s still exists after consolidation", col)
+		}
+	}
+}
+
+// TestConsolidatedRoleRoundTrip verifies role guidance still round-trips through
+// the typed fields after consolidation, with the extra bag preserved.
+func TestConsolidatedRoleRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	r, err := CreateRoleWithParams(ctx, db, RoleCreateParams{
+		Title: "QA", Description: "tests things", AcceptanceCriteria: "all green",
+		DORMap: GuidanceMap{"default": "ready"},
+		Attrs:  Attrs{"color": "purple"},
+	})
+	if err != nil {
+		t.Fatalf("CreateRoleWithParams() error = %v", err)
+	}
+	got, err := GetRoleByID(ctx, db, r.ID)
+	if err != nil {
+		t.Fatalf("GetRoleByID() error = %v", err)
+	}
+	if got.Description != "tests things" || got.AcceptanceCriteria != "all green" {
+		t.Fatalf("role text fields not round-tripped: %+v", got)
+	}
+	if got.DORMap["default"] != "ready" {
+		t.Fatalf("DORMap not round-tripped: %#v", got.DORMap)
+	}
+	if got.Attrs.GetString("color") != "purple" {
+		t.Fatalf("extra attr lost: %#v", got.Attrs)
+	}
+	for _, k := range []string{"description", "acceptance_criteria", "dor_map", "dod_map", "ac_map"} {
+		if _, dup := got.Attrs[k]; dup {
+			t.Fatalf("attrs duplicates typed field %q: %#v", k, got.Attrs)
+		}
+	}
+}

--- a/internal/store/consolidate_stages_test.go
+++ b/internal/store/consolidate_stages_test.go
@@ -1,0 +1,136 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// TestConsolidateStagesMigrationNoDataLoss simulates the pre-consolidation
+// workflow_stages shape (guidance text columns present and populated) and verifies
+// the upgrade folds the values into attrs with no loss, drops the columns, and the
+// values remain readable via the typed WorkflowStage fields.
+func TestConsolidateStagesMigrationNoDataLoss(t *testing.T) {
+	// Not parallel: manipulates schema_version and raw columns.
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+	wf, err := CreateWorkflow(ctx, db, "wf-mig", "")
+	if err != nil {
+		t.Fatalf("CreateWorkflow() error = %v", err)
+	}
+	stage, err := AddWorkflowStageWithDefinitions(ctx, db, wf.ID, "design", "", "", "", 0)
+	if err != nil {
+		t.Fatalf("AddWorkflowStageWithDefinitions() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	for _, stmt := range []string{
+		`ALTER TABLE workflow_stages ADD COLUMN description TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE workflow_stages ADD COLUMN acceptance_criteria TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE workflow_stages ADD COLUMN definition_of_ready TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE workflow_stages ADD COLUMN definition_of_done TEXT NOT NULL DEFAULT ''`,
+	} {
+		if _, execErr := raw.Exec(stmt); execErr != nil {
+			_ = raw.Close()
+			t.Fatalf("setup %q error = %v", stmt, execErr)
+		}
+	}
+	if _, execErr := raw.Exec(
+		`UPDATE workflow_stages SET description=?, acceptance_criteria=?, definition_of_ready=?, definition_of_done=?, attrs='{}' WHERE workflow_stage_id=?`,
+		"design phase", "approved design", "brief ready", "design signed off", stage.ID,
+	); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("populate error = %v", execErr)
+	}
+	if _, execErr := raw.Exec(`UPDATE schema_meta SET value='11' WHERE key='schema_version'`); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("set version error = %v", execErr)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw.Close() error = %v", err)
+	}
+
+	if _, err := UpgradeInPlace(ctx, path); err != nil {
+		t.Fatalf("UpgradeInPlace() error = %v", err)
+	}
+
+	db2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() after upgrade error = %v", err)
+	}
+	defer db2.Close()
+
+	got, err := GetWorkflowStage(ctx, db2, stage.ID)
+	if err != nil {
+		t.Fatalf("GetWorkflowStage() error = %v", err)
+	}
+	if got.Description != "design phase" || got.AcceptanceCriteria != "approved design" ||
+		got.DefinitionOfReady != "brief ready" || got.DefinitionOfDone != "design signed off" {
+		t.Fatalf("stage guidance not preserved: %+v", got)
+	}
+	for _, col := range []string{"description", "acceptance_criteria", "definition_of_ready", "definition_of_done"} {
+		if columnExists(ctx, db2, "workflow_stages", col) {
+			t.Errorf("workflow_stages.%s still exists after consolidation", col)
+		}
+	}
+}
+
+// TestConsolidatedStageRoundTripAndExport verifies stage guidance round-trips via
+// typed fields after consolidation, that SetWorkflowStageAttrs preserves guidance,
+// and that workflow export/import still carries the stage description.
+func TestConsolidatedStageRoundTripAndExport(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	wf, err := CreateWorkflow(ctx, db, "wf-rt", "")
+	if err != nil {
+		t.Fatalf("CreateWorkflow() error = %v", err)
+	}
+	stage, err := AddWorkflowStageWithDefinitions(ctx, db, wf.ID, "build", "build it", "branch", "merged", 0)
+	if err != nil {
+		t.Fatalf("AddWorkflowStageWithDefinitions() error = %v", err)
+	}
+	if stage.Description != "build it" || stage.DefinitionOfDone != "merged" {
+		t.Fatalf("stage guidance not round-tripped on create: %+v", stage)
+	}
+
+	// Setting extra attrs must preserve the guidance text.
+	updated, err := SetWorkflowStageAttrs(ctx, db, stage.ID, Attrs{"board_color": "green"})
+	if err != nil {
+		t.Fatalf("SetWorkflowStageAttrs() error = %v", err)
+	}
+	if updated.Description != "build it" {
+		t.Fatalf("SetWorkflowStageAttrs wiped guidance: %+v", updated)
+	}
+	if updated.Attrs.GetString("board_color") != "green" {
+		t.Fatalf("extra attr lost: %#v", updated.Attrs)
+	}
+	if _, dup := updated.Attrs["description"]; dup {
+		t.Fatalf("attrs duplicates guidance field: %#v", updated.Attrs)
+	}
+
+	// Workflow export/import must still carry the stage description.
+	export, err := ExportWorkflow(ctx, db, wf.ID)
+	if err != nil {
+		t.Fatalf("ExportWorkflow() error = %v", err)
+	}
+	export.Name = "wf-rt-copy"
+	imported, err := ImportWorkflow(ctx, db, export)
+	if err != nil {
+		t.Fatalf("ImportWorkflow() error = %v", err)
+	}
+	stages, err := ListWorkflowStages(ctx, db, imported.ID)
+	if err != nil {
+		t.Fatalf("ListWorkflowStages() error = %v", err)
+	}
+	if len(stages) == 0 || stages[0].Description != "build it" {
+		t.Fatalf("export/import did not preserve stage description: %+v", stages)
+	}
+}

--- a/internal/store/consolidate_tickets_test.go
+++ b/internal/store/consolidate_tickets_test.go
@@ -1,0 +1,142 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// TestConsolidateTicketsMigrationNoDataLoss simulates a pre-consolidation (v11)
+// tickets table — the soft columns still present and populated — and verifies the
+// upgrade moves every value into the attrs bag with no data loss, drops the
+// columns, and that the values are still readable via the typed Ticket fields.
+func TestConsolidateTicketsMigrationNoDataLoss(t *testing.T) {
+	// Not parallel: manipulates schema_version and raw columns.
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+	tk, err := CreateTicket(ctx, db, TicketCreateParams{ProjectID: 1, Type: "task", Title: "to-migrate"})
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	// Recreate the pre-consolidation shape.
+	for _, stmt := range []string{
+		`ALTER TABLE tickets ADD COLUMN git_repository TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE tickets ADD COLUMN git_branch TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE tickets ADD COLUMN estimate_complete TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE tickets ADD COLUMN health_score INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE tickets ADD COLUMN author TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE tickets ADD COLUMN pr_url TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE tickets ADD COLUMN open INTEGER NOT NULL DEFAULT 1`,
+	} {
+		if _, execErr := raw.Exec(stmt); execErr != nil {
+			_ = raw.Close()
+			t.Fatalf("setup %q error = %v", stmt, execErr)
+		}
+	}
+	if _, execErr := raw.Exec(
+		`UPDATE tickets SET git_repository=?, git_branch=?, estimate_complete=?, health_score=?, author=?, pr_url=?, attrs='{}' WHERE ticket_id=?`,
+		"git@example.com:x.git", "feature/x", "2026-01-15", 42, "alice", "https://pr/1", tk.ID,
+	); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("populate error = %v", execErr)
+	}
+	if _, execErr := raw.Exec(`UPDATE schema_meta SET value='11' WHERE key='schema_version'`); execErr != nil {
+		_ = raw.Close()
+		t.Fatalf("set version error = %v", execErr)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw.Close() error = %v", err)
+	}
+
+	if _, err := UpgradeInPlace(ctx, path); err != nil {
+		t.Fatalf("UpgradeInPlace() error = %v", err)
+	}
+
+	db2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() after upgrade error = %v", err)
+	}
+	defer db2.Close()
+
+	got, err := GetTicket(ctx, db2, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if got.GitRepository != "git@example.com:x.git" {
+		t.Errorf("GitRepository = %q, want preserved", got.GitRepository)
+	}
+	if got.GitBranch != "feature/x" {
+		t.Errorf("GitBranch = %q, want preserved", got.GitBranch)
+	}
+	if got.EstimateComplete != "2026-01-15" {
+		t.Errorf("EstimateComplete = %q, want preserved", got.EstimateComplete)
+	}
+	if got.HealthScore != 42 {
+		t.Errorf("HealthScore = %d, want 42", got.HealthScore)
+	}
+	if got.Author != "alice" {
+		t.Errorf("Author = %q, want alice", got.Author)
+	}
+	if got.PrURL != "https://pr/1" {
+		t.Errorf("PrURL = %q, want preserved", got.PrURL)
+	}
+
+	// Columns must be gone after consolidation.
+	for _, col := range []string{"git_repository", "git_branch", "estimate_complete", "health_score", "author", "pr_url", "open"} {
+		if columnExists(ctx, db2, "tickets", col) {
+			t.Errorf("tickets.%s still exists after consolidation", col)
+		}
+	}
+}
+
+// TestConsolidatedTicketFieldsRoundTrip verifies the soft fields still work
+// end-to-end through the typed Ticket fields after consolidation, and that the
+// user-visible Attrs bag does not duplicate them.
+func TestConsolidatedTicketFieldsRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	tk, err := CreateTicket(ctx, db, TicketCreateParams{
+		ProjectID: 1, Type: "bug", Title: "rt",
+		GitRepository: "git@x", GitBranch: "main", Author: "bob",
+		Attrs: Attrs{"severity": "high"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+	got, err := GetTicket(ctx, db, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if got.GitRepository != "git@x" || got.GitBranch != "main" || got.Author != "bob" {
+		t.Fatalf("typed soft fields not round-tripped: %+v", got)
+	}
+	// The extra bag keeps the genuinely-extra key but not the typed/back-compat ones.
+	if got.Attrs.GetString("severity") != "high" {
+		t.Fatalf("extra attr lost: %#v", got.Attrs)
+	}
+	if _, dup := got.Attrs["git_repository"]; dup {
+		t.Fatalf("attrs duplicates a typed field: %#v", got.Attrs)
+	}
+
+	// Dedicated setters write through to the bag.
+	if _, err := SetTicketPrURL(ctx, db, tk.ID, "https://pr/9"); err != nil {
+		t.Fatalf("SetTicketPrURL() error = %v", err)
+	}
+	after, err := GetTicket(ctx, db, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if after.PrURL != "https://pr/9" {
+		t.Fatalf("PrURL via setter = %q, want https://pr/9", after.PrURL)
+	}
+}

--- a/internal/store/fold_guidance_maps_test.go
+++ b/internal/store/fold_guidance_maps_test.go
@@ -1,0 +1,164 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// TestFoldTicketGuidanceMapsMigration simulates a pre-fold tickets table with
+// dor_map/dod_map/ac_map columns populated, and verifies the upgrade embeds them
+// into attrs as nested objects with no loss, drops the columns, and the maps remain
+// readable via the typed Ticket fields.
+func TestFoldTicketGuidanceMapsMigration(t *testing.T) {
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+	tk, err := CreateTicket(ctx, db, TicketCreateParams{ProjectID: 1, Type: "task", Title: "g"})
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	for _, stmt := range []string{
+		`ALTER TABLE tickets ADD COLUMN dor_map TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE tickets ADD COLUMN dod_map TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE tickets ADD COLUMN ac_map TEXT NOT NULL DEFAULT '{}'`,
+	} {
+		if _, e := raw.Exec(stmt); e != nil {
+			_ = raw.Close()
+			t.Fatalf("setup %q error = %v", stmt, e)
+		}
+	}
+	if _, e := raw.Exec(`UPDATE tickets SET dor_map=?, dod_map=?, ac_map=?, attrs='{}' WHERE ticket_id=?`,
+		`{"default":"ready"}`, `{"develop":"done"}`, `{"default":"ac"}`, tk.ID); e != nil {
+		_ = raw.Close()
+		t.Fatalf("populate error = %v", e)
+	}
+	if _, e := raw.Exec(`UPDATE schema_meta SET value='11' WHERE key='schema_version'`); e != nil {
+		_ = raw.Close()
+		t.Fatalf("set version error = %v", e)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw.Close() error = %v", err)
+	}
+
+	if _, err := UpgradeInPlace(ctx, path); err != nil {
+		t.Fatalf("UpgradeInPlace() error = %v", err)
+	}
+	db2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() after upgrade error = %v", err)
+	}
+	defer db2.Close()
+	got, err := GetTicket(ctx, db2, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if got.DORMap["default"] != "ready" || got.DODMap["develop"] != "done" || got.ACMap["default"] != "ac" {
+		t.Fatalf("guidance maps not preserved: dor=%#v dod=%#v ac=%#v", got.DORMap, got.DODMap, got.ACMap)
+	}
+	for _, col := range []string{"dor_map", "dod_map", "ac_map"} {
+		if columnExists(ctx, db2, "tickets", col) {
+			t.Errorf("tickets.%s still exists after fold", col)
+		}
+	}
+}
+
+// TestFoldProjectGuidanceMapsMigration is the projects counterpart.
+func TestFoldProjectGuidanceMapsMigration(t *testing.T) {
+	ctx := context.Background()
+	db, path := attrsTestDB(t)
+	p, err := CreateProjectWithParams(ctx, db, ProjectCreateParams{Title: "P", Prefix: "PFG"})
+	if err != nil {
+		t.Fatalf("CreateProjectWithParams() error = %v", err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("db.Close() error = %v", err)
+	}
+
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	for _, stmt := range []string{
+		`ALTER TABLE projects ADD COLUMN dor_map TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE projects ADD COLUMN dod_map TEXT NOT NULL DEFAULT '{}'`,
+		`ALTER TABLE projects ADD COLUMN ac_map TEXT NOT NULL DEFAULT '{}'`,
+	} {
+		if _, e := raw.Exec(stmt); e != nil {
+			_ = raw.Close()
+			t.Fatalf("setup %q error = %v", stmt, e)
+		}
+	}
+	if _, e := raw.Exec(`UPDATE projects SET dor_map=?, dod_map=?, ac_map=?, attrs='{}' WHERE project_id=?`,
+		`{"default":"pready"}`, `{"default":"pdone"}`, `{"default":"pac"}`, p.ID); e != nil {
+		_ = raw.Close()
+		t.Fatalf("populate error = %v", e)
+	}
+	if _, e := raw.Exec(`UPDATE schema_meta SET value='11' WHERE key='schema_version'`); e != nil {
+		_ = raw.Close()
+		t.Fatalf("set version error = %v", e)
+	}
+	if err := raw.Close(); err != nil {
+		t.Fatalf("raw.Close() error = %v", err)
+	}
+
+	if _, err := UpgradeInPlace(ctx, path); err != nil {
+		t.Fatalf("UpgradeInPlace() error = %v", err)
+	}
+	db2, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() after upgrade error = %v", err)
+	}
+	defer db2.Close()
+	got, err := GetProjectByID(ctx, db2, p.ID)
+	if err != nil {
+		t.Fatalf("GetProjectByID() error = %v", err)
+	}
+	if got.DORMap["default"] != "pready" || got.DODMap["default"] != "pdone" || got.ACMap["default"] != "pac" {
+		t.Fatalf("project guidance maps not preserved: dor=%#v dod=%#v ac=%#v", got.DORMap, got.DODMap, got.ACMap)
+	}
+	for _, col := range []string{"dor_map", "dod_map", "ac_map"} {
+		if columnExists(ctx, db2, "projects", col) {
+			t.Errorf("projects.%s still exists after fold", col)
+		}
+	}
+}
+
+// TestFoldGuidanceMapsRoundTrip checks create/read of guidance maps via typed
+// fields after the fold, with no attrs duplication.
+func TestFoldGuidanceMapsRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	tk, err := CreateTicket(ctx, db, TicketCreateParams{
+		ProjectID: 1, Type: "task", Title: "rt",
+		DORMap: GuidanceMap{"default": "x"}, ACMap: GuidanceMap{"default": "y"},
+		Attrs: Attrs{"k": "v"},
+	})
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+	got, err := GetTicket(ctx, db, tk.ID)
+	if err != nil {
+		t.Fatalf("GetTicket() error = %v", err)
+	}
+	if got.DORMap["default"] != "x" || got.ACMap["default"] != "y" {
+		t.Fatalf("guidance maps not round-tripped: %#v / %#v", got.DORMap, got.ACMap)
+	}
+	if got.Attrs.GetString("k") != "v" {
+		t.Fatalf("extra attr lost: %#v", got.Attrs)
+	}
+	for _, k := range []string{"dor_map", "dod_map", "ac_map"} {
+		if _, dup := got.Attrs[k]; dup {
+			t.Fatalf("attrs duplicates guidance map %q: %#v", k, got.Attrs)
+		}
+	}
+}

--- a/internal/store/guidance.go
+++ b/internal/store/guidance.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"encoding/json"
 	"strings"
 )
 
@@ -57,30 +56,6 @@ func withLegacyAcceptanceCriteria(acceptanceCriteria string, acMap GuidanceMap) 
 		normalized[DefaultGuidanceStageKey] = legacy
 	}
 	return normalized
-}
-
-func guidanceMapJSON(m GuidanceMap) (string, error) {
-	normalized := normalizeGuidanceMap(m)
-	if len(normalized) == 0 {
-		return "{}", nil
-	}
-	data, err := json.Marshal(normalized)
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
-}
-
-func parseGuidanceMap(raw string) (GuidanceMap, error) {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return nil, nil
-	}
-	var parsed map[string]string
-	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-		return nil, err
-	}
-	return normalizeGuidanceMap(GuidanceMap(parsed)), nil
 }
 
 func (m GuidanceMap) Resolve(stage string) (string, bool) {

--- a/internal/store/migration_safety_test.go
+++ b/internal/store/migration_safety_test.go
@@ -1,0 +1,186 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// countTickets opens path read-only-ish and returns the number of rows in tickets.
+func countTickets(t *testing.T, path string) int {
+	t.Helper()
+	raw, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer raw.Close()
+	var n int
+	if err := raw.QueryRow(`SELECT COUNT(*) FROM tickets`).Scan(&n); err != nil {
+		t.Fatalf("count tickets error = %v", err)
+	}
+	return n
+}
+
+func currentVersionDBWithTicket(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ticket.db")
+	if err := Init(path, "admin", "secret12"); err != nil {
+		t.Fatalf("Init() error = %v", err)
+	}
+	db, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	_, err = CreateTicket(context.Background(), db, TicketCreateParams{
+		ProjectID: 1, Type: "task", Title: "safety ticket",
+	})
+	if closeErr := db.Close(); closeErr != nil && err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		t.Fatalf("CreateTicket() error = %v", err)
+	}
+	return path
+}
+
+// TestUpgradeInPlaceRollsBackOnFailedMigration injects a migration that mutates the
+// live database and then fails; the original data and schema version must be
+// recovered from the verified backup, and the error must be surfaced.
+func TestUpgradeInPlaceRollsBackOnFailedMigration(t *testing.T) {
+	// Not parallel: mutates the runSchemaUpgrade package seam.
+	path := currentVersionDBWithTicket(t)
+	if got := countTickets(t, path); got != 1 {
+		t.Fatalf("precondition: countTickets = %d, want 1", got)
+	}
+	wantVersion, err := DetectSchemaVersion(path)
+	if err != nil {
+		t.Fatalf("DetectSchemaVersion() error = %v", err)
+	}
+
+	prev := runSchemaUpgrade
+	runSchemaUpgrade = func(ctx context.Context, p string, found int) error {
+		// Destructive change BEFORE failing, to prove rollback restores data.
+		raw, openErr := sql.Open("sqlite", p)
+		if openErr != nil {
+			return openErr
+		}
+		if _, execErr := raw.Exec(`DELETE FROM tickets`); execErr != nil {
+			_ = raw.Close()
+			return execErr
+		}
+		_ = raw.Close()
+		return errors.New("injected migration failure")
+	}
+	defer func() { runSchemaUpgrade = prev }()
+
+	_, upErr := UpgradeInPlace(context.Background(), path)
+	if upErr == nil {
+		t.Fatal("UpgradeInPlace() error = nil, want injected failure")
+	}
+
+	// Data recovered.
+	if got := countTickets(t, path); got != 1 {
+		t.Fatalf("after rollback countTickets = %d, want 1 (data not recovered)", got)
+	}
+	// Schema version unchanged.
+	if got, vErr := DetectSchemaVersion(path); vErr != nil {
+		t.Fatalf("DetectSchemaVersion() after rollback error = %v", vErr)
+	} else if got != wantVersion {
+		t.Fatalf("schema version after rollback = %d, want %d", got, wantVersion)
+	}
+}
+
+// TestUpgradeInPlaceTakesVerifiedBackup confirms a verifiable backup is produced
+// before the migration runs.
+func TestUpgradeInPlaceTakesVerifiedBackup(t *testing.T) {
+	t.Parallel()
+	path := currentVersionDBWithTicket(t)
+
+	res, err := UpgradeInPlaceWithBackup(context.Background(), path)
+	if err != nil {
+		t.Fatalf("UpgradeInPlaceWithBackup() error = %v", err)
+	}
+	if res.BackupPath == "" {
+		t.Fatal("BackupPath is empty; no backup was taken")
+	}
+	if _, statErr := os.Stat(res.BackupPath); statErr != nil {
+		t.Fatalf("backup file missing: %v", statErr)
+	}
+	if vErr := verifyDatabaseBackup(context.Background(), res.BackupPath, res.From); vErr != nil {
+		t.Fatalf("backup did not verify: %v", vErr)
+	}
+}
+
+// TestVerifyDatabaseBackupRejectsBadBackups ensures verification fails for a
+// corrupt file and for a wrong expected version, so a bad backup cannot precede a
+// migration.
+func TestVerifyDatabaseBackupRejectsBadBackups(t *testing.T) {
+	t.Parallel()
+	path := currentVersionDBWithTicket(t)
+	version, err := DetectSchemaVersion(path)
+	if err != nil {
+		t.Fatalf("DetectSchemaVersion() error = %v", err)
+	}
+
+	// Good backup verifies at the right version.
+	if vErr := verifyDatabaseBackup(context.Background(), path, version); vErr != nil {
+		t.Fatalf("good backup failed to verify: %v", vErr)
+	}
+	// Wrong expected version is rejected.
+	if vErr := verifyDatabaseBackup(context.Background(), path, version+1); vErr == nil {
+		t.Fatal("verifyDatabaseBackup() error = nil for wrong version, want error")
+	}
+	// A garbage (non-SQLite) file is rejected.
+	bad := filepath.Join(t.TempDir(), "garbage.db")
+	if writeErr := os.WriteFile(bad, []byte("this is not a sqlite database"), 0o600); writeErr != nil {
+		t.Fatalf("write garbage error = %v", writeErr)
+	}
+	if vErr := verifyDatabaseBackup(context.Background(), bad, version); vErr == nil {
+		t.Fatal("verifyDatabaseBackup() error = nil for corrupt file, want error")
+	}
+}
+
+// TestPruneOldBackupsRetainsNewest verifies the retention policy keeps only the
+// newest N backups.
+func TestPruneOldBackupsRetainsNewest(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	base := filepath.Join(dir, "ticket.db")
+	if err := os.WriteFile(base, []byte("live"), 0o600); err != nil {
+		t.Fatalf("write base error = %v", err)
+	}
+	// Create 7 timestamped backups with sortable suffixes.
+	stamps := []string{
+		"20260101-000001.000000000",
+		"20260101-000002.000000000",
+		"20260101-000003.000000000",
+		"20260101-000004.000000000",
+		"20260101-000005.000000000",
+		"20260101-000006.000000000",
+		"20260101-000007.000000000",
+	}
+	for _, s := range stamps {
+		if err := os.WriteFile(base+".bak-"+s, []byte("b"), 0o600); err != nil {
+			t.Fatalf("write backup error = %v", err)
+		}
+	}
+	if err := pruneOldBackups(base, 3); err != nil {
+		t.Fatalf("pruneOldBackups() error = %v", err)
+	}
+	matches, err := filepath.Glob(base + ".bak-*")
+	if err != nil {
+		t.Fatalf("glob error = %v", err)
+	}
+	if len(matches) != 3 {
+		t.Fatalf("after prune kept %d backups, want 3: %v", len(matches), matches)
+	}
+	// The three newest must remain.
+	for _, s := range stamps[len(stamps)-3:] {
+		if _, statErr := os.Stat(base + ".bak-" + s); statErr != nil {
+			t.Fatalf("expected newest backup %s to remain: %v", s, statErr)
+		}
+	}
+}

--- a/internal/store/project.go
+++ b/internal/store/project.go
@@ -44,6 +44,7 @@ type Project struct {
 	AgentModelURL      string      `json:"agent_model_url"`
 	AgentModelAPIKey   string      `json:"agent_model_api_key"`
 	ProgrammeID        *int64      `json:"programme_id"`
+	Attrs              Attrs       `json:"attrs,omitempty"`
 }
 
 func (p Project) ResolveGuidance(stage string) ResolvedGuidance {
@@ -69,6 +70,7 @@ type ProjectCreateParams struct {
 	AgentModelName     string
 	AgentModelURL      string
 	AgentModelAPIKey   string
+	Attrs              Attrs
 }
 
 type ProjectUpdateParams struct {
@@ -88,6 +90,7 @@ type ProjectUpdateParams struct {
 	AgentModelName     string
 	AgentModelURL      string
 	AgentModelAPIKey   string
+	Attrs              Attrs // nil = preserve existing attrs; non-nil = replace the bag
 }
 
 func CreateProject(ctx context.Context, db *sql.DB, title, description, acceptanceCriteria, createdBy string) (Project, error) {
@@ -152,19 +155,24 @@ func CreateProjectWithParams(ctx context.Context, db *sql.DB, params ProjectCrea
 	if acceptanceCriteria == "" && acMap != nil {
 		acceptanceCriteria = acMap[DefaultGuidanceStageKey]
 	}
+	attrsJSON, err := marshalAttrs(params.Attrs)
+	if err != nil {
+		return Project{}, err
+	}
 	query := `
-		INSERT INTO projects (prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO projects (prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, attrs)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 	args := []any{
 		uniquePrefix, title, strings.TrimSpace(params.Description), acceptanceCriteria, dorJSON, dodJSON, acJSON,
 		strings.TrimSpace(params.GitRepository), strings.TrimSpace(params.Notes), visibility, nullableUserID(params.CreatedBy), workflowID,
 		strings.TrimSpace(params.AgentModelProvider), strings.TrimSpace(params.AgentModelName), strings.TrimSpace(params.AgentModelURL), strings.TrimSpace(params.AgentModelAPIKey),
+		attrsJSON,
 	}
 	if hasExplicitID {
 		query = `
-			INSERT INTO projects (project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?)
+			INSERT INTO projects (project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, attrs)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?, ?)
 		`
 		args = append([]any{explicitID}, args...)
 	}
@@ -200,16 +208,21 @@ func scanProject(s scanner) (Project, error) {
 	var workflowID sql.NullInt64
 	var programmeID sql.NullInt64
 	var dorJSON, dodJSON, acJSON string
+	var attrsJSON sql.NullString
 	if err := s.Scan(
 		&project.ID, &project.Prefix, &project.Title, &project.Description, &project.AcceptanceCriteria,
 		&dorJSON, &dodJSON, &acJSON, &project.GitRepository, &project.Notes, &project.Status, &project.Visibility,
 		&project.DefaultDraft, &project.CreatedBy, &project.CreatedAt, &project.UpdatedAt, &workflowID,
 		&project.AgentModelProvider, &project.AgentModelName, &project.AgentModelURL, &project.AgentModelAPIKey,
-		&programmeID,
+		&programmeID, &attrsJSON,
 	); err != nil {
 		return Project{}, err
 	}
 	var err error
+	project.Attrs, err = parseAttrs(attrsJSON.String)
+	if err != nil {
+		return Project{}, err
+	}
 	project.DORMap, err = parseGuidanceMap(dorJSON)
 	if err != nil {
 		return Project{}, err
@@ -240,7 +253,7 @@ func ListProjects(ctx context.Context, db *sql.DB, limit int) ([]Project, error)
 		limit = 1000
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
 		FROM projects
 		ORDER BY created_at, project_id
 		LIMIT ?
@@ -289,7 +302,7 @@ func ListProjectsVisibleToUser(ctx context.Context, db *sql.DB, user User) ([]Pr
 			FROM teams parent
 			JOIN team_scope ts ON ts.parent_team_id = parent.team_id
 		)
-		SELECT DISTINCT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id
+		SELECT DISTINCT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id, p.attrs
 		FROM projects p
 		LEFT JOIN project_members pm ON pm.project_id = p.project_id AND pm.user_id = ?
 		LEFT JOIN project_teams pt ON pt.project_id = p.project_id
@@ -335,7 +348,7 @@ func GetProject(ctx context.Context, db *sql.DB, rawID string) (Project, error) 
 		return GetProjectByID(ctx, db, id)
 	}
 	row := db.QueryRowContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
 		FROM projects
 		WHERE prefix = ?
 	`, strings.ToUpper(rawID))
@@ -358,7 +371,7 @@ func GetProjectByID(ctx context.Context, db *sql.DB, id int64) (Project, error) 
 		return Project{}, err
 	}
 	row := db.QueryRowContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
 		FROM projects
 		WHERE project_id = ?
 	`, id)
@@ -388,7 +401,7 @@ func GetProjectByGitRepository(ctx context.Context, db *sql.DB, gitRepository st
 		return Project{}, err
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id,
+		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id, p.attrs,
 		       r.repository
 		FROM projects p
 		JOIN project_git_repositories r ON r.project_id = p.project_id
@@ -449,17 +462,22 @@ func scanProjectWithWorkflowIDAndRepository(s scanner) (projectWithRepository, e
 	var workflowID sql.NullInt64
 	var programmeID sql.NullInt64
 	var dorJSON, dodJSON, acJSON string
+	var attrsJSON sql.NullString
 	if err := s.Scan(
 		&result.project.ID, &result.project.Prefix, &result.project.Title, &result.project.Description, &result.project.AcceptanceCriteria,
 		&dorJSON, &dodJSON, &acJSON, &result.project.GitRepository, &result.project.Notes, &result.project.Status, &result.project.Visibility,
 		&result.project.DefaultDraft, &result.project.CreatedBy, &result.project.CreatedAt, &result.project.UpdatedAt, &workflowID,
 		&result.project.AgentModelProvider, &result.project.AgentModelName, &result.project.AgentModelURL, &result.project.AgentModelAPIKey,
-		&programmeID,
+		&programmeID, &attrsJSON,
 		&result.repository,
 	); err != nil {
 		return projectWithRepository{}, err
 	}
 	var err error
+	result.project.Attrs, err = parseAttrs(attrsJSON.String)
+	if err != nil {
+		return projectWithRepository{}, err
+	}
 	result.project.DORMap, err = parseGuidanceMap(dorJSON)
 	if err != nil {
 		return projectWithRepository{}, err
@@ -578,11 +596,19 @@ func UpdateProjectWithParams(ctx context.Context, db *sql.DB, id int64, params P
 	if err != nil {
 		return Project{}, err
 	}
+	attrsToWrite := current.Attrs
+	if params.Attrs != nil {
+		attrsToWrite = params.Attrs
+	}
+	attrsJSON, err := marshalAttrs(attrsToWrite)
+	if err != nil {
+		return Project{}, err
+	}
 	_, err = db.ExecContext(ctx, `
 		UPDATE projects
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, notes = ?, status = ?, visibility = ?, workflow_id = ?, agent_model_provider = ?, agent_model_name = ?, agent_model_url = ?, agent_model_api_key = ?, updated_at = CURRENT_TIMESTAMP
+		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, notes = ?, status = ?, visibility = ?, workflow_id = ?, agent_model_provider = ?, agent_model_name = ?, agent_model_url = ?, agent_model_api_key = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE project_id = ?
-	`, nextTitle, nextDescription, nextAC, dorJSON, dodJSON, acJSON, nextRepo, nextNotes, nextStatus, nextVisibility, nextWorkflowID, nextAgentModelProvider, nextAgentModelName, nextAgentModelURL, nextAgentModelAPIKey, id)
+	`, nextTitle, nextDescription, nextAC, dorJSON, dodJSON, acJSON, nextRepo, nextNotes, nextStatus, nextVisibility, nextWorkflowID, nextAgentModelProvider, nextAgentModelName, nextAgentModelURL, nextAgentModelAPIKey, attrsJSON, id)
 	if err != nil {
 		return Project{}, err
 	}
@@ -612,7 +638,7 @@ func validProjectVisibility(visibility string) bool {
 
 func getProjectByTitle(ctx context.Context, db *sql.DB, title string) (Project, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
 		FROM projects
 		WHERE LOWER(title) = LOWER(?)
 		ORDER BY project_id

--- a/internal/store/project.go
+++ b/internal/store/project.go
@@ -155,24 +155,24 @@ func CreateProjectWithParams(ctx context.Context, db *sql.DB, params ProjectCrea
 	if acceptanceCriteria == "" && acMap != nil {
 		acceptanceCriteria = acMap[DefaultGuidanceStageKey]
 	}
-	attrsJSON, err := marshalAttrs(params.Attrs)
+	// agent_model_* now live in the attrs bag (TK-112).
+	attrsJSON, err := projectAttrsForWrite(params.Attrs, params.AgentModelProvider, params.AgentModelName, params.AgentModelURL, params.AgentModelAPIKey)
 	if err != nil {
 		return Project{}, err
 	}
 	query := `
-		INSERT INTO projects (prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, attrs)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO projects (prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, attrs)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?)
 	`
 	args := []any{
 		uniquePrefix, title, strings.TrimSpace(params.Description), acceptanceCriteria, dorJSON, dodJSON, acJSON,
 		strings.TrimSpace(params.GitRepository), strings.TrimSpace(params.Notes), visibility, nullableUserID(params.CreatedBy), workflowID,
-		strings.TrimSpace(params.AgentModelProvider), strings.TrimSpace(params.AgentModelName), strings.TrimSpace(params.AgentModelURL), strings.TrimSpace(params.AgentModelAPIKey),
 		attrsJSON,
 	}
 	if hasExplicitID {
 		query = `
-			INSERT INTO projects (project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, attrs)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?, ?, ?, ?, ?)
+			INSERT INTO projects (project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, attrs)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?)
 		`
 		args = append([]any{explicitID}, args...)
 	}
@@ -203,6 +203,38 @@ func CreateProjectWithParams(ctx context.Context, db *sql.DB, params ProjectCrea
 	return GetProjectByID(ctx, db, id)
 }
 
+// projectAttrAgentModelKeys are the agent-model config fields that now live in the
+// projects attrs bag (TK-112), surfaced as typed Project fields for back-compat.
+var projectAttrAgentModelKeys = []string{"agent_model_provider", "agent_model_name", "agent_model_url", "agent_model_api_key"}
+
+// hydrateProjectAttrs copies the bag-backed agent-model fields into typed Project
+// fields and strips them from the visible bag.
+func hydrateProjectAttrs(p *Project) {
+	p.AgentModelProvider = p.Attrs.GetString("agent_model_provider")
+	p.AgentModelName = p.Attrs.GetString("agent_model_name")
+	p.AgentModelURL = p.Attrs.GetString("agent_model_url")
+	p.AgentModelAPIKey = p.Attrs.GetString("agent_model_api_key")
+	for _, k := range projectAttrAgentModelKeys {
+		delete(p.Attrs, k)
+	}
+	if len(p.Attrs) == 0 {
+		p.Attrs = nil
+	}
+}
+
+// projectAttrsForWrite merges the bag-backed agent-model fields into a base bag.
+func projectAttrsForWrite(base Attrs, provider, name, url, apiKey string) (string, error) {
+	merged := Attrs{}
+	for k, v := range base {
+		merged[k] = v
+	}
+	merged.SetString("agent_model_provider", strings.TrimSpace(provider))
+	merged.SetString("agent_model_name", strings.TrimSpace(name))
+	merged.SetString("agent_model_url", strings.TrimSpace(url))
+	merged.SetString("agent_model_api_key", strings.TrimSpace(apiKey))
+	return marshalAttrs(merged)
+}
+
 func scanProject(s scanner) (Project, error) {
 	var project Project
 	var workflowID sql.NullInt64
@@ -213,7 +245,6 @@ func scanProject(s scanner) (Project, error) {
 		&project.ID, &project.Prefix, &project.Title, &project.Description, &project.AcceptanceCriteria,
 		&dorJSON, &dodJSON, &acJSON, &project.GitRepository, &project.Notes, &project.Status, &project.Visibility,
 		&project.DefaultDraft, &project.CreatedBy, &project.CreatedAt, &project.UpdatedAt, &workflowID,
-		&project.AgentModelProvider, &project.AgentModelName, &project.AgentModelURL, &project.AgentModelAPIKey,
 		&programmeID, &attrsJSON,
 	); err != nil {
 		return Project{}, err
@@ -223,6 +254,7 @@ func scanProject(s scanner) (Project, error) {
 	if err != nil {
 		return Project{}, err
 	}
+	hydrateProjectAttrs(&project)
 	project.DORMap, err = parseGuidanceMap(dorJSON)
 	if err != nil {
 		return Project{}, err
@@ -253,7 +285,7 @@ func ListProjects(ctx context.Context, db *sql.DB, limit int) ([]Project, error)
 		limit = 1000
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		ORDER BY created_at, project_id
 		LIMIT ?
@@ -302,7 +334,7 @@ func ListProjectsVisibleToUser(ctx context.Context, db *sql.DB, user User) ([]Pr
 			FROM teams parent
 			JOIN team_scope ts ON ts.parent_team_id = parent.team_id
 		)
-		SELECT DISTINCT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id, p.attrs
+		SELECT DISTINCT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs
 		FROM projects p
 		LEFT JOIN project_members pm ON pm.project_id = p.project_id AND pm.user_id = ?
 		LEFT JOIN project_teams pt ON pt.project_id = p.project_id
@@ -348,7 +380,7 @@ func GetProject(ctx context.Context, db *sql.DB, rawID string) (Project, error) 
 		return GetProjectByID(ctx, db, id)
 	}
 	row := db.QueryRowContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		WHERE prefix = ?
 	`, strings.ToUpper(rawID))
@@ -371,7 +403,7 @@ func GetProjectByID(ctx context.Context, db *sql.DB, id int64) (Project, error) 
 		return Project{}, err
 	}
 	row := db.QueryRowContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		WHERE project_id = ?
 	`, id)
@@ -401,7 +433,7 @@ func GetProjectByGitRepository(ctx context.Context, db *sql.DB, gitRepository st
 		return Project{}, err
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id, p.attrs,
+		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs,
 		       r.repository
 		FROM projects p
 		JOIN project_git_repositories r ON r.project_id = p.project_id
@@ -467,7 +499,6 @@ func scanProjectWithWorkflowIDAndRepository(s scanner) (projectWithRepository, e
 		&result.project.ID, &result.project.Prefix, &result.project.Title, &result.project.Description, &result.project.AcceptanceCriteria,
 		&dorJSON, &dodJSON, &acJSON, &result.project.GitRepository, &result.project.Notes, &result.project.Status, &result.project.Visibility,
 		&result.project.DefaultDraft, &result.project.CreatedBy, &result.project.CreatedAt, &result.project.UpdatedAt, &workflowID,
-		&result.project.AgentModelProvider, &result.project.AgentModelName, &result.project.AgentModelURL, &result.project.AgentModelAPIKey,
 		&programmeID, &attrsJSON,
 		&result.repository,
 	); err != nil {
@@ -478,6 +509,7 @@ func scanProjectWithWorkflowIDAndRepository(s scanner) (projectWithRepository, e
 	if err != nil {
 		return projectWithRepository{}, err
 	}
+	hydrateProjectAttrs(&result.project)
 	result.project.DORMap, err = parseGuidanceMap(dorJSON)
 	if err != nil {
 		return projectWithRepository{}, err
@@ -596,19 +628,19 @@ func UpdateProjectWithParams(ctx context.Context, db *sql.DB, id int64, params P
 	if err != nil {
 		return Project{}, err
 	}
-	attrsToWrite := current.Attrs
+	baseAttrs := current.Attrs
 	if params.Attrs != nil {
-		attrsToWrite = params.Attrs
+		baseAttrs = params.Attrs
 	}
-	attrsJSON, err := marshalAttrs(attrsToWrite)
+	attrsJSON, err := projectAttrsForWrite(baseAttrs, nextAgentModelProvider, nextAgentModelName, nextAgentModelURL, nextAgentModelAPIKey)
 	if err != nil {
 		return Project{}, err
 	}
 	_, err = db.ExecContext(ctx, `
 		UPDATE projects
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, notes = ?, status = ?, visibility = ?, workflow_id = ?, agent_model_provider = ?, agent_model_name = ?, agent_model_url = ?, agent_model_api_key = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
+		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, notes = ?, status = ?, visibility = ?, workflow_id = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE project_id = ?
-	`, nextTitle, nextDescription, nextAC, dorJSON, dodJSON, acJSON, nextRepo, nextNotes, nextStatus, nextVisibility, nextWorkflowID, nextAgentModelProvider, nextAgentModelName, nextAgentModelURL, nextAgentModelAPIKey, attrsJSON, id)
+	`, nextTitle, nextDescription, nextAC, dorJSON, dodJSON, acJSON, nextRepo, nextNotes, nextStatus, nextVisibility, nextWorkflowID, attrsJSON, id)
 	if err != nil {
 		return Project{}, err
 	}
@@ -638,7 +670,7 @@ func validProjectVisibility(visibility string) bool {
 
 func getProjectByTitle(ctx context.Context, db *sql.DB, title string) (Project, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, agent_model_provider, agent_model_name, agent_model_url, agent_model_api_key, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		WHERE LOWER(title) = LOWER(?)
 		ORDER BY project_id
@@ -716,7 +748,14 @@ func SetProjectDefaultDraft(ctx context.Context, db *sql.DB, projectID int64, dr
 func SetProjectAgentModelConfig(ctx context.Context, db *sql.DB, projectID int64, cfg AgentModelConfig) (Project, error) {
 	result, err := db.ExecContext(ctx, `
 		UPDATE projects
-		SET agent_model_provider = ?, agent_model_name = ?, agent_model_url = ?, agent_model_api_key = ?, updated_at = CURRENT_TIMESTAMP
+		SET attrs = json_set(
+			json_set(
+				json_set(
+					json_set(attrs, '$.agent_model_provider', ?),
+					'$.agent_model_name', ?),
+				'$.agent_model_url', ?),
+			'$.agent_model_api_key', ?),
+			updated_at = CURRENT_TIMESTAMP
 		WHERE project_id = ?
 	`, strings.TrimSpace(cfg.Provider), strings.TrimSpace(cfg.Model), strings.TrimSpace(cfg.URL), strings.TrimSpace(cfg.APIKey), projectID)
 	if err != nil {

--- a/internal/store/project.go
+++ b/internal/store/project.go
@@ -138,41 +138,29 @@ func CreateProjectWithParams(ctx context.Context, db *sql.DB, params ProjectCrea
 	if err != nil {
 		return Project{}, err
 	}
-	dorJSON, err := guidanceMapJSON(params.DORMap)
-	if err != nil {
-		return Project{}, err
-	}
-	dodJSON, err := guidanceMapJSON(params.DODMap)
-	if err != nil {
-		return Project{}, err
-	}
 	acMap := withLegacyAcceptanceCriteria(params.AcceptanceCriteria, params.ACMap)
-	acJSON, err := guidanceMapJSON(acMap)
-	if err != nil {
-		return Project{}, err
-	}
 	acceptanceCriteria := strings.TrimSpace(params.AcceptanceCriteria)
 	if acceptanceCriteria == "" && acMap != nil {
 		acceptanceCriteria = acMap[DefaultGuidanceStageKey]
 	}
-	// agent_model_* now live in the attrs bag (TK-112).
-	attrsJSON, err := projectAttrsForWrite(params.Attrs, params.AgentModelProvider, params.AgentModelName, params.AgentModelURL, params.AgentModelAPIKey)
+	// agent_model_* (TK-112) and dor/dod/ac guidance maps (TK-115) live in attrs.
+	attrsJSON, err := projectAttrsForWrite(params.Attrs, params.AgentModelProvider, params.AgentModelName, params.AgentModelURL, params.AgentModelAPIKey, params.DORMap, params.DODMap, acMap)
 	if err != nil {
 		return Project{}, err
 	}
 	query := `
-		INSERT INTO projects (prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, attrs)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?)
+		INSERT INTO projects (prefix, title, description, acceptance_criteria, git_repository, notes, status, visibility, created_by, workflow_id, attrs)
+		VALUES (?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?)
 	`
 	args := []any{
-		uniquePrefix, title, strings.TrimSpace(params.Description), acceptanceCriteria, dorJSON, dodJSON, acJSON,
+		uniquePrefix, title, strings.TrimSpace(params.Description), acceptanceCriteria,
 		strings.TrimSpace(params.GitRepository), strings.TrimSpace(params.Notes), visibility, nullableUserID(params.CreatedBy), workflowID,
 		attrsJSON,
 	}
 	if hasExplicitID {
 		query = `
-			INSERT INTO projects (project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, created_by, workflow_id, attrs)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?)
+			INSERT INTO projects (project_id, prefix, title, description, acceptance_criteria, git_repository, notes, status, visibility, created_by, workflow_id, attrs)
+			VALUES (?, ?, ?, ?, ?, ?, ?, 'open', ?, ?, ?, ?)
 		`
 		args = append([]any{explicitID}, args...)
 	}
@@ -214,7 +202,14 @@ func hydrateProjectAttrs(p *Project) {
 	p.AgentModelName = p.Attrs.GetString("agent_model_name")
 	p.AgentModelURL = p.Attrs.GetString("agent_model_url")
 	p.AgentModelAPIKey = p.Attrs.GetString("agent_model_api_key")
+	// Guidance maps folded into the bag (TK-115).
+	p.DORMap = guidanceMapFromAttr(p.Attrs["dor_map"])
+	p.DODMap = guidanceMapFromAttr(p.Attrs["dod_map"])
+	p.ACMap = withLegacyAcceptanceCriteria(p.AcceptanceCriteria, guidanceMapFromAttr(p.Attrs["ac_map"]))
 	for _, k := range projectAttrAgentModelKeys {
+		delete(p.Attrs, k)
+	}
+	for _, k := range []string{"dor_map", "dod_map", "ac_map"} {
 		delete(p.Attrs, k)
 	}
 	if len(p.Attrs) == 0 {
@@ -222,8 +217,9 @@ func hydrateProjectAttrs(p *Project) {
 	}
 }
 
-// projectAttrsForWrite merges the bag-backed agent-model fields into a base bag.
-func projectAttrsForWrite(base Attrs, provider, name, url, apiKey string) (string, error) {
+// projectAttrsForWrite merges the bag-backed agent-model fields and guidance maps
+// into a base bag (TK-112, TK-115).
+func projectAttrsForWrite(base Attrs, provider, name, url, apiKey string, dor, dod, ac GuidanceMap) (string, error) {
 	merged := Attrs{}
 	for k, v := range base {
 		merged[k] = v
@@ -232,6 +228,9 @@ func projectAttrsForWrite(base Attrs, provider, name, url, apiKey string) (strin
 	merged.SetString("agent_model_name", strings.TrimSpace(name))
 	merged.SetString("agent_model_url", strings.TrimSpace(url))
 	merged.SetString("agent_model_api_key", strings.TrimSpace(apiKey))
+	setGuidanceAttr(merged, "dor_map", dor)
+	setGuidanceAttr(merged, "dod_map", dod)
+	setGuidanceAttr(merged, "ac_map", ac)
 	return marshalAttrs(merged)
 }
 
@@ -239,11 +238,10 @@ func scanProject(s scanner) (Project, error) {
 	var project Project
 	var workflowID sql.NullInt64
 	var programmeID sql.NullInt64
-	var dorJSON, dodJSON, acJSON string
 	var attrsJSON sql.NullString
 	if err := s.Scan(
 		&project.ID, &project.Prefix, &project.Title, &project.Description, &project.AcceptanceCriteria,
-		&dorJSON, &dodJSON, &acJSON, &project.GitRepository, &project.Notes, &project.Status, &project.Visibility,
+		&project.GitRepository, &project.Notes, &project.Status, &project.Visibility,
 		&project.DefaultDraft, &project.CreatedBy, &project.CreatedAt, &project.UpdatedAt, &workflowID,
 		&programmeID, &attrsJSON,
 	); err != nil {
@@ -255,19 +253,6 @@ func scanProject(s scanner) (Project, error) {
 		return Project{}, err
 	}
 	hydrateProjectAttrs(&project)
-	project.DORMap, err = parseGuidanceMap(dorJSON)
-	if err != nil {
-		return Project{}, err
-	}
-	project.DODMap, err = parseGuidanceMap(dodJSON)
-	if err != nil {
-		return Project{}, err
-	}
-	project.ACMap, err = parseGuidanceMap(acJSON)
-	if err != nil {
-		return Project{}, err
-	}
-	project.ACMap = withLegacyAcceptanceCriteria(project.AcceptanceCriteria, project.ACMap)
 	if workflowID.Valid {
 		project.WorkflowID = &workflowID.Int64
 	}
@@ -285,7 +270,7 @@ func ListProjects(ctx context.Context, db *sql.DB, limit int) ([]Project, error)
 		limit = 1000
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		ORDER BY created_at, project_id
 		LIMIT ?
@@ -334,7 +319,7 @@ func ListProjectsVisibleToUser(ctx context.Context, db *sql.DB, user User) ([]Pr
 			FROM teams parent
 			JOIN team_scope ts ON ts.parent_team_id = parent.team_id
 		)
-		SELECT DISTINCT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs
+		SELECT DISTINCT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs
 		FROM projects p
 		LEFT JOIN project_members pm ON pm.project_id = p.project_id AND pm.user_id = ?
 		LEFT JOIN project_teams pt ON pt.project_id = p.project_id
@@ -380,7 +365,7 @@ func GetProject(ctx context.Context, db *sql.DB, rawID string) (Project, error) 
 		return GetProjectByID(ctx, db, id)
 	}
 	row := db.QueryRowContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		WHERE prefix = ?
 	`, strings.ToUpper(rawID))
@@ -403,7 +388,7 @@ func GetProjectByID(ctx context.Context, db *sql.DB, id int64) (Project, error) 
 		return Project{}, err
 	}
 	row := db.QueryRowContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		WHERE project_id = ?
 	`, id)
@@ -433,7 +418,7 @@ func GetProjectByGitRepository(ctx context.Context, db *sql.DB, gitRepository st
 		return Project{}, err
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs,
+		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs,
 		       r.repository
 		FROM projects p
 		JOIN project_git_repositories r ON r.project_id = p.project_id
@@ -493,11 +478,10 @@ func scanProjectWithWorkflowIDAndRepository(s scanner) (projectWithRepository, e
 	var result projectWithRepository
 	var workflowID sql.NullInt64
 	var programmeID sql.NullInt64
-	var dorJSON, dodJSON, acJSON string
 	var attrsJSON sql.NullString
 	if err := s.Scan(
 		&result.project.ID, &result.project.Prefix, &result.project.Title, &result.project.Description, &result.project.AcceptanceCriteria,
-		&dorJSON, &dodJSON, &acJSON, &result.project.GitRepository, &result.project.Notes, &result.project.Status, &result.project.Visibility,
+		&result.project.GitRepository, &result.project.Notes, &result.project.Status, &result.project.Visibility,
 		&result.project.DefaultDraft, &result.project.CreatedBy, &result.project.CreatedAt, &result.project.UpdatedAt, &workflowID,
 		&programmeID, &attrsJSON,
 		&result.repository,
@@ -510,19 +494,6 @@ func scanProjectWithWorkflowIDAndRepository(s scanner) (projectWithRepository, e
 		return projectWithRepository{}, err
 	}
 	hydrateProjectAttrs(&result.project)
-	result.project.DORMap, err = parseGuidanceMap(dorJSON)
-	if err != nil {
-		return projectWithRepository{}, err
-	}
-	result.project.DODMap, err = parseGuidanceMap(dodJSON)
-	if err != nil {
-		return projectWithRepository{}, err
-	}
-	result.project.ACMap, err = parseGuidanceMap(acJSON)
-	if err != nil {
-		return projectWithRepository{}, err
-	}
-	result.project.ACMap = withLegacyAcceptanceCriteria(result.project.AcceptanceCriteria, result.project.ACMap)
 	if workflowID.Valid {
 		id := workflowID.Int64
 		result.project.WorkflowID = &id
@@ -616,31 +587,19 @@ func UpdateProjectWithParams(ctx context.Context, db *sql.DB, id int64, params P
 	if nextAgentModelAPIKey == "" {
 		nextAgentModelAPIKey = current.AgentModelAPIKey
 	}
-	dorJSON, err := guidanceMapJSON(nextDORMap)
-	if err != nil {
-		return Project{}, err
-	}
-	dodJSON, err := guidanceMapJSON(nextDODMap)
-	if err != nil {
-		return Project{}, err
-	}
-	acJSON, err := guidanceMapJSON(nextACMap)
-	if err != nil {
-		return Project{}, err
-	}
 	baseAttrs := current.Attrs
 	if params.Attrs != nil {
 		baseAttrs = params.Attrs
 	}
-	attrsJSON, err := projectAttrsForWrite(baseAttrs, nextAgentModelProvider, nextAgentModelName, nextAgentModelURL, nextAgentModelAPIKey)
+	attrsJSON, err := projectAttrsForWrite(baseAttrs, nextAgentModelProvider, nextAgentModelName, nextAgentModelURL, nextAgentModelAPIKey, nextDORMap, nextDODMap, nextACMap)
 	if err != nil {
 		return Project{}, err
 	}
 	_, err = db.ExecContext(ctx, `
 		UPDATE projects
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, notes = ?, status = ?, visibility = ?, workflow_id = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
+		SET title = ?, description = ?, acceptance_criteria = ?, git_repository = ?, notes = ?, status = ?, visibility = ?, workflow_id = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE project_id = ?
-	`, nextTitle, nextDescription, nextAC, dorJSON, dodJSON, acJSON, nextRepo, nextNotes, nextStatus, nextVisibility, nextWorkflowID, attrsJSON, id)
+	`, nextTitle, nextDescription, nextAC, nextRepo, nextNotes, nextStatus, nextVisibility, nextWorkflowID, attrsJSON, id)
 	if err != nil {
 		return Project{}, err
 	}
@@ -670,7 +629,7 @@ func validProjectVisibility(visibility string) bool {
 
 func getProjectByTitle(ctx context.Context, db *sql.DB, title string) (Project, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT project_id, prefix, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
+		SELECT project_id, prefix, title, description, acceptance_criteria, git_repository, notes, status, visibility, default_draft, COALESCE(created_by, ''), created_at, updated_at, workflow_id, programme_id, attrs
 		FROM projects
 		WHERE LOWER(title) = LOWER(?)
 		ORDER BY project_id

--- a/internal/store/project_alias.go
+++ b/internal/store/project_alias.go
@@ -34,7 +34,7 @@ func GetProjectByAlias(ctx context.Context, db *sql.DB, alias, userID string) (P
 	}
 	trimmedUserID := strings.TrimSpace(userID)
 	query := `
-		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id, p.attrs
+		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs
 		FROM project_aliases pa
 		JOIN projects p ON p.project_id = pa.project_id
 		WHERE pa.alias_name = ? AND ((pa.user_id IS NULL AND ? = '') OR pa.user_id = ?)

--- a/internal/store/project_alias.go
+++ b/internal/store/project_alias.go
@@ -34,7 +34,7 @@ func GetProjectByAlias(ctx context.Context, db *sql.DB, alias, userID string) (P
 	}
 	trimmedUserID := strings.TrimSpace(userID)
 	query := `
-		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id
+		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.agent_model_provider, p.agent_model_name, p.agent_model_url, p.agent_model_api_key, p.programme_id, p.attrs
 		FROM project_aliases pa
 		JOIN projects p ON p.project_id = pa.project_id
 		WHERE pa.alias_name = ? AND ((pa.user_id IS NULL AND ? = '') OR pa.user_id = ?)

--- a/internal/store/project_alias.go
+++ b/internal/store/project_alias.go
@@ -34,7 +34,7 @@ func GetProjectByAlias(ctx context.Context, db *sql.DB, alias, userID string) (P
 	}
 	trimmedUserID := strings.TrimSpace(userID)
 	query := `
-		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.dor_map, p.dod_map, p.ac_map, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs
+		SELECT p.project_id, p.prefix, p.title, p.description, p.acceptance_criteria, p.git_repository, p.notes, p.status, p.visibility, p.default_draft, COALESCE(p.created_by, ''), p.created_at, p.updated_at, p.workflow_id, p.programme_id, p.attrs
 		FROM project_aliases pa
 		JOIN projects p ON p.project_id = pa.project_id
 		WHERE pa.alias_name = ? AND ((pa.user_id IS NULL AND ? = '') OR pa.user_id = ?)

--- a/internal/store/reorder.go
+++ b/internal/store/reorder.go
@@ -91,6 +91,7 @@ func ReorderChildTickets(ctx context.Context, db *sql.DB, parentID string, order
 // ListChildTicketsByOrder returns a parent's live children sorted by their
 // explicit sort_order (creation order as tie-break).
 func ListChildTicketsByOrder(ctx context.Context, db *sql.DB, parentID string) ([]Ticket, error) {
+	// #nosec G202 -- ticketSelectColumns is a fixed, code-controlled column list (no user input); values are bound parameters.
 	rows, err := db.QueryContext(ctx, `
 		SELECT `+ticketSelectColumns("")+`
 		FROM tickets

--- a/internal/store/reorder.go
+++ b/internal/store/reorder.go
@@ -92,7 +92,7 @@ func ReorderChildTickets(ctx context.Context, db *sql.DB, parentID string, order
 // explicit sort_order (creation order as tie-break).
 func ListChildTicketsByOrder(ctx context.Context, db *sql.DB, parentID string) ([]Ticket, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
+		SELECT `+ticketSelectColumns("")+`
 		FROM tickets
 		WHERE parent_id = ? AND deleted = 0
 		ORDER BY sort_order, created_at, ticket_id

--- a/internal/store/role.go
+++ b/internal/store/role.go
@@ -105,11 +105,12 @@ func CreateRoleWithParams(ctx context.Context, db *sql.DB, params RoleCreatePara
 // setGuidanceAttr stores a guidance map as a nested object in the bag, or removes
 // the key when the map is empty (keeping the stored bag sparse).
 func setGuidanceAttr(a Attrs, key string, m GuidanceMap) {
-	if len(m) == 0 {
+	n := normalizeGuidanceMap(m)
+	if len(n) == 0 {
 		delete(a, key)
 		return
 	}
-	a[key] = map[string]string(m)
+	a[key] = map[string]string(n)
 }
 
 // hydrateRoleAttrs copies the bag-backed guidance fields into typed Role fields and

--- a/internal/store/role.go
+++ b/internal/store/role.go
@@ -66,36 +66,25 @@ func CreateRoleWithParams(ctx context.Context, db *sql.DB, params RoleCreatePara
 	if err != nil {
 		return Role{}, err
 	}
-	dorJSON, err := guidanceMapJSON(params.DORMap)
-	if err != nil {
-		return Role{}, err
-	}
-	dodJSON, err := guidanceMapJSON(params.DODMap)
-	if err != nil {
-		return Role{}, err
-	}
 	acMap := withLegacyAcceptanceCriteria(params.AcceptanceCriteria, params.ACMap)
-	acJSON, err := guidanceMapJSON(acMap)
-	if err != nil {
-		return Role{}, err
-	}
 	acceptanceCriteria := strings.TrimSpace(params.AcceptanceCriteria)
 	if acceptanceCriteria == "" && acMap != nil {
 		acceptanceCriteria = acMap[DefaultGuidanceStageKey]
 	}
-	attrsJSON, err := marshalAttrs(params.Attrs)
+	// description/acceptance_criteria and dor/dod/ac maps live in the attrs bag (TK-113).
+	attrsJSON, err := roleAttrsForWrite(params.Attrs, params.Description, acceptanceCriteria, params.DORMap, params.DODMap, acMap)
 	if err != nil {
 		return Role{}, err
 	}
 	query := `
-		INSERT INTO roles (workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, attrs, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		INSERT INTO roles (workflow_id, title, attrs, updated_at)
+		VALUES (?, ?, ?, CURRENT_TIMESTAMP)
 	`
-	args := []any{nullableInt64(params.WorkflowID), title, strings.TrimSpace(params.Description), acceptanceCriteria, dorJSON, dodJSON, acJSON, attrsJSON}
+	args := []any{nullableInt64(params.WorkflowID), title, attrsJSON}
 	if hasExplicitID {
 		query = `
-			INSERT INTO roles (role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, attrs, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+			INSERT INTO roles (role_id, workflow_id, title, attrs, updated_at)
+			VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
 		`
 		args = append([]any{explicitID}, args...)
 	}
@@ -113,12 +102,51 @@ func CreateRoleWithParams(ctx context.Context, db *sql.DB, params RoleCreatePara
 	return GetRoleByID(ctx, db, id)
 }
 
+// setGuidanceAttr stores a guidance map as a nested object in the bag, or removes
+// the key when the map is empty (keeping the stored bag sparse).
+func setGuidanceAttr(a Attrs, key string, m GuidanceMap) {
+	if len(m) == 0 {
+		delete(a, key)
+		return
+	}
+	a[key] = map[string]string(m)
+}
+
+// hydrateRoleAttrs copies the bag-backed guidance fields into typed Role fields and
+// strips them from the visible bag (TK-113).
+func hydrateRoleAttrs(r *Role) {
+	r.Description = r.Attrs.GetString("description")
+	r.AcceptanceCriteria = r.Attrs.GetString("acceptance_criteria")
+	r.DORMap = guidanceMapFromAttr(r.Attrs["dor_map"])
+	r.DODMap = guidanceMapFromAttr(r.Attrs["dod_map"])
+	r.ACMap = withLegacyAcceptanceCriteria(r.AcceptanceCriteria, guidanceMapFromAttr(r.Attrs["ac_map"]))
+	for _, k := range []string{"description", "acceptance_criteria", "dor_map", "dod_map", "ac_map"} {
+		delete(r.Attrs, k)
+	}
+	if len(r.Attrs) == 0 {
+		r.Attrs = nil
+	}
+}
+
+// roleAttrsForWrite folds the bag-backed guidance fields into a base bag (TK-113).
+func roleAttrsForWrite(base Attrs, description, acceptanceCriteria string, dor, dod, ac GuidanceMap) (string, error) {
+	merged := Attrs{}
+	for k, v := range base {
+		merged[k] = v
+	}
+	merged.SetString("description", strings.TrimSpace(description))
+	merged.SetString("acceptance_criteria", strings.TrimSpace(acceptanceCriteria))
+	setGuidanceAttr(merged, "dor_map", dor)
+	setGuidanceAttr(merged, "dod_map", dod)
+	setGuidanceAttr(merged, "ac_map", ac)
+	return marshalAttrs(merged)
+}
+
 func scanRoleValues(scan func(dest ...any) error) (Role, error) {
 	var role Role
 	var workflowID sql.NullInt64
-	var dorJSON, dodJSON, acJSON string
 	var attrsJSON sql.NullString
-	if err := scan(&role.ID, &workflowID, &role.Title, &role.Description, &role.AcceptanceCriteria, &dorJSON, &dodJSON, &acJSON, &role.CreatedAt, &role.UpdatedAt, &attrsJSON); err != nil {
+	if err := scan(&role.ID, &workflowID, &role.Title, &role.CreatedAt, &role.UpdatedAt, &attrsJSON); err != nil {
 		return Role{}, err
 	}
 	var err error
@@ -126,19 +154,7 @@ func scanRoleValues(scan func(dest ...any) error) (Role, error) {
 	if err != nil {
 		return Role{}, err
 	}
-	role.DORMap, err = parseGuidanceMap(dorJSON)
-	if err != nil {
-		return Role{}, err
-	}
-	role.DODMap, err = parseGuidanceMap(dodJSON)
-	if err != nil {
-		return Role{}, err
-	}
-	role.ACMap, err = parseGuidanceMap(acJSON)
-	if err != nil {
-		return Role{}, err
-	}
-	role.ACMap = withLegacyAcceptanceCriteria(role.AcceptanceCriteria, role.ACMap)
+	hydrateRoleAttrs(&role)
 	if workflowID.Valid {
 		role.WorkflowID = &workflowID.Int64
 	}
@@ -186,31 +202,19 @@ func UpdateRoleWithParams(ctx context.Context, db *sql.DB, id int64, params Role
 		nextACMap = withLegacyAcceptanceCriteria(params.AcceptanceCriteria, current.ACMap)
 	}
 	nextACMap = withLegacyAcceptanceCriteria(acceptanceCriteria, nextACMap)
-	dorJSON, err := guidanceMapJSON(nextDORMap)
-	if err != nil {
-		return Role{}, err
-	}
-	dodJSON, err := guidanceMapJSON(nextDODMap)
-	if err != nil {
-		return Role{}, err
-	}
-	acJSON, err := guidanceMapJSON(nextACMap)
-	if err != nil {
-		return Role{}, err
-	}
-	attrsToWrite := current.Attrs
+	baseAttrs := current.Attrs
 	if params.Attrs != nil {
-		attrsToWrite = params.Attrs
+		baseAttrs = params.Attrs
 	}
-	attrsJSON, err := marshalAttrs(attrsToWrite)
+	attrsJSON, err := roleAttrsForWrite(baseAttrs, description, acceptanceCriteria, nextDORMap, nextDODMap, nextACMap)
 	if err != nil {
 		return Role{}, err
 	}
 	result, err := db.ExecContext(ctx, `
 		UPDATE roles
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
+		SET title = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE role_id = ?
-	`, title, description, acceptanceCriteria, dorJSON, dodJSON, acJSON, attrsJSON, id)
+	`, title, attrsJSON, id)
 	if err != nil {
 		return Role{}, err
 	}
@@ -229,7 +233,7 @@ func ListRoles(ctx context.Context, db *sql.DB, limit int) ([]Role, error) {
 		limit = 1000
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
+		SELECT role_id, workflow_id, title, created_at, updated_at, attrs
 		FROM roles
 		ORDER BY title
 		LIMIT ?
@@ -243,7 +247,7 @@ func ListRoles(ctx context.Context, db *sql.DB, limit int) ([]Role, error) {
 
 func ListRolesByWorkflow(ctx context.Context, db *sql.DB, workflowID int64) ([]Role, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
+		SELECT role_id, workflow_id, title, created_at, updated_at, attrs
 		FROM roles
 		WHERE workflow_id = ?
 		ORDER BY title
@@ -269,7 +273,7 @@ func scanRoles(rows *sql.Rows) ([]Role, error) {
 
 func GetRoleByID(ctx context.Context, db *sql.DB, id int64) (Role, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
+		SELECT role_id, workflow_id, title, created_at, updated_at, attrs
 		FROM roles
 		WHERE role_id = ?
 	`, id)
@@ -278,7 +282,7 @@ func GetRoleByID(ctx context.Context, db *sql.DB, id int64) (Role, error) {
 
 func GetRoleByTitle(ctx context.Context, db *sql.DB, title string) (Role, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
+		SELECT role_id, workflow_id, title, created_at, updated_at, attrs
 		FROM roles
 		WHERE title = ?
 	`, strings.TrimSpace(title))
@@ -287,7 +291,7 @@ func GetRoleByTitle(ctx context.Context, db *sql.DB, title string) (Role, error)
 
 func getRoleByTitleTx(ctx context.Context, tx *sql.Tx, title string) (Role, error) {
 	row := tx.QueryRowContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
+		SELECT role_id, workflow_id, title, created_at, updated_at, attrs
 		FROM roles
 		WHERE title = ?
 	`, strings.TrimSpace(title))
@@ -356,7 +360,7 @@ func ReorderWorkflowStageRoles(ctx context.Context, db *sql.DB, workflowID, stag
 
 func ListWorkflowStageRoles(ctx context.Context, db *sql.DB, workflowID, stageID int64) ([]Role, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT r.role_id, r.workflow_id, r.title, r.description, r.acceptance_criteria, r.dor_map, r.dod_map, r.ac_map, r.created_at, r.updated_at, r.attrs
+		SELECT r.role_id, r.workflow_id, r.title, r.created_at, r.updated_at, r.attrs
 		FROM workflow_stage_roles sr
 		JOIN roles r ON r.role_id = sr.role_id
 		WHERE sr.workflow_id = ? AND sr.stage_id = ?

--- a/internal/store/role.go
+++ b/internal/store/role.go
@@ -19,6 +19,7 @@ type Role struct {
 	ACMap              GuidanceMap `json:"ac_map,omitempty"`
 	CreatedAt          string      `json:"created_at"`
 	UpdatedAt          string      `json:"updated_at"`
+	Attrs              Attrs       `json:"attrs,omitempty"`
 }
 
 type RoleCreateParams struct {
@@ -30,6 +31,7 @@ type RoleCreateParams struct {
 	DORMap             GuidanceMap
 	DODMap             GuidanceMap
 	ACMap              GuidanceMap
+	Attrs              Attrs
 }
 
 type RoleUpdateParams struct {
@@ -39,6 +41,7 @@ type RoleUpdateParams struct {
 	DORMap             GuidanceMap
 	DODMap             GuidanceMap
 	ACMap              GuidanceMap
+	Attrs              Attrs // nil = preserve existing attrs; non-nil = replace the bag
 }
 
 func (r Role) ResolveGuidance(stage string) ResolvedGuidance {
@@ -80,15 +83,19 @@ func CreateRoleWithParams(ctx context.Context, db *sql.DB, params RoleCreatePara
 	if acceptanceCriteria == "" && acMap != nil {
 		acceptanceCriteria = acMap[DefaultGuidanceStageKey]
 	}
+	attrsJSON, err := marshalAttrs(params.Attrs)
+	if err != nil {
+		return Role{}, err
+	}
 	query := `
-		INSERT INTO roles (workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		INSERT INTO roles (workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, attrs, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 	`
-	args := []any{nullableInt64(params.WorkflowID), title, strings.TrimSpace(params.Description), acceptanceCriteria, dorJSON, dodJSON, acJSON}
+	args := []any{nullableInt64(params.WorkflowID), title, strings.TrimSpace(params.Description), acceptanceCriteria, dorJSON, dodJSON, acJSON, attrsJSON}
 	if hasExplicitID {
 		query = `
-			INSERT INTO roles (role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+			INSERT INTO roles (role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, attrs, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
 		`
 		args = append([]any{explicitID}, args...)
 	}
@@ -110,10 +117,15 @@ func scanRoleValues(scan func(dest ...any) error) (Role, error) {
 	var role Role
 	var workflowID sql.NullInt64
 	var dorJSON, dodJSON, acJSON string
-	if err := scan(&role.ID, &workflowID, &role.Title, &role.Description, &role.AcceptanceCriteria, &dorJSON, &dodJSON, &acJSON, &role.CreatedAt, &role.UpdatedAt); err != nil {
+	var attrsJSON sql.NullString
+	if err := scan(&role.ID, &workflowID, &role.Title, &role.Description, &role.AcceptanceCriteria, &dorJSON, &dodJSON, &acJSON, &role.CreatedAt, &role.UpdatedAt, &attrsJSON); err != nil {
 		return Role{}, err
 	}
 	var err error
+	role.Attrs, err = parseAttrs(attrsJSON.String)
+	if err != nil {
+		return Role{}, err
+	}
 	role.DORMap, err = parseGuidanceMap(dorJSON)
 	if err != nil {
 		return Role{}, err
@@ -186,11 +198,19 @@ func UpdateRoleWithParams(ctx context.Context, db *sql.DB, id int64, params Role
 	if err != nil {
 		return Role{}, err
 	}
+	attrsToWrite := current.Attrs
+	if params.Attrs != nil {
+		attrsToWrite = params.Attrs
+	}
+	attrsJSON, err := marshalAttrs(attrsToWrite)
+	if err != nil {
+		return Role{}, err
+	}
 	result, err := db.ExecContext(ctx, `
 		UPDATE roles
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, updated_at = CURRENT_TIMESTAMP
+		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP
 		WHERE role_id = ?
-	`, title, description, acceptanceCriteria, dorJSON, dodJSON, acJSON, id)
+	`, title, description, acceptanceCriteria, dorJSON, dodJSON, acJSON, attrsJSON, id)
 	if err != nil {
 		return Role{}, err
 	}
@@ -209,7 +229,7 @@ func ListRoles(ctx context.Context, db *sql.DB, limit int) ([]Role, error) {
 		limit = 1000
 	}
 	rows, err := db.QueryContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at
+		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
 		FROM roles
 		ORDER BY title
 		LIMIT ?
@@ -223,7 +243,7 @@ func ListRoles(ctx context.Context, db *sql.DB, limit int) ([]Role, error) {
 
 func ListRolesByWorkflow(ctx context.Context, db *sql.DB, workflowID int64) ([]Role, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at
+		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
 		FROM roles
 		WHERE workflow_id = ?
 		ORDER BY title
@@ -249,7 +269,7 @@ func scanRoles(rows *sql.Rows) ([]Role, error) {
 
 func GetRoleByID(ctx context.Context, db *sql.DB, id int64) (Role, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at
+		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
 		FROM roles
 		WHERE role_id = ?
 	`, id)
@@ -258,7 +278,7 @@ func GetRoleByID(ctx context.Context, db *sql.DB, id int64) (Role, error) {
 
 func GetRoleByTitle(ctx context.Context, db *sql.DB, title string) (Role, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at
+		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
 		FROM roles
 		WHERE title = ?
 	`, strings.TrimSpace(title))
@@ -267,7 +287,7 @@ func GetRoleByTitle(ctx context.Context, db *sql.DB, title string) (Role, error)
 
 func getRoleByTitleTx(ctx context.Context, tx *sql.Tx, title string) (Role, error) {
 	row := tx.QueryRowContext(ctx, `
-		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at
+		SELECT role_id, workflow_id, title, description, acceptance_criteria, dor_map, dod_map, ac_map, created_at, updated_at, attrs
 		FROM roles
 		WHERE title = ?
 	`, strings.TrimSpace(title))
@@ -336,7 +356,7 @@ func ReorderWorkflowStageRoles(ctx context.Context, db *sql.DB, workflowID, stag
 
 func ListWorkflowStageRoles(ctx context.Context, db *sql.DB, workflowID, stageID int64) ([]Role, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT r.role_id, r.workflow_id, r.title, r.description, r.acceptance_criteria, r.dor_map, r.dod_map, r.ac_map, r.created_at, r.updated_at
+		SELECT r.role_id, r.workflow_id, r.title, r.description, r.acceptance_criteria, r.dor_map, r.dod_map, r.ac_map, r.created_at, r.updated_at, r.attrs
 		FROM workflow_stage_roles sr
 		JOIN roles r ON r.role_id = sr.role_id
 		WHERE sr.workflow_id = ? AND sr.stage_id = ?

--- a/internal/store/schema_version.go
+++ b/internal/store/schema_version.go
@@ -8,8 +8,10 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const (
@@ -17,6 +19,9 @@ const (
 	CurrentSchemaVersion = 10
 	schemaMetaTable      = "schema_meta"
 	schemaVersionKey     = "schema_version"
+	// DefaultBackupRetention is the number of timestamped pre-upgrade backups
+	// kept alongside a database; older ones are pruned after a successful upgrade.
+	DefaultBackupRetention = 5
 )
 
 type SchemaVersionError struct {
@@ -229,9 +234,58 @@ func UpgradeDatabase(ctx context.Context, sourcePath, targetPath string) error {
 	return ImportSnapshot(ctx, targetDB, snapshot)
 }
 
+// UpgradeResult describes the outcome of an in-place upgrade.
+type UpgradeResult struct {
+	From       int    // schema version found before the upgrade
+	To         int    // schema version after the upgrade (CurrentSchemaVersion)
+	BackupPath string // path to the verified pre-upgrade backup that was taken
+}
+
+// runSchemaUpgrade performs the actual schema migration for a database whose
+// detected version is found (<= CurrentSchemaVersion). It is held in a package
+// variable so tests can inject a failing migration to exercise rollback; production
+// always uses runSchemaUpgradeDefault.
+var runSchemaUpgrade = runSchemaUpgradeDefault
+
+func runSchemaUpgradeDefault(ctx context.Context, path string, found int) error {
+	if found == CurrentSchemaVersion {
+		db, openErr := openSQLite(path)
+		if openErr != nil {
+			return openErr
+		}
+		defer db.Close()
+		if schemaErr := createSchema(ctx, db); schemaErr != nil {
+			return schemaErr
+		}
+		return enableWAL(ctx, db)
+	}
+
+	// Older schema: rebuild into a fresh database (which brings the schema fully
+	// current and re-imports the data) and atomically swap it into place.
+	tmpDir, err := os.MkdirTemp(filepath.Dir(path), ".tk-upgrade-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+	rebuilt := filepath.Join(tmpDir, "ticket.db")
+	if err := UpgradeDatabase(ctx, path, rebuilt); err != nil {
+		return err
+	}
+	return replaceSQLiteDatabase(rebuilt, path)
+}
+
 // UpgradeInPlace upgrades the database at path so its schema matches the current
 // version, leaving the database at the same path. It returns the schema version
-// found before the upgrade.
+// found before the upgrade. See UpgradeInPlaceWithBackup for the backup details.
+func UpgradeInPlace(ctx context.Context, path string) (int, error) {
+	res, err := UpgradeInPlaceWithBackup(ctx, path)
+	return res.From, err
+}
+
+// UpgradeInPlaceWithBackup upgrades the database at path in place, taking a
+// WAL-checkpointed, integrity-verified backup BEFORE any mutation and rolling the
+// database back from that backup if the migration fails. Every migration path is
+// protected, not just server startup.
 //
 //   - If the database is already at the current version, it re-applies the
 //     idempotent additive migrations in place (createSchema creates any missing
@@ -240,46 +294,148 @@ func UpgradeDatabase(ctx context.Context, sourcePath, targetPath string) error {
 //   - If the database is at an older version, it rebuilds a fresh database from a
 //     snapshot of the upgraded data and atomically swaps it into place.
 //   - If the database is newer than this binary, it returns a SchemaVersionError.
-func UpgradeInPlace(ctx context.Context, path string) (int, error) {
+//
+// On success, backups older than DefaultBackupRetention are pruned.
+func UpgradeInPlaceWithBackup(ctx context.Context, path string) (UpgradeResult, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {
-		return 0, errors.New("database path is required")
+		return UpgradeResult{}, errors.New("database path is required")
 	}
 	found, err := DetectSchemaVersion(path)
 	if err != nil {
-		return 0, err
+		return UpgradeResult{}, err
 	}
+	res := UpgradeResult{From: found, To: CurrentSchemaVersion}
 	if found > CurrentSchemaVersion {
-		return found, &SchemaVersionError{Path: path, Found: found, Current: CurrentSchemaVersion, UpgradeNeeded: false}
+		return res, &SchemaVersionError{Path: path, Found: found, Current: CurrentSchemaVersion, UpgradeNeeded: false}
 	}
 
-	if found == CurrentSchemaVersion {
-		db, openErr := openSQLite(path)
-		if openErr != nil {
-			return found, openErr
-		}
-		defer db.Close()
-		if schemaErr := createSchema(ctx, db); schemaErr != nil {
-			return found, schemaErr
-		}
-		return found, enableWAL(ctx, db)
-	}
-
-	// Older schema: rebuild into a fresh database (which brings the schema fully
-	// current and re-imports the data) and atomically swap it into place.
-	tmpDir, err := os.MkdirTemp(filepath.Dir(path), ".tk-upgrade-")
+	// Take a checkpointed, integrity-verified backup before mutating the live DB.
+	backupPath, err := takeVerifiedBackup(ctx, path, found)
 	if err != nil {
-		return found, err
+		return res, fmt.Errorf("pre-upgrade backup failed: %w", err)
 	}
-	defer os.RemoveAll(tmpDir)
-	rebuilt := filepath.Join(tmpDir, "ticket.db")
-	if err := UpgradeDatabase(ctx, path, rebuilt); err != nil {
-		return found, err
+	res.BackupPath = backupPath
+
+	if migErr := runSchemaUpgrade(ctx, path, found); migErr != nil {
+		if restoreErr := restoreFromBackup(backupPath, path); restoreErr != nil {
+			return res, fmt.Errorf("migration failed (%v) AND automatic rollback failed (%v); restore manually from %s", migErr, restoreErr, backupPath)
+		}
+		return res, fmt.Errorf("migration failed and was rolled back from backup %s: %w", backupPath, migErr)
 	}
-	if err := replaceSQLiteDatabase(rebuilt, path); err != nil {
-		return found, err
+
+	if pruneErr := pruneOldBackups(path, DefaultBackupRetention); pruneErr != nil {
+		// Pruning is best-effort housekeeping; do not fail a successful upgrade.
+		return res, nil //nolint:nilerr // intentional: prune failures must not fail the upgrade
 	}
-	return found, nil
+	return res, nil
+}
+
+// backupPathFor returns a unique timestamped backup path for a database. The
+// nanosecond suffix keeps backups taken in quick succession distinct and sortable.
+func backupPathFor(path string) string {
+	return fmt.Sprintf("%s.bak-%s", path, time.Now().Format("20060102-150405.000000000"))
+}
+
+// takeVerifiedBackup checkpoints the WAL of the live database, copies it (and its
+// sidecars) to a timestamped backup, and verifies that backup with an integrity
+// check and a schema-version read before returning. The live database is not
+// modified.
+func takeVerifiedBackup(ctx context.Context, path string, expectedVersion int) (string, error) {
+	if err := checkpointWAL(ctx, path); err != nil {
+		return "", fmt.Errorf("wal checkpoint failed: %w", err)
+	}
+	backupPath := backupPathFor(path)
+	if err := copySQLiteDatabase(path, backupPath); err != nil {
+		return "", err
+	}
+	if err := verifyDatabaseBackup(ctx, backupPath, expectedVersion); err != nil {
+		return "", fmt.Errorf("backup verification failed: %w", err)
+	}
+	return backupPath, nil
+}
+
+// checkpointWAL flushes the write-ahead log into the main database file so a file
+// copy of the main file is a self-contained, consistent backup. It is harmless on
+// a database that is not in WAL mode.
+func checkpointWAL(ctx context.Context, path string) error {
+	db, err := openSQLite(path)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	_, err = db.ExecContext(ctx, `PRAGMA wal_checkpoint(TRUNCATE);`)
+	return err
+}
+
+// verifyDatabaseBackup opens a backup database, runs PRAGMA integrity_check, and
+// confirms it reports the expected schema version. It returns an error if the
+// backup is unreadable, corrupt, or at an unexpected version.
+func verifyDatabaseBackup(ctx context.Context, path string, expectedVersion int) error {
+	db, err := openSQLite(path)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	var result string
+	if scanErr := db.QueryRowContext(ctx, `PRAGMA integrity_check;`).Scan(&result); scanErr != nil {
+		return scanErr
+	}
+	if !strings.EqualFold(strings.TrimSpace(result), "ok") {
+		return fmt.Errorf("integrity_check returned %q", result)
+	}
+	got, err := readSchemaVersion(ctx, db)
+	if err != nil {
+		return err
+	}
+	if got != expectedVersion {
+		return fmt.Errorf("backup schema version is %d, expected %d", got, expectedVersion)
+	}
+	return nil
+}
+
+// restoreFromBackup restores the live database (and its sidecars) from a backup,
+// used to roll back a failed migration. Stale live sidecars are removed first so
+// the restored main file is authoritative.
+func restoreFromBackup(backupPath, livePath string) error {
+	for _, suffix := range []string{"-wal", "-shm"} {
+		if err := os.Remove(livePath + suffix); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+	}
+	return copySQLiteDatabase(backupPath, livePath)
+}
+
+// pruneOldBackups removes all but the newest keep timestamped backups (and their
+// sidecars) for a database. Backups sort chronologically by their zero-padded
+// timestamp suffix.
+func pruneOldBackups(path string, keep int) error {
+	if keep <= 0 {
+		return nil
+	}
+	matches, err := filepath.Glob(path + ".bak-*")
+	if err != nil {
+		return err
+	}
+	backups := make([]string, 0, len(matches))
+	for _, m := range matches {
+		if strings.HasSuffix(m, "-wal") || strings.HasSuffix(m, "-shm") {
+			continue
+		}
+		backups = append(backups, m)
+	}
+	if len(backups) <= keep {
+		return nil
+	}
+	sort.Strings(backups)
+	for _, b := range backups[:len(backups)-keep] {
+		for _, suffix := range []string{"", "-wal", "-shm"} {
+			if err := os.Remove(b + suffix); err != nil && !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // replaceSQLiteDatabase atomically replaces the database at dst (and its WAL/SHM

--- a/internal/store/schema_version.go
+++ b/internal/store/schema_version.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	LegacySchemaVersion  = 1
-	CurrentSchemaVersion = 11
+	CurrentSchemaVersion = 12
 	schemaMetaTable      = "schema_meta"
 	schemaVersionKey     = "schema_version"
 	// DefaultBackupRetention is the number of timestamped pre-upgrade backups

--- a/internal/store/schema_version.go
+++ b/internal/store/schema_version.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	LegacySchemaVersion  = 1
-	CurrentSchemaVersion = 10
+	CurrentSchemaVersion = 11
 	schemaMetaTable      = "schema_meta"
 	schemaVersionKey     = "schema_version"
 	// DefaultBackupRetention is the number of timestamped pre-upgrade backups

--- a/internal/store/sdlc.go
+++ b/internal/store/sdlc.go
@@ -246,10 +246,16 @@ func AddWorkflowStageWithDefinitions(ctx context.Context, db *sql.DB, workflowID
 	if stageName == "" {
 		return WorkflowStage{}, errors.New("stage name is required")
 	}
+	// guidance text lives in the attrs bag (TK-114); preserve the prior mapping
+	// (description=wow, acceptance_criteria=definition_of_ready=dor, ...).
+	attrsJSON, err := stageAttrsForWrite(nil, wow, dor, dor, dod)
+	if err != nil {
+		return WorkflowStage{}, err
+	}
 	result, err := db.ExecContext(ctx, `
-		INSERT INTO workflow_stages (workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, attrs, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, '{}', CURRENT_TIMESTAMP)
-	`, workflowID, stageName, strings.TrimSpace(wow), strings.TrimSpace(dor), strings.TrimSpace(dor), strings.TrimSpace(dod), sortOrder)
+		INSERT INTO workflow_stages (workflow_id, stage_name, sort_order, attrs, updated_at)
+		VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
+	`, workflowID, stageName, sortOrder, attrsJSON)
 	if err != nil {
 		return WorkflowStage{}, err
 	}
@@ -275,7 +281,13 @@ func SetWorkflowStageBacklog(ctx context.Context, db *sql.DB, stageID int64, isB
 // stage updates do not touch attrs, so the bag is preserved across them; this is
 // the explicit way to write it.
 func SetWorkflowStageAttrs(ctx context.Context, db *sql.DB, stageID int64, attrs Attrs) (WorkflowStage, error) {
-	attrsJSON, err := marshalAttrs(attrs)
+	// The guidance-text fields also live in the bag (TK-114), so replace only the
+	// extra keys and fold the stage's existing guidance text back in.
+	current, err := getWorkflowStageRow(ctx, db, stageID)
+	if err != nil {
+		return WorkflowStage{}, err
+	}
+	attrsJSON, err := stageAttrsForWrite(attrs, current.Description, current.AcceptanceCriteria, current.DefinitionOfReady, current.DefinitionOfDone)
 	if err != nil {
 		return WorkflowStage{}, err
 	}
@@ -305,29 +317,24 @@ func UpdateWorkflowStageWithDefinitions(ctx context.Context, db *sql.DB, stageID
 	if name == "" {
 		return WorkflowStage{}, errors.New("stage name is required")
 	}
-	if isBacklogStage != nil {
-		result, err := db.ExecContext(ctx, `
-			UPDATE workflow_stages
-			SET stage_name = ?, description = ?, acceptance_criteria = ?, definition_of_ready = ?, definition_of_done = ?, is_backlog_stage = ?, updated_at = CURRENT_TIMESTAMP
-			WHERE workflow_stage_id = ?
-		`, name, strings.TrimSpace(wow), strings.TrimSpace(dor), strings.TrimSpace(dor), strings.TrimSpace(dod), *isBacklogStage, stageID)
-		if err != nil {
-			return WorkflowStage{}, err
-		}
-		affected, err := result.RowsAffected()
-		if err != nil {
-			return WorkflowStage{}, err
-		}
-		if affected == 0 {
-			return WorkflowStage{}, sql.ErrNoRows
-		}
-		return getWorkflowStageRow(ctx, db, stageID)
+	// Guidance text lives in the attrs bag (TK-114); fold it in over the stage's
+	// existing extra bag, preserving the prior column mapping
+	// (description=wow, acceptance_criteria=definition_of_ready=dor, ...).
+	current, err := getWorkflowStageRow(ctx, db, stageID)
+	if err != nil {
+		return WorkflowStage{}, err
 	}
-	result, err := db.ExecContext(ctx, `
-		UPDATE workflow_stages
-		SET stage_name = ?, description = ?, acceptance_criteria = ?, definition_of_ready = ?, definition_of_done = ?, updated_at = CURRENT_TIMESTAMP
-		WHERE workflow_stage_id = ?
-	`, name, strings.TrimSpace(wow), strings.TrimSpace(dor), strings.TrimSpace(dor), strings.TrimSpace(dod), stageID)
+	attrsJSON, err := stageAttrsForWrite(current.Attrs, wow, dor, dor, dod)
+	if err != nil {
+		return WorkflowStage{}, err
+	}
+	query := `UPDATE workflow_stages SET stage_name = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP WHERE workflow_stage_id = ?`
+	args := []any{name, attrsJSON, stageID}
+	if isBacklogStage != nil {
+		query = `UPDATE workflow_stages SET stage_name = ?, attrs = ?, is_backlog_stage = ?, updated_at = CURRENT_TIMESTAMP WHERE workflow_stage_id = ?`
+		args = []any{name, attrsJSON, *isBacklogStage, stageID}
+	}
+	result, err := db.ExecContext(ctx, query, args...)
 	if err != nil {
 		return WorkflowStage{}, err
 	}
@@ -599,10 +606,14 @@ func ImportWorkflow(ctx context.Context, db *sql.DB, export WorkflowExport) (Wor
 		if stageName == "" {
 			return Workflow{}, errors.New("workflow stage name is required")
 		}
+		stageAttrsJSON, attrsErr := stageAttrsForWrite(nil, s.Description, "", "", "")
+		if attrsErr != nil {
+			return Workflow{}, attrsErr
+		}
 		stageResult, err := tx.ExecContext(ctx, `
-			INSERT INTO workflow_stages (workflow_id, stage_name, description, sort_order, updated_at)
+			INSERT INTO workflow_stages (workflow_id, stage_name, sort_order, attrs, updated_at)
 			VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP)
-		`, workflowID, stageName, strings.TrimSpace(s.Description), s.SortOrder)
+		`, workflowID, stageName, s.SortOrder, stageAttrsJSON)
 		if err != nil {
 			return Workflow{}, err
 		}
@@ -895,16 +906,44 @@ func getWorkflowRow(ctx context.Context, db *sql.DB, id int64) (Workflow, error)
 	return w, nil
 }
 
+// hydrateStageAttrs copies the bag-backed guidance-text fields into typed
+// WorkflowStage fields and strips them from the visible bag (TK-114).
+func hydrateStageAttrs(s *WorkflowStage) {
+	s.Description = s.Attrs.GetString("description")
+	s.AcceptanceCriteria = s.Attrs.GetString("acceptance_criteria")
+	s.DefinitionOfReady = s.Attrs.GetString("definition_of_ready")
+	s.DefinitionOfDone = s.Attrs.GetString("definition_of_done")
+	for _, k := range []string{"description", "acceptance_criteria", "definition_of_ready", "definition_of_done"} {
+		delete(s.Attrs, k)
+	}
+	if len(s.Attrs) == 0 {
+		s.Attrs = nil
+	}
+}
+
+// stageAttrsForWrite folds the bag-backed guidance-text fields into a base bag.
+func stageAttrsForWrite(base Attrs, description, acceptanceCriteria, definitionOfReady, definitionOfDone string) (string, error) {
+	merged := Attrs{}
+	for k, v := range base {
+		merged[k] = v
+	}
+	merged.SetString("description", strings.TrimSpace(description))
+	merged.SetString("acceptance_criteria", strings.TrimSpace(acceptanceCriteria))
+	merged.SetString("definition_of_ready", strings.TrimSpace(definitionOfReady))
+	merged.SetString("definition_of_done", strings.TrimSpace(definitionOfDone))
+	return marshalAttrs(merged)
+}
+
 func getWorkflowStageRow(ctx context.Context, db *sql.DB, id int64) (WorkflowStage, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT workflow_stage_id, workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at, attrs
+		SELECT workflow_stage_id, workflow_id, stage_name, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at, attrs
 		FROM workflow_stages
 		WHERE workflow_stage_id = ?
 	`, id)
 	var s WorkflowStage
 	var attrsJSON sql.NullString
-	if err := row.Scan(&s.ID, &s.WorkflowID, &s.StageName, &s.Description,
-		&s.AcceptanceCriteria, &s.DefinitionOfReady, &s.DefinitionOfDone, &s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt, &attrsJSON); err != nil {
+	if err := row.Scan(&s.ID, &s.WorkflowID, &s.StageName,
+		&s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt, &attrsJSON); err != nil {
 		return WorkflowStage{}, err
 	}
 	attrs, err := parseAttrs(attrsJSON.String)
@@ -912,6 +951,7 @@ func getWorkflowStageRow(ctx context.Context, db *sql.DB, id int64) (WorkflowSta
 		return WorkflowStage{}, err
 	}
 	s.Attrs = attrs
+	hydrateStageAttrs(&s)
 	roles, err := ListWorkflowStageRoles(ctx, db, s.WorkflowID, s.ID)
 	if err != nil {
 		return WorkflowStage{}, err
@@ -928,7 +968,7 @@ func getWorkflowStageRow(ctx context.Context, db *sql.DB, id int64) (WorkflowSta
 
 func listWorkflowStages(ctx context.Context, db *sql.DB, workflowID int64) ([]WorkflowStage, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT workflow_stage_id, workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at, attrs
+		SELECT workflow_stage_id, workflow_id, stage_name, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at, attrs
 		FROM workflow_stages
 		WHERE workflow_id = ?
 		ORDER BY sort_order, workflow_stage_id
@@ -941,8 +981,8 @@ func listWorkflowStages(ctx context.Context, db *sql.DB, workflowID int64) ([]Wo
 	for rows.Next() {
 		var s WorkflowStage
 		var attrsJSON sql.NullString
-		if scanErr := rows.Scan(&s.ID, &s.WorkflowID, &s.StageName, &s.Description,
-			&s.AcceptanceCriteria, &s.DefinitionOfReady, &s.DefinitionOfDone, &s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt, &attrsJSON); scanErr != nil {
+		if scanErr := rows.Scan(&s.ID, &s.WorkflowID, &s.StageName,
+			&s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt, &attrsJSON); scanErr != nil {
 			return nil, scanErr
 		}
 		attrs, parseErr := parseAttrs(attrsJSON.String)
@@ -950,6 +990,7 @@ func listWorkflowStages(ctx context.Context, db *sql.DB, workflowID int64) ([]Wo
 			return nil, parseErr
 		}
 		s.Attrs = attrs
+		hydrateStageAttrs(&s)
 		stages = append(stages, s)
 	}
 	if rowsErr := rows.Err(); rowsErr != nil {

--- a/internal/store/sdlc.go
+++ b/internal/store/sdlc.go
@@ -39,6 +39,7 @@ type WorkflowStage struct {
 	NextStageIDs       []int64 `json:"next_stage_ids,omitempty"`
 	CreatedAt          string  `json:"created_at"`
 	UpdatedAt          string  `json:"updated_at"`
+	Attrs              Attrs   `json:"attrs,omitempty"`
 }
 
 type WorkflowWithStages struct {
@@ -246,8 +247,8 @@ func AddWorkflowStageWithDefinitions(ctx context.Context, db *sql.DB, workflowID
 		return WorkflowStage{}, errors.New("stage name is required")
 	}
 	result, err := db.ExecContext(ctx, `
-		INSERT INTO workflow_stages (workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+		INSERT INTO workflow_stages (workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, attrs, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, '{}', CURRENT_TIMESTAMP)
 	`, workflowID, stageName, strings.TrimSpace(wow), strings.TrimSpace(dor), strings.TrimSpace(dor), strings.TrimSpace(dod), sortOrder)
 	if err != nil {
 		return WorkflowStage{}, err
@@ -268,6 +269,31 @@ func SetWorkflowStageBacklog(ctx context.Context, db *sql.DB, stageID int64, isB
 		WHERE workflow_stage_id = ?
 	`, isBacklogStage, stageID)
 	return err
+}
+
+// SetWorkflowStageAttrs replaces the extensible attribute bag for a stage. Normal
+// stage updates do not touch attrs, so the bag is preserved across them; this is
+// the explicit way to write it.
+func SetWorkflowStageAttrs(ctx context.Context, db *sql.DB, stageID int64, attrs Attrs) (WorkflowStage, error) {
+	attrsJSON, err := marshalAttrs(attrs)
+	if err != nil {
+		return WorkflowStage{}, err
+	}
+	result, err := db.ExecContext(ctx, `
+		UPDATE workflow_stages SET attrs = ?, updated_at = CURRENT_TIMESTAMP
+		WHERE workflow_stage_id = ?
+	`, attrsJSON, stageID)
+	if err != nil {
+		return WorkflowStage{}, err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return WorkflowStage{}, err
+	}
+	if affected == 0 {
+		return WorkflowStage{}, sql.ErrNoRows
+	}
+	return getWorkflowStageRow(ctx, db, stageID)
 }
 
 func UpdateWorkflowStage(ctx context.Context, db *sql.DB, stageID int64, name, description, acceptanceCriteria string) (WorkflowStage, error) {
@@ -871,15 +897,21 @@ func getWorkflowRow(ctx context.Context, db *sql.DB, id int64) (Workflow, error)
 
 func getWorkflowStageRow(ctx context.Context, db *sql.DB, id int64) (WorkflowStage, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT workflow_stage_id, workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at
+		SELECT workflow_stage_id, workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at, attrs
 		FROM workflow_stages
 		WHERE workflow_stage_id = ?
 	`, id)
 	var s WorkflowStage
+	var attrsJSON sql.NullString
 	if err := row.Scan(&s.ID, &s.WorkflowID, &s.StageName, &s.Description,
-		&s.AcceptanceCriteria, &s.DefinitionOfReady, &s.DefinitionOfDone, &s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt); err != nil {
+		&s.AcceptanceCriteria, &s.DefinitionOfReady, &s.DefinitionOfDone, &s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt, &attrsJSON); err != nil {
 		return WorkflowStage{}, err
 	}
+	attrs, err := parseAttrs(attrsJSON.String)
+	if err != nil {
+		return WorkflowStage{}, err
+	}
+	s.Attrs = attrs
 	roles, err := ListWorkflowStageRoles(ctx, db, s.WorkflowID, s.ID)
 	if err != nil {
 		return WorkflowStage{}, err
@@ -896,7 +928,7 @@ func getWorkflowStageRow(ctx context.Context, db *sql.DB, id int64) (WorkflowSta
 
 func listWorkflowStages(ctx context.Context, db *sql.DB, workflowID int64) ([]WorkflowStage, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT workflow_stage_id, workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at
+		SELECT workflow_stage_id, workflow_id, stage_name, description, acceptance_criteria, definition_of_ready, definition_of_done, sort_order, COALESCE(is_backlog_stage, 0), created_at, updated_at, attrs
 		FROM workflow_stages
 		WHERE workflow_id = ?
 		ORDER BY sort_order, workflow_stage_id
@@ -908,10 +940,16 @@ func listWorkflowStages(ctx context.Context, db *sql.DB, workflowID int64) ([]Wo
 	stages := make([]WorkflowStage, 0)
 	for rows.Next() {
 		var s WorkflowStage
+		var attrsJSON sql.NullString
 		if scanErr := rows.Scan(&s.ID, &s.WorkflowID, &s.StageName, &s.Description,
-			&s.AcceptanceCriteria, &s.DefinitionOfReady, &s.DefinitionOfDone, &s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt); scanErr != nil {
+			&s.AcceptanceCriteria, &s.DefinitionOfReady, &s.DefinitionOfDone, &s.SortOrder, &s.IsBacklogStage, &s.CreatedAt, &s.UpdatedAt, &attrsJSON); scanErr != nil {
 			return nil, scanErr
 		}
+		attrs, parseErr := parseAttrs(attrsJSON.String)
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		s.Attrs = attrs
 		stages = append(stages, s)
 	}
 	if rowsErr := rows.Err(); rowsErr != nil {
@@ -942,7 +980,7 @@ func listWorkflowStages(ctx context.Context, db *sql.DB, workflowID int64) ([]Wo
 // given workflowID in a single query and returns them grouped by stage_id.
 func listWorkflowStageRolesBatch(ctx context.Context, db *sql.DB, workflowID int64) (map[int64][]Role, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT sr.stage_id, r.role_id, r.workflow_id, r.title, r.description, r.acceptance_criteria, r.dor_map, r.dod_map, r.ac_map, r.created_at, r.updated_at
+		SELECT sr.stage_id, r.role_id, r.workflow_id, r.title, r.description, r.acceptance_criteria, r.dor_map, r.dod_map, r.ac_map, r.created_at, r.updated_at, r.attrs
 		FROM workflow_stage_roles sr
 		JOIN roles r ON r.role_id = sr.role_id
 		WHERE sr.workflow_id = ?

--- a/internal/store/sdlc.go
+++ b/internal/store/sdlc.go
@@ -980,7 +980,7 @@ func listWorkflowStages(ctx context.Context, db *sql.DB, workflowID int64) ([]Wo
 // given workflowID in a single query and returns them grouped by stage_id.
 func listWorkflowStageRolesBatch(ctx context.Context, db *sql.DB, workflowID int64) (map[int64][]Role, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT sr.stage_id, r.role_id, r.workflow_id, r.title, r.description, r.acceptance_criteria, r.dor_map, r.dod_map, r.ac_map, r.created_at, r.updated_at, r.attrs
+		SELECT sr.stage_id, r.role_id, r.workflow_id, r.title, r.created_at, r.updated_at, r.attrs
 		FROM workflow_stage_roles sr
 		JOIN roles r ON r.role_id = sr.role_id
 		WHERE sr.workflow_id = ?

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -364,8 +364,6 @@ CREATE TABLE IF NOT EXISTS tickets (
 	dor_map TEXT NOT NULL DEFAULT '{}',
 	dod_map TEXT NOT NULL DEFAULT '{}',
 	ac_map TEXT NOT NULL DEFAULT '{}',
-	git_repository TEXT NOT NULL DEFAULT '',
-	git_branch TEXT NOT NULL DEFAULT '',
 	workflow_stage_id INTEGER,
 	role_id INTEGER,
 	stage TEXT NOT NULL DEFAULT 'develop',
@@ -374,8 +372,6 @@ CREATE TABLE IF NOT EXISTS tickets (
 	priority INTEGER NOT NULL DEFAULT 3,
 	sort_order INTEGER NOT NULL DEFAULT 0,
 	estimate_effort INTEGER NOT NULL DEFAULT 0,
-	estimate_complete TEXT NOT NULL DEFAULT '',
-	health_score INTEGER NOT NULL DEFAULT 0,
 	assignee TEXT NOT NULL DEFAULT '',
 	draft INTEGER NOT NULL DEFAULT 1,
 	complete INTEGER NOT NULL DEFAULT 0,
@@ -1073,16 +1069,9 @@ CREATE TABLE user_notifications (
 			return err
 		}
 	}
-	if !columnExists(ctx, db, "tickets", "estimate_complete") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN estimate_complete TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "tickets", "git_repository") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN git_repository TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
+	// estimate_complete and git_repository moved into the attrs bag (TK-111); their
+	// legacy ADD COLUMN migrations were removed and the columns are dropped by the
+	// attrs-consolidation step below.
 	if !columnExists(ctx, db, "tickets", "dor_map") {
 		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN dor_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
 			return err
@@ -1098,28 +1087,8 @@ CREATE TABLE user_notifications (
 			return err
 		}
 	}
-	if !columnExists(ctx, db, "tickets", "git_branch") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN git_branch TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "tickets", "health_score") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN health_score INTEGER NOT NULL DEFAULT 0`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "tickets", "open") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN open INTEGER NOT NULL DEFAULT 1`); err != nil {
-			return err
-		}
-		// Legacy behavior used archived for close/open. Preserve closed state and reset archived.
-		if _, err := db.ExecContext(ctx, `UPDATE tickets SET open = CASE WHEN archived = 1 THEN 0 ELSE 1 END`); err != nil {
-			return err
-		}
-		if _, err := db.ExecContext(ctx, `UPDATE tickets SET archived = 0`); err != nil {
-			return err
-		}
-	}
+	// git_branch and health_score moved into the attrs bag (TK-111); the legacy
+	// `open` column is dropped entirely. See the attrs-consolidation step below.
 	if !columnExists(ctx, db, "tickets", "deleted") {
 		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN deleted INTEGER NOT NULL DEFAULT 0`); err != nil {
 			return err
@@ -1572,16 +1541,9 @@ CREATE TABLE user_notifications (
 			return err
 		}
 	}
-	// Add author column to store the username of who created the ticket
-	if !columnExists(ctx, db, "tickets", "author") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN author TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-		// Backfill author from created_by user ID
-		if _, err := db.ExecContext(ctx, `UPDATE tickets SET author = COALESCE((SELECT u.username FROM users u WHERE u.user_id = tickets.created_by), '') WHERE author = ''`); err != nil {
-			return err
-		}
-	}
+	// author moved into the attrs bag (TK-111); its legacy ADD COLUMN + backfill
+	// were removed. The attrs-consolidation step below migrates and drops it,
+	// backfilling author from created_by into attrs for rows that lack it.
 	// Account lockout columns for brute-force protection.
 	if !columnExists(ctx, db, "users", "failed_login_attempts") {
 		if _, err := db.ExecContext(ctx, `ALTER TABLE users ADD COLUMN failed_login_attempts INTEGER DEFAULT 0`); err != nil {
@@ -1606,7 +1568,6 @@ CREATE TABLE user_notifications (
 		{table: "tickets", column: "assignee", stmt: `CREATE INDEX IF NOT EXISTS idx_tickets_assignee ON tickets(assignee)`},
 		{table: "tickets", column: "stage", stmt: `CREATE INDEX IF NOT EXISTS idx_tickets_stage ON tickets(stage)`},
 		{table: "tickets", column: "state", stmt: `CREATE INDEX IF NOT EXISTS idx_tickets_state ON tickets(state)`},
-		{table: "tickets", column: "open", stmt: `CREATE INDEX IF NOT EXISTS idx_tickets_open ON tickets(open)`},
 		{table: "tickets", column: "draft", stmt: `CREATE INDEX IF NOT EXISTS idx_tickets_draft ON tickets(draft)`},
 		{table: "tickets", column: "complete", stmt: `CREATE INDEX IF NOT EXISTS idx_tickets_complete ON tickets(complete)`},
 		{table: "tickets", column: "archived", stmt: `CREATE INDEX IF NOT EXISTS idx_tickets_archived ON tickets(archived)`},
@@ -1723,12 +1684,8 @@ CREATE TABLE user_notifications (
 		}
 	}
 
-	// Add pr_url to tickets (developer agent stores PR link after completing).
-	if !columnExists(ctx, db, "tickets", "pr_url") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN pr_url TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
+	// pr_url moved into the attrs bag (TK-111); its legacy ADD COLUMN was removed
+	// and the column is migrated and dropped by the attrs-consolidation step below.
 
 	// Add started_at to tickets: when a ticket enters the active state (TK-88).
 	if !columnExists(ctx, db, "tickets", "started_at") {
@@ -1754,6 +1711,61 @@ CREATE TABLE user_notifications (
 			if _, err := db.ExecContext(ctx, `ALTER TABLE `+table+` ADD COLUMN attrs TEXT NOT NULL DEFAULT '{}'`); err != nil {
 				return err
 			}
+		}
+	}
+
+	// Consolidate tickets soft columns into the attrs bag and drop them (TK-111).
+	// json_set only fills a key that is currently absent, so re-running this never
+	// clobbers a value written through the bag; the column is dropped once its data
+	// is preserved. Runs before the row-reading backfills below so they see the
+	// narrowed shape.
+	for _, col := range []string{"git_repository", "git_branch", "estimate_complete", "pr_url"} {
+		if columnExists(ctx, db, "tickets", col) {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE tickets SET attrs = json_set(attrs, '$.%s', %s) `+
+					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) <> ''`,
+				col, col, col, col)); err != nil {
+				return err
+			}
+			if _, err := db.ExecContext(ctx, `ALTER TABLE tickets DROP COLUMN `+col); err != nil {
+				return err
+			}
+		}
+	}
+	if columnExists(ctx, db, "tickets", "health_score") {
+		if _, err := db.ExecContext(ctx, `UPDATE tickets SET attrs = json_set(attrs, '$.health_score', health_score) `+
+			`WHERE json_extract(attrs, '$.health_score') IS NULL AND COALESCE(health_score, 0) <> 0`); err != nil {
+			return err
+		}
+		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets DROP COLUMN health_score`); err != nil {
+			return err
+		}
+	}
+	if columnExists(ctx, db, "tickets", "author") {
+		// Preserve an explicit author, else backfill from the creator's username
+		// (the behaviour the old author column migration had), all into attrs.
+		if _, err := db.ExecContext(ctx, `UPDATE tickets SET attrs = json_set(attrs, '$.author', author) `+
+			`WHERE json_extract(attrs, '$.author') IS NULL AND TRIM(COALESCE(author, '')) <> ''`); err != nil {
+			return err
+		}
+		if _, err := db.ExecContext(ctx, `UPDATE tickets SET attrs = json_set(attrs, '$.author', `+
+			`(SELECT u.username FROM users u WHERE u.user_id = tickets.created_by)) `+
+			`WHERE json_extract(attrs, '$.author') IS NULL `+
+			`AND TRIM(COALESCE((SELECT u.username FROM users u WHERE u.user_id = tickets.created_by), '')) <> ''`); err != nil {
+			return err
+		}
+		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets DROP COLUMN author`); err != nil {
+			return err
+		}
+	}
+	// The legacy `open` column is dead (superseded by complete/archived). Drop its
+	// index (a column cannot be dropped while indexed) and the column itself.
+	if columnExists(ctx, db, "tickets", "open") {
+		if _, err := db.ExecContext(ctx, `DROP INDEX IF EXISTS idx_tickets_open`); err != nil {
+			return err
+		}
+		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets DROP COLUMN open`); err != nil {
+			return err
 		}
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -281,6 +281,7 @@ CREATE TABLE IF NOT EXISTS roles (
 	dor_map TEXT NOT NULL DEFAULT '{}',
 	dod_map TEXT NOT NULL DEFAULT '{}',
 	ac_map TEXT NOT NULL DEFAULT '{}',
+	attrs TEXT NOT NULL DEFAULT '{}',
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	FOREIGN KEY(workflow_id) REFERENCES workflows(workflow_id),
@@ -310,6 +311,7 @@ CREATE TABLE IF NOT EXISTS projects (
 	agent_model_name TEXT NOT NULL DEFAULT '',
 	agent_model_url TEXT NOT NULL DEFAULT '',
 	agent_model_api_key TEXT NOT NULL DEFAULT '',
+	attrs TEXT NOT NULL DEFAULT '{}',
 	FOREIGN KEY(created_by) REFERENCES users(user_id),
 	FOREIGN KEY(workflow_id) REFERENCES workflows(workflow_id)
 );
@@ -385,6 +387,7 @@ CREATE TABLE IF NOT EXISTS tickets (
 	created_by TEXT,
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	attrs TEXT NOT NULL DEFAULT '{}',
 	FOREIGN KEY(project_id) REFERENCES projects(project_id),
 	FOREIGN KEY(parent_id) REFERENCES tickets(ticket_id),
 	FOREIGN KEY(clone_of) REFERENCES tickets(ticket_id),
@@ -606,6 +609,7 @@ CREATE TABLE IF NOT EXISTS workflow_stages (
 	is_backlog_stage INTEGER NOT NULL DEFAULT 0,
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	attrs TEXT NOT NULL DEFAULT '{}',
 	FOREIGN KEY(workflow_id) REFERENCES workflows(workflow_id),
 	UNIQUE(workflow_id, stage_name)
 );
@@ -1737,6 +1741,19 @@ CREATE TABLE user_notifications (
 	if !columnExists(ctx, db, "users", "agent_role") {
 		if _, err := db.ExecContext(ctx, `ALTER TABLE users ADD COLUMN agent_role TEXT NOT NULL DEFAULT ''`); err != nil {
 			return err
+		}
+	}
+
+	// Add the extensible JSON attribute bag (TK-109) to the high-churn entities.
+	// Stored as TEXT JSON (not binary JSONB) so it survives the generic snapshot
+	// export/import used by backups and the migration rebuild path; json_extract
+	// queries and expression indexes work identically on TEXT. A constant '{}'
+	// default is permitted on ADD COLUMN, so no backfill is required.
+	for _, table := range []string{"tickets", "projects", "roles", "workflow_stages"} {
+		if !columnExists(ctx, db, table, "attrs") {
+			if _, err := db.ExecContext(ctx, `ALTER TABLE `+table+` ADD COLUMN attrs TEXT NOT NULL DEFAULT '{}'`); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -289,9 +289,6 @@ CREATE TABLE IF NOT EXISTS projects (
 	title TEXT NOT NULL,
 	description TEXT NOT NULL DEFAULT '',
 	acceptance_criteria TEXT NOT NULL DEFAULT '',
-	dor_map TEXT NOT NULL DEFAULT '{}',
-	dod_map TEXT NOT NULL DEFAULT '{}',
-	ac_map TEXT NOT NULL DEFAULT '{}',
 	git_repository TEXT NOT NULL DEFAULT '',
 	notes TEXT NOT NULL DEFAULT '',
 	status TEXT NOT NULL DEFAULT 'open',
@@ -352,9 +349,6 @@ CREATE TABLE IF NOT EXISTS tickets (
 	title TEXT NOT NULL,
 	description TEXT NOT NULL DEFAULT '',
 	acceptance_criteria TEXT NOT NULL DEFAULT '',
-	dor_map TEXT NOT NULL DEFAULT '{}',
-	dod_map TEXT NOT NULL DEFAULT '{}',
-	ac_map TEXT NOT NULL DEFAULT '{}',
 	workflow_stage_id INTEGER,
 	role_id INTEGER,
 	stage TEXT NOT NULL DEFAULT 'develop',
@@ -921,21 +915,9 @@ func migrateSchema(ctx context.Context, db *sql.DB) error {
 			return err
 		}
 	}
-	if !columnExists(ctx, db, "projects", "dor_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN dor_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "projects", "dod_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN dod_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "projects", "ac_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN ac_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
+	// projects dor_map/dod_map/ac_map are folded into the attrs bag (TK-115); their
+	// legacy ADD COLUMN migrations were removed and the columns are migrated and
+	// dropped by the attrs-consolidation step below.
 	if columnExists(ctx, db, "projects", "git_branch") {
 		if _, err := db.ExecContext(ctx, `ALTER TABLE projects DROP COLUMN git_branch`); err != nil {
 			return err
@@ -1044,21 +1026,9 @@ CREATE TABLE user_notifications (
 	// estimate_complete and git_repository moved into the attrs bag (TK-111); their
 	// legacy ADD COLUMN migrations were removed and the columns are dropped by the
 	// attrs-consolidation step below.
-	if !columnExists(ctx, db, "tickets", "dor_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN dor_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "tickets", "dod_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN dod_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "tickets", "ac_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets ADD COLUMN ac_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
+	// tickets dor_map/dod_map/ac_map are folded into the attrs bag (TK-115); their
+	// legacy ADD COLUMN migrations were removed and the columns are migrated and
+	// dropped by the attrs-consolidation step below.
 	// git_branch and health_score moved into the attrs bag (TK-111); the legacy
 	// `open` column is dropped entirely. See the attrs-consolidation step below.
 	if !columnExists(ctx, db, "tickets", "deleted") {
@@ -1721,6 +1691,21 @@ CREATE TABLE user_notifications (
 			return err
 		}
 	}
+	// Fold tickets guidance maps into the attrs bag and drop them (TK-115); embedded
+	// as nested JSON objects via json(col). Non-clobbering and idempotent.
+	for _, col := range []string{"dor_map", "dod_map", "ac_map"} {
+		if columnExists(ctx, db, "tickets", col) {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE tickets SET attrs = json_set(attrs, '$.%s', json(%s)) `+
+					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) NOT IN ('', '{}')`,
+				col, col, col, col)); err != nil {
+				return err
+			}
+			if _, err := db.ExecContext(ctx, `ALTER TABLE tickets DROP COLUMN `+col); err != nil {
+				return err
+			}
+		}
+	}
 
 	// Consolidate projects agent-model config columns into the attrs bag and drop
 	// them (TK-112). Same idempotent, non-clobbering pattern as tickets above.
@@ -1729,6 +1714,20 @@ CREATE TABLE user_notifications (
 			if _, err := db.ExecContext(ctx, fmt.Sprintf(
 				`UPDATE projects SET attrs = json_set(attrs, '$.%s', %s) `+
 					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) <> ''`,
+				col, col, col, col)); err != nil {
+				return err
+			}
+			if _, err := db.ExecContext(ctx, `ALTER TABLE projects DROP COLUMN `+col); err != nil {
+				return err
+			}
+		}
+	}
+	// Fold projects guidance maps into the attrs bag and drop them (TK-115).
+	for _, col := range []string{"dor_map", "dod_map", "ac_map"} {
+		if columnExists(ctx, db, "projects", col) {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE projects SET attrs = json_set(attrs, '$.%s', json(%s)) `+
+					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) NOT IN ('', '{}')`,
 				col, col, col, col)); err != nil {
 				return err
 			}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -307,10 +307,6 @@ CREATE TABLE IF NOT EXISTS projects (
 	ticket_sequence INTEGER NOT NULL DEFAULT 0,
 	default_draft INTEGER NOT NULL DEFAULT 0,
 	workflow_id INTEGER,
-	agent_model_provider TEXT NOT NULL DEFAULT '',
-	agent_model_name TEXT NOT NULL DEFAULT '',
-	agent_model_url TEXT NOT NULL DEFAULT '',
-	agent_model_api_key TEXT NOT NULL DEFAULT '',
 	attrs TEXT NOT NULL DEFAULT '{}',
 	FOREIGN KEY(created_by) REFERENCES users(user_id),
 	FOREIGN KEY(workflow_id) REFERENCES workflows(workflow_id)
@@ -972,26 +968,9 @@ func migrateSchema(ctx context.Context, db *sql.DB) error {
 			return err
 		}
 	}
-	if !columnExists(ctx, db, "projects", "agent_model_provider") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN agent_model_provider TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "projects", "agent_model_name") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN agent_model_name TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "projects", "agent_model_url") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN agent_model_url TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "projects", "agent_model_api_key") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE projects ADD COLUMN agent_model_api_key TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
+	// agent_model_provider/name/url/api_key moved into the projects attrs bag
+	// (TK-112); their legacy ADD COLUMN migrations were removed and the columns are
+	// migrated and dropped by the attrs-consolidation step below.
 	if _, err := db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_projects_workflow_id ON projects(workflow_id)`); err != nil {
 		return err
 	}
@@ -1766,6 +1745,22 @@ CREATE TABLE user_notifications (
 		}
 		if _, err := db.ExecContext(ctx, `ALTER TABLE tickets DROP COLUMN open`); err != nil {
 			return err
+		}
+	}
+
+	// Consolidate projects agent-model config columns into the attrs bag and drop
+	// them (TK-112). Same idempotent, non-clobbering pattern as tickets above.
+	for _, col := range []string{"agent_model_provider", "agent_model_name", "agent_model_url", "agent_model_api_key"} {
+		if columnExists(ctx, db, "projects", col) {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE projects SET attrs = json_set(attrs, '$.%s', %s) `+
+					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) <> ''`,
+				col, col, col, col)); err != nil {
+				return err
+			}
+			if _, err := db.ExecContext(ctx, `ALTER TABLE projects DROP COLUMN `+col); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -276,11 +276,6 @@ CREATE TABLE IF NOT EXISTS roles (
 	role_id INTEGER PRIMARY KEY AUTOINCREMENT,
 	workflow_id INTEGER,
 	title TEXT NOT NULL,
-	description TEXT NOT NULL DEFAULT '',
-	acceptance_criteria TEXT NOT NULL DEFAULT '',
-	dor_map TEXT NOT NULL DEFAULT '{}',
-	dod_map TEXT NOT NULL DEFAULT '{}',
-	ac_map TEXT NOT NULL DEFAULT '{}',
 	attrs TEXT NOT NULL DEFAULT '{}',
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -1093,21 +1088,9 @@ CREATE TABLE user_notifications (
 			return err
 		}
 	}
-	if !columnExists(ctx, db, "roles", "dor_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE roles ADD COLUMN dor_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "roles", "dod_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE roles ADD COLUMN dod_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "roles", "ac_map") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE roles ADD COLUMN ac_map TEXT NOT NULL DEFAULT '{}'`); err != nil {
-			return err
-		}
-	}
+	// roles description/acceptance_criteria/dor_map/dod_map/ac_map are folded into
+	// the roles attrs bag (TK-113); their legacy ADD COLUMN migrations were removed
+	// and the columns are migrated and dropped by the attrs-consolidation step below.
 	if _, err := db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_tickets_workflow_stage_id ON tickets(workflow_stage_id)`); err != nil {
 		return err
 	}
@@ -1759,6 +1742,37 @@ CREATE TABLE user_notifications (
 				return err
 			}
 			if _, err := db.ExecContext(ctx, `ALTER TABLE projects DROP COLUMN `+col); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Fold roles guidance columns into the attrs bag and drop them (TK-113). The
+	// scalar text fields (description, acceptance_criteria) are stored as strings;
+	// the guidance maps (dor_map/dod_map/ac_map) are embedded as nested JSON objects
+	// via json(col). Non-clobbering and idempotent.
+	for _, col := range []string{"description", "acceptance_criteria"} {
+		if columnExists(ctx, db, "roles", col) {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE roles SET attrs = json_set(attrs, '$.%s', %s) `+
+					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) <> ''`,
+				col, col, col, col)); err != nil {
+				return err
+			}
+			if _, err := db.ExecContext(ctx, `ALTER TABLE roles DROP COLUMN `+col); err != nil {
+				return err
+			}
+		}
+	}
+	for _, col := range []string{"dor_map", "dod_map", "ac_map"} {
+		if columnExists(ctx, db, "roles", col) {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE roles SET attrs = json_set(attrs, '$.%s', json(%s)) `+
+					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) NOT IN ('', '{}')`,
+				col, col, col, col)); err != nil {
+				return err
+			}
+			if _, err := db.ExecContext(ctx, `ALTER TABLE roles DROP COLUMN `+col); err != nil {
 				return err
 			}
 		}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -590,8 +590,6 @@ CREATE TABLE IF NOT EXISTS workflow_stages (
 	workflow_stage_id INTEGER PRIMARY KEY AUTOINCREMENT,
 	workflow_id INTEGER NOT NULL,
 	stage_name TEXT NOT NULL,
-	description TEXT NOT NULL DEFAULT '',
-	acceptance_criteria TEXT NOT NULL DEFAULT '',
 	sort_order INTEGER NOT NULL DEFAULT 0,
 	is_backlog_stage INTEGER NOT NULL DEFAULT 0,
 	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -1216,17 +1214,10 @@ CREATE TABLE user_notifications (
 	if err := backfillTicketWorkflowStages(ctx, db); err != nil {
 		return err
 	}
-	// Add DoR/DoD to workflow stages
-	if !columnExists(ctx, db, "workflow_stages", "definition_of_ready") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE workflow_stages ADD COLUMN definition_of_ready TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
-	if !columnExists(ctx, db, "workflow_stages", "definition_of_done") {
-		if _, err := db.ExecContext(ctx, `ALTER TABLE workflow_stages ADD COLUMN definition_of_done TEXT NOT NULL DEFAULT ''`); err != nil {
-			return err
-		}
-	}
+	// workflow_stages description/acceptance_criteria/definition_of_ready/
+	// definition_of_done are folded into the stage attrs bag (TK-114); their legacy
+	// ADD COLUMN migrations were removed and the columns are migrated and dropped by
+	// the attrs-consolidation step below.
 	// Add new columns to users for merged agent support
 	if !columnExists(ctx, db, "users", "user_type") {
 		if _, err := db.ExecContext(ctx, `ALTER TABLE users ADD COLUMN user_type TEXT NOT NULL DEFAULT 'user'`); err != nil {
@@ -1773,6 +1764,22 @@ CREATE TABLE user_notifications (
 				return err
 			}
 			if _, err := db.ExecContext(ctx, `ALTER TABLE roles DROP COLUMN `+col); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Fold workflow_stages guidance text columns into the attrs bag and drop them
+	// (TK-114). All four are scalar text. Non-clobbering and idempotent.
+	for _, col := range []string{"description", "acceptance_criteria", "definition_of_ready", "definition_of_done"} {
+		if columnExists(ctx, db, "workflow_stages", col) {
+			if _, err := db.ExecContext(ctx, fmt.Sprintf(
+				`UPDATE workflow_stages SET attrs = json_set(attrs, '$.%s', %s) `+
+					`WHERE json_extract(attrs, '$.%s') IS NULL AND TRIM(COALESCE(%s, '')) <> ''`,
+				col, col, col, col)); err != nil {
+				return err
+			}
+			if _, err := db.ExecContext(ctx, `ALTER TABLE workflow_stages DROP COLUMN `+col); err != nil {
 				return err
 			}
 		}

--- a/internal/store/ticket.go
+++ b/internal/store/ticket.go
@@ -285,14 +285,16 @@ func CreateTicket(ctx context.Context, db *sql.DB, params TicketCreateParams) (T
 	if err != nil {
 		return Ticket{}, err
 	}
-	attrsJSON, err := marshalAttrs(params.Attrs)
+	// git_repository, git_branch, estimate_complete, author (and health_score,
+	// pr_url which default to 0/"") now live in the attrs bag (TK-111).
+	attrsJSON, err := ticketAttrsForWrite(params.Attrs, params.GitRepository, params.GitBranch, params.EstimateComplete, params.Author, "", 0)
 	if err != nil {
 		return Ticket{}, err
 	}
 	_, err = tx.ExecContext(ctx, `
-		INSERT INTO tickets (ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, author, draft, created_by, attrs)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, key, params.ProjectID, nullableString(params.ParentID), nullableString(params.CloneOf), params.Type, params.Title, params.Description, acceptanceCriteria, dorJSON, dodJSON, acJSON, strings.TrimSpace(params.GitRepository), strings.TrimSpace(params.GitBranch), nullableInt64(ticketWorkflowID), nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), priority, order, params.EstimateEffort, strings.TrimSpace(params.EstimateComplete), 0, strings.TrimSpace(params.Assignee), strings.TrimSpace(params.Author), 1, nullableUserID(params.CreatedBy), attrsJSON)
+		INSERT INTO tickets (ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, assignee, draft, created_by, attrs)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, key, params.ProjectID, nullableString(params.ParentID), nullableString(params.CloneOf), params.Type, params.Title, params.Description, acceptanceCriteria, dorJSON, dodJSON, acJSON, nullableInt64(ticketWorkflowID), nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), priority, order, params.EstimateEffort, strings.TrimSpace(params.Assignee), 1, nullableUserID(params.CreatedBy), attrsJSON)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -561,12 +563,15 @@ writeTicket:
 	if !reopened && current.Complete {
 		completeVal = 1
 	}
-	// attrs: preserve the existing bag unless the caller supplies a replacement.
-	attrsToWrite := current.Attrs
+	// attrs: start from the existing extra bag (or a caller-supplied replacement)
+	// and fold the bag-backed soft fields in (TK-111). git_repository/git_branch/
+	// estimate_complete follow this update's values; author/pr_url/health_score are
+	// not edited here, so the current values are preserved.
+	baseAttrs := current.Attrs
 	if params.Attrs != nil {
-		attrsToWrite = params.Attrs
+		baseAttrs = params.Attrs
 	}
-	attrsJSON, err := marshalAttrs(attrsToWrite)
+	attrsJSON, err := ticketAttrsForWrite(baseAttrs, nextGitRepository, nextGitBranch, strings.TrimSpace(params.EstimateComplete), current.Author, current.PrURL, current.HealthScore)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -574,10 +579,10 @@ writeTicket:
 	// active state; otherwise preserve the existing value (TK-88).
 	result, err := db.ExecContext(ctx, `
 		UPDATE tickets
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, git_branch = ?, parent_id = ?, assignee = ?, workflow_stage_id = ?, role_id = ?, stage = ?, state = ?, status = ?, priority = ?, sort_order = ?, estimate_effort = ?, estimate_complete = ?, complete = ?, type = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP,
+		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, parent_id = ?, assignee = ?, workflow_stage_id = ?, role_id = ?, stage = ?, state = ?, status = ?, priority = ?, sort_order = ?, estimate_effort = ?, complete = ?, type = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP,
 			started_at = CASE WHEN ? = 'active' AND ? != 'active' THEN CURRENT_TIMESTAMP ELSE ? END
 		WHERE ticket_id = ?
-	`, title, params.Description, nextAcceptanceCriteria, dorJSON, dodJSON, acJSON, nextGitRepository, nextGitBranch, nullableString(params.ParentID), assignee, nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), params.Priority, params.Order, params.EstimateEffort, strings.TrimSpace(params.EstimateComplete), completeVal, nextType, attrsJSON, state, current.State, current.StartedAt, id)
+	`, title, params.Description, nextAcceptanceCriteria, dorJSON, dodJSON, acJSON, nullableString(params.ParentID), assignee, nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), params.Priority, params.Order, params.EstimateEffort, completeVal, nextType, attrsJSON, state, current.State, current.StartedAt, id)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -819,7 +824,7 @@ func MarkTicketReady(ctx context.Context, db *sql.DB, id, actorUsername, actorID
 // SetTicketPrURL stores the PR URL on a ticket after a developer agent creates it.
 func SetTicketPrURL(ctx context.Context, db *sql.DB, id, prURL string) (Ticket, error) {
 	result, err := db.ExecContext(ctx, `
-		UPDATE tickets SET pr_url = ?, updated_at = CURRENT_TIMESTAMP WHERE ticket_id = ?
+		UPDATE tickets SET attrs = json_set(attrs, '$.pr_url', ?), updated_at = CURRENT_TIMESTAMP WHERE ticket_id = ?
 	`, strings.TrimSpace(prURL), id)
 	if err != nil {
 		return Ticket{}, err
@@ -1201,7 +1206,7 @@ func SetTicketHealth(ctx context.Context, db *sql.DB, id string, score int) (Tic
 	}
 	result, err := db.ExecContext(ctx, `
 		UPDATE tickets
-		SET health_score = ?, updated_at = CURRENT_TIMESTAMP
+		SET attrs = json_set(attrs, '$.health_score', ?), updated_at = CURRENT_TIMESTAMP
 		WHERE ticket_id = ?
 	`, score, id)
 	if err != nil {
@@ -1485,22 +1490,61 @@ type scanner interface {
 var ticketColumnNames = []string{
 	"ticket_id", "project_id", "parent_id", "clone_of", "type", "title",
 	"description", "acceptance_criteria", "dor_map", "dod_map", "ac_map",
-	"git_repository", "git_branch", "workflow_id", "workflow_stage_id", "role_id",
+	"workflow_id", "workflow_stage_id", "role_id",
 	"stage", "state", "status", "priority", "sort_order", "estimate_effort",
-	"estimate_complete", "health_score", "assignee", "author", "draft", "complete",
+	"assignee", "draft", "complete",
 	"archived", "deleted", "previous_workflow_stage_id", "previous_role_id",
 	"release_id", "created_by", "created_at", "updated_at", "recommended_ready",
-	"pr_url", "started_at", "attrs",
+	"started_at", "attrs",
 }
 
 // ticketColumnCoalesce maps nullable columns to the SQL literal substituted via
 // COALESCE when selecting them, so scanTicket can scan into non-pointer fields.
 var ticketColumnCoalesce = map[string]string{
-	"author":            "''",
 	"created_by":        "''",
 	"recommended_ready": "0",
-	"pr_url":            "''",
 	"started_at":        "''",
+}
+
+// ticketAttrStringKeys are the soft string fields that now live in the attrs bag
+// (TK-111) and are surfaced as typed Ticket fields for back-compat.
+var ticketAttrStringKeys = []string{"git_repository", "git_branch", "estimate_complete", "author", "pr_url"}
+
+const ticketAttrHealthScoreKey = "health_score"
+
+// hydrateTicketAttrs copies the bag-backed soft fields out of t.Attrs into their
+// typed Ticket fields and removes them from the user-visible bag (so they are not
+// duplicated). It is the read-side of the attrs consolidation.
+func hydrateTicketAttrs(t *Ticket) {
+	t.GitRepository = t.Attrs.GetString("git_repository")
+	t.GitBranch = t.Attrs.GetString("git_branch")
+	t.EstimateComplete = t.Attrs.GetString("estimate_complete")
+	t.Author = t.Attrs.GetString("author")
+	t.PrURL = t.Attrs.GetString("pr_url")
+	t.HealthScore = t.Attrs.GetInt(ticketAttrHealthScoreKey)
+	for _, k := range ticketAttrStringKeys {
+		delete(t.Attrs, k)
+	}
+	delete(t.Attrs, ticketAttrHealthScoreKey)
+	if len(t.Attrs) == 0 {
+		t.Attrs = nil
+	}
+}
+
+// ticketAttrsForWrite merges the bag-backed typed fields into a base bag and
+// returns the JSON text to store. It is the write-side of the attrs consolidation.
+func ticketAttrsForWrite(base Attrs, gitRepository, gitBranch, estimateComplete, author, prURL string, healthScore int) (string, error) {
+	merged := Attrs{}
+	for k, v := range base {
+		merged[k] = v
+	}
+	merged.SetString("git_repository", strings.TrimSpace(gitRepository))
+	merged.SetString("git_branch", strings.TrimSpace(gitBranch))
+	merged.SetString("estimate_complete", strings.TrimSpace(estimateComplete))
+	merged.SetString("author", strings.TrimSpace(author))
+	merged.SetString("pr_url", strings.TrimSpace(prURL))
+	merged.SetInt(ticketAttrHealthScoreKey, healthScore)
+	return marshalAttrs(merged)
 }
 
 // ticketSelectColumns returns the comma-separated SELECT expressions for reading a
@@ -1562,8 +1606,6 @@ func scanTicket(s scanner) (Ticket, error) {
 		&dorJSON,
 		&dodJSON,
 		&acJSON,
-		&ticket.GitRepository,
-		&ticket.GitBranch,
 		&workflowID,
 		&workflowStageID,
 		&roleID,
@@ -1573,10 +1615,7 @@ func scanTicket(s scanner) (Ticket, error) {
 		&ticket.Priority,
 		&ticket.Order,
 		&ticket.EstimateEffort,
-		&ticket.EstimateComplete,
-		&ticket.HealthScore,
 		&ticket.Assignee,
-		&ticket.Author,
 		&draft,
 		&complete,
 		&archived,
@@ -1588,7 +1627,6 @@ func scanTicket(s scanner) (Ticket, error) {
 		&ticket.CreatedAt,
 		&ticket.UpdatedAt,
 		&recommendedReady,
-		&ticket.PrURL,
 		&ticket.StartedAt,
 		&attrsJSON,
 	); err != nil {
@@ -1645,6 +1683,7 @@ func scanTicket(s scanner) (Ticket, error) {
 	ticket.Archived = archived == 1
 	ticket.Deleted = deleted == 1
 	ticket.RecommendedReady = recommendedReady == 1
+	hydrateTicketAttrs(&ticket)
 	return ticket, nil
 }
 

--- a/internal/store/ticket.go
+++ b/internal/store/ticket.go
@@ -198,19 +198,7 @@ func CreateTicket(ctx context.Context, db *sql.DB, params TicketCreateParams) (T
 	if state == StateActive && strings.TrimSpace(params.Assignee) == "" {
 		return Ticket{}, errors.New("active ticket requires assignee")
 	}
-	dorJSON, err := guidanceMapJSON(params.DORMap)
-	if err != nil {
-		return Ticket{}, err
-	}
-	dodJSON, err := guidanceMapJSON(params.DODMap)
-	if err != nil {
-		return Ticket{}, err
-	}
 	acMap := withLegacyAcceptanceCriteria(params.AcceptanceCriteria, params.ACMap)
-	acJSON, err := guidanceMapJSON(acMap)
-	if err != nil {
-		return Ticket{}, err
-	}
 	acceptanceCriteria := strings.TrimSpace(params.AcceptanceCriteria)
 	if acceptanceCriteria == "" && acMap != nil {
 		acceptanceCriteria = acMap[DefaultGuidanceStageKey]
@@ -287,14 +275,14 @@ func CreateTicket(ctx context.Context, db *sql.DB, params TicketCreateParams) (T
 	}
 	// git_repository, git_branch, estimate_complete, author (and health_score,
 	// pr_url which default to 0/"") now live in the attrs bag (TK-111).
-	attrsJSON, err := ticketAttrsForWrite(params.Attrs, params.GitRepository, params.GitBranch, params.EstimateComplete, params.Author, "", 0)
+	attrsJSON, err := ticketAttrsForWrite(params.Attrs, params.GitRepository, params.GitBranch, params.EstimateComplete, params.Author, "", 0, params.DORMap, params.DODMap, acMap)
 	if err != nil {
 		return Ticket{}, err
 	}
 	_, err = tx.ExecContext(ctx, `
-		INSERT INTO tickets (ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, assignee, draft, created_by, attrs)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, key, params.ProjectID, nullableString(params.ParentID), nullableString(params.CloneOf), params.Type, params.Title, params.Description, acceptanceCriteria, dorJSON, dodJSON, acJSON, nullableInt64(ticketWorkflowID), nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), priority, order, params.EstimateEffort, strings.TrimSpace(params.Assignee), 1, nullableUserID(params.CreatedBy), attrsJSON)
+		INSERT INTO tickets (ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, assignee, draft, created_by, attrs)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, key, params.ProjectID, nullableString(params.ParentID), nullableString(params.CloneOf), params.Type, params.Title, params.Description, acceptanceCriteria, nullableInt64(ticketWorkflowID), nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), priority, order, params.EstimateEffort, strings.TrimSpace(params.Assignee), 1, nullableUserID(params.CreatedBy), attrsJSON)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -407,18 +395,6 @@ func UpdateTicket(ctx context.Context, db *sql.DB, id string, params TicketUpdat
 		nextACMap = withLegacyAcceptanceCriteria(params.AcceptanceCriteria, current.ACMap)
 	}
 	nextACMap = withLegacyAcceptanceCriteria(nextAcceptanceCriteria, nextACMap)
-	dorJSON, err := guidanceMapJSON(nextDORMap)
-	if err != nil {
-		return Ticket{}, err
-	}
-	dodJSON, err := guidanceMapJSON(nextDODMap)
-	if err != nil {
-		return Ticket{}, err
-	}
-	acJSON, err := guidanceMapJSON(nextACMap)
-	if err != nil {
-		return Ticket{}, err
-	}
 	if assignmentErr := validateTicketAssignmentChange(current.Assignee, assignee, params.ActorUsername, params.ActorRole); assignmentErr != nil {
 		return Ticket{}, assignmentErr
 	}
@@ -571,7 +547,8 @@ writeTicket:
 	if params.Attrs != nil {
 		baseAttrs = params.Attrs
 	}
-	attrsJSON, err := ticketAttrsForWrite(baseAttrs, nextGitRepository, nextGitBranch, strings.TrimSpace(params.EstimateComplete), current.Author, current.PrURL, current.HealthScore)
+	// Guidance maps (dor/dod/ac) are also folded into the bag (TK-115).
+	attrsJSON, err := ticketAttrsForWrite(baseAttrs, nextGitRepository, nextGitBranch, strings.TrimSpace(params.EstimateComplete), current.Author, current.PrURL, current.HealthScore, nextDORMap, nextDODMap, nextACMap)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -579,10 +556,10 @@ writeTicket:
 	// active state; otherwise preserve the existing value (TK-88).
 	result, err := db.ExecContext(ctx, `
 		UPDATE tickets
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, parent_id = ?, assignee = ?, workflow_stage_id = ?, role_id = ?, stage = ?, state = ?, status = ?, priority = ?, sort_order = ?, estimate_effort = ?, complete = ?, type = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP,
+		SET title = ?, description = ?, acceptance_criteria = ?, parent_id = ?, assignee = ?, workflow_stage_id = ?, role_id = ?, stage = ?, state = ?, status = ?, priority = ?, sort_order = ?, estimate_effort = ?, complete = ?, type = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP,
 			started_at = CASE WHEN ? = 'active' AND ? != 'active' THEN CURRENT_TIMESTAMP ELSE ? END
 		WHERE ticket_id = ?
-	`, title, params.Description, nextAcceptanceCriteria, dorJSON, dodJSON, acJSON, nullableString(params.ParentID), assignee, nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), params.Priority, params.Order, params.EstimateEffort, completeVal, nextType, attrsJSON, state, current.State, current.StartedAt, id)
+	`, title, params.Description, nextAcceptanceCriteria, nullableString(params.ParentID), assignee, nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), params.Priority, params.Order, params.EstimateEffort, completeVal, nextType, attrsJSON, state, current.State, current.StartedAt, id)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -1492,7 +1469,7 @@ type scanner interface {
 // SELECT in this package.
 var ticketColumnNames = []string{
 	"ticket_id", "project_id", "parent_id", "clone_of", "type", "title",
-	"description", "acceptance_criteria", "dor_map", "dod_map", "ac_map",
+	"description", "acceptance_criteria",
 	"workflow_id", "workflow_stage_id", "role_id",
 	"stage", "state", "status", "priority", "sort_order", "estimate_effort",
 	"assignee", "draft", "complete",
@@ -1525,10 +1502,17 @@ func hydrateTicketAttrs(t *Ticket) {
 	t.Author = t.Attrs.GetString("author")
 	t.PrURL = t.Attrs.GetString("pr_url")
 	t.HealthScore = t.Attrs.GetInt(ticketAttrHealthScoreKey)
+	// Guidance maps folded into the bag (TK-115).
+	t.DORMap = guidanceMapFromAttr(t.Attrs["dor_map"])
+	t.DODMap = guidanceMapFromAttr(t.Attrs["dod_map"])
+	t.ACMap = withLegacyAcceptanceCriteria(t.AcceptanceCriteria, guidanceMapFromAttr(t.Attrs["ac_map"]))
 	for _, k := range ticketAttrStringKeys {
 		delete(t.Attrs, k)
 	}
 	delete(t.Attrs, ticketAttrHealthScoreKey)
+	for _, k := range []string{"dor_map", "dod_map", "ac_map"} {
+		delete(t.Attrs, k)
+	}
 	if len(t.Attrs) == 0 {
 		t.Attrs = nil
 	}
@@ -1536,7 +1520,7 @@ func hydrateTicketAttrs(t *Ticket) {
 
 // ticketAttrsForWrite merges the bag-backed typed fields into a base bag and
 // returns the JSON text to store. It is the write-side of the attrs consolidation.
-func ticketAttrsForWrite(base Attrs, gitRepository, gitBranch, estimateComplete, author, prURL string, healthScore int) (string, error) {
+func ticketAttrsForWrite(base Attrs, gitRepository, gitBranch, estimateComplete, author, prURL string, healthScore int, dor, dod, ac GuidanceMap) (string, error) {
 	merged := Attrs{}
 	for k, v := range base {
 		merged[k] = v
@@ -1547,6 +1531,9 @@ func ticketAttrsForWrite(base Attrs, gitRepository, gitBranch, estimateComplete,
 	merged.SetString("author", strings.TrimSpace(author))
 	merged.SetString("pr_url", strings.TrimSpace(prURL))
 	merged.SetInt(ticketAttrHealthScoreKey, healthScore)
+	setGuidanceAttr(merged, "dor_map", dor)
+	setGuidanceAttr(merged, "dod_map", dod)
+	setGuidanceAttr(merged, "ac_map", ac)
 	return marshalAttrs(merged)
 }
 
@@ -1584,9 +1571,6 @@ func scanTicket(s scanner) (Ticket, error) {
 	var workflowID sql.NullInt64
 	var workflowStageID sql.NullInt64
 	var roleID sql.NullInt64
-	var dorJSON string
-	var dodJSON string
-	var acJSON string
 	var storedStatus string
 	var draft int
 	var complete int
@@ -1606,9 +1590,6 @@ func scanTicket(s scanner) (Ticket, error) {
 		&ticket.Title,
 		&ticket.Description,
 		&ticket.AcceptanceCriteria,
-		&dorJSON,
-		&dodJSON,
-		&acJSON,
 		&workflowID,
 		&workflowStageID,
 		&roleID,
@@ -1665,21 +1646,6 @@ func scanTicket(s scanner) (Ticket, error) {
 		v := int(releaseID.Int64)
 		ticket.ReleaseID = &v
 	}
-	dorMap, err := parseGuidanceMap(dorJSON)
-	if err != nil {
-		return Ticket{}, err
-	}
-	dodMap, err := parseGuidanceMap(dodJSON)
-	if err != nil {
-		return Ticket{}, err
-	}
-	acMap, err := parseGuidanceMap(acJSON)
-	if err != nil {
-		return Ticket{}, err
-	}
-	ticket.DORMap = dorMap
-	ticket.DODMap = dodMap
-	ticket.ACMap = withLegacyAcceptanceCriteria(ticket.AcceptanceCriteria, acMap)
 	ticket.Status = RenderLifecycleStatus(ticket.Stage, ticket.State)
 	ticket.Draft = draft == 1
 	ticket.Complete = complete == 1

--- a/internal/store/ticket.go
+++ b/internal/store/ticket.go
@@ -58,6 +58,7 @@ type Ticket struct {
 	CreatedBy               string      `json:"created_by"`
 	CreatedAt               string      `json:"created_at"`
 	UpdatedAt               string      `json:"updated_at"`
+	Attrs                   Attrs       `json:"attrs,omitempty"`
 }
 
 func (t Ticket) ResolveGuidance(stage string) ResolvedGuidance {
@@ -86,6 +87,7 @@ type TicketCreateParams struct {
 	Author             string
 	State              string
 	CreatedBy          string
+	Attrs              Attrs
 }
 
 type TicketUpdateParams struct {
@@ -111,6 +113,7 @@ type TicketUpdateParams struct {
 	Type               string // if non-empty, update the ticket type
 	ReleaseID          *int   // nil = don't change, use SetReleaseID flag to clear
 	SetReleaseID       bool   // true = apply ReleaseID (even if nil, meaning clear it)
+	Attrs              Attrs  // nil = preserve existing attrs; non-nil = replace the bag
 }
 
 type TicketListParams struct {
@@ -282,10 +285,14 @@ func CreateTicket(ctx context.Context, db *sql.DB, params TicketCreateParams) (T
 	if err != nil {
 		return Ticket{}, err
 	}
+	attrsJSON, err := marshalAttrs(params.Attrs)
+	if err != nil {
+		return Ticket{}, err
+	}
 	_, err = tx.ExecContext(ctx, `
-		INSERT INTO tickets (ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, author, draft, created_by)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-	`, key, params.ProjectID, nullableString(params.ParentID), nullableString(params.CloneOf), params.Type, params.Title, params.Description, acceptanceCriteria, dorJSON, dodJSON, acJSON, strings.TrimSpace(params.GitRepository), strings.TrimSpace(params.GitBranch), nullableInt64(ticketWorkflowID), nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), priority, order, params.EstimateEffort, strings.TrimSpace(params.EstimateComplete), 0, strings.TrimSpace(params.Assignee), strings.TrimSpace(params.Author), 1, nullableUserID(params.CreatedBy))
+		INSERT INTO tickets (ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, author, draft, created_by, attrs)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	`, key, params.ProjectID, nullableString(params.ParentID), nullableString(params.CloneOf), params.Type, params.Title, params.Description, acceptanceCriteria, dorJSON, dodJSON, acJSON, strings.TrimSpace(params.GitRepository), strings.TrimSpace(params.GitBranch), nullableInt64(ticketWorkflowID), nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), priority, order, params.EstimateEffort, strings.TrimSpace(params.EstimateComplete), 0, strings.TrimSpace(params.Assignee), strings.TrimSpace(params.Author), 1, nullableUserID(params.CreatedBy), attrsJSON)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -554,14 +561,23 @@ writeTicket:
 	if !reopened && current.Complete {
 		completeVal = 1
 	}
+	// attrs: preserve the existing bag unless the caller supplies a replacement.
+	attrsToWrite := current.Attrs
+	if params.Attrs != nil {
+		attrsToWrite = params.Attrs
+	}
+	attrsJSON, err := marshalAttrs(attrsToWrite)
+	if err != nil {
+		return Ticket{}, err
+	}
 	// started_at records when work began: stamp it on the transition INTO the
 	// active state; otherwise preserve the existing value (TK-88).
 	result, err := db.ExecContext(ctx, `
 		UPDATE tickets
-		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, git_branch = ?, parent_id = ?, assignee = ?, workflow_stage_id = ?, role_id = ?, stage = ?, state = ?, status = ?, priority = ?, sort_order = ?, estimate_effort = ?, estimate_complete = ?, complete = ?, type = ?, updated_at = CURRENT_TIMESTAMP,
+		SET title = ?, description = ?, acceptance_criteria = ?, dor_map = ?, dod_map = ?, ac_map = ?, git_repository = ?, git_branch = ?, parent_id = ?, assignee = ?, workflow_stage_id = ?, role_id = ?, stage = ?, state = ?, status = ?, priority = ?, sort_order = ?, estimate_effort = ?, estimate_complete = ?, complete = ?, type = ?, attrs = ?, updated_at = CURRENT_TIMESTAMP,
 			started_at = CASE WHEN ? = 'active' AND ? != 'active' THEN CURRENT_TIMESTAMP ELSE ? END
 		WHERE ticket_id = ?
-	`, title, params.Description, nextAcceptanceCriteria, dorJSON, dodJSON, acJSON, nextGitRepository, nextGitBranch, nullableString(params.ParentID), assignee, nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), params.Priority, params.Order, params.EstimateEffort, strings.TrimSpace(params.EstimateComplete), completeVal, nextType, state, current.State, current.StartedAt, id)
+	`, title, params.Description, nextAcceptanceCriteria, dorJSON, dodJSON, acJSON, nextGitRepository, nextGitBranch, nullableString(params.ParentID), assignee, nullableInt64(workflowStageID), nullableInt64(roleID), stage, state, RenderLifecycleStatus(stage, state), params.Priority, params.Order, params.EstimateEffort, strings.TrimSpace(params.EstimateComplete), completeVal, nextType, attrsJSON, state, current.State, current.StartedAt, id)
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -1474,7 +1490,7 @@ var ticketColumnNames = []string{
 	"estimate_complete", "health_score", "assignee", "author", "draft", "complete",
 	"archived", "deleted", "previous_workflow_stage_id", "previous_role_id",
 	"release_id", "created_by", "created_at", "updated_at", "recommended_ready",
-	"pr_url", "started_at",
+	"pr_url", "started_at", "attrs",
 }
 
 // ticketColumnCoalesce maps nullable columns to the SQL literal substituted via
@@ -1533,6 +1549,7 @@ func scanTicket(s scanner) (Ticket, error) {
 	var prevRoleID sql.NullInt64
 	var releaseID sql.NullInt64
 	var recommendedReady int
+	var attrsJSON sql.NullString
 	if err := s.Scan(
 		&ticket.ID,
 		&ticket.ProjectID,
@@ -1573,9 +1590,15 @@ func scanTicket(s scanner) (Ticket, error) {
 		&recommendedReady,
 		&ticket.PrURL,
 		&ticket.StartedAt,
+		&attrsJSON,
 	); err != nil {
 		return Ticket{}, err
 	}
+	attrs, err := parseAttrs(attrsJSON.String)
+	if err != nil {
+		return Ticket{}, err
+	}
+	ticket.Attrs = attrs
 	if parentID.Valid {
 		ticket.ParentID = &parentID.String
 	}

--- a/internal/store/ticket.go
+++ b/internal/store/ticket.go
@@ -1211,7 +1211,7 @@ func ListTickets(ctx context.Context, db *sql.DB, params TicketListParams) ([]Ti
 	}
 
 	query := `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
+		SELECT ` + ticketSelectColumns("") + `
 		FROM tickets
 		WHERE project_id = ?
 	`
@@ -1297,7 +1297,7 @@ func SearchTickets(ctx context.Context, db *sql.DB, projectID int64, query strin
 
 func GetTicketByProject(ctx context.Context, db *sql.DB, projectID int64, id string) (Ticket, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
+		SELECT `+ticketSelectColumns("")+`
 		FROM tickets
 		WHERE project_id = ? AND ticket_id = ? AND deleted = 0
 	`, projectID, id)
@@ -1313,7 +1313,7 @@ func GetTicketByProject(ctx context.Context, db *sql.DB, projectID int64, id str
 
 func GetTicket(ctx context.Context, db *sql.DB, id string) (Ticket, error) {
 	row := db.QueryRowContext(ctx, `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
+		SELECT `+ticketSelectColumns("")+`
 		FROM tickets
 		WHERE ticket_id = ? AND deleted = 0
 	`, id)
@@ -1413,31 +1413,15 @@ func ListTicketParents(ctx context.Context, db *sql.DB, id string) ([]Ticket, er
 	// Load the full ancestor chain in one recursive CTE query instead of
 	// making one GetTicket() call per ancestor level (O(depth) queries).
 	rows, err := db.QueryContext(ctx, `
-		WITH RECURSIVE ancestors(ticket_id, project_id, parent_id, clone_of, type, title,
-		  description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch,
-		  workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order,
-		  estimate_effort, estimate_complete, health_score, assignee, author,
-		  draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, created_by, created_at, updated_at, recommended_ready, pr_url, started_at) AS (
-			SELECT ticket_id, project_id, parent_id, clone_of, type, title,
-			  description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch,
-			  workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order,
-			  estimate_effort, estimate_complete, health_score, assignee, COALESCE(author,''),
-			  draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by,''), created_at, updated_at, COALESCE(recommended_ready,0), COALESCE(pr_url,''), COALESCE(started_at,'')
+		WITH RECURSIVE ancestors(`+ticketColumnList()+`) AS (
+			SELECT `+ticketSelectColumns("")+`
 			FROM tickets WHERE ticket_id = ? AND deleted = 0
 			UNION ALL
-			SELECT t.ticket_id, t.project_id, t.parent_id, t.clone_of, t.type, t.title,
-			  t.description, t.acceptance_criteria, t.dor_map, t.dod_map, t.ac_map, t.git_repository, t.git_branch,
-			  t.workflow_id, t.workflow_stage_id, t.role_id, t.stage, t.state, t.status, t.priority, t.sort_order,
-			  t.estimate_effort, t.estimate_complete, t.health_score, t.assignee, COALESCE(t.author,''),
-			  t.draft, t.complete, t.archived, t.deleted, t.previous_workflow_stage_id, t.previous_role_id, t.release_id, COALESCE(t.created_by,''), t.created_at, t.updated_at, COALESCE(t.recommended_ready,0), COALESCE(t.pr_url,''), COALESCE(t.started_at,'')
+			SELECT `+ticketSelectColumns("t")+`
 			FROM tickets t
 			JOIN ancestors a ON t.ticket_id = a.parent_id
 		)
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title,
-		  description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch,
-		  workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order,
-		  estimate_effort, estimate_complete, health_score, assignee, author,
-		  draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, created_by, created_at, updated_at, recommended_ready, pr_url, started_at
+		SELECT `+ticketColumnList()+`
 		FROM ancestors
 		WHERE ticket_id != ?
 	`, id, id)
@@ -1476,6 +1460,58 @@ func ListTicketParents(ctx context.Context, db *sql.DB, id string) ([]Ticket, er
 
 type scanner interface {
 	Scan(dest ...any) error
+}
+
+// ticketColumnNames is the single source of truth for the tickets columns, in the
+// exact order scanTicket reads them. Adding a column means appending here (plus a
+// scan target in scanTicket and a field on Ticket) instead of editing every
+// SELECT in this package.
+var ticketColumnNames = []string{
+	"ticket_id", "project_id", "parent_id", "clone_of", "type", "title",
+	"description", "acceptance_criteria", "dor_map", "dod_map", "ac_map",
+	"git_repository", "git_branch", "workflow_id", "workflow_stage_id", "role_id",
+	"stage", "state", "status", "priority", "sort_order", "estimate_effort",
+	"estimate_complete", "health_score", "assignee", "author", "draft", "complete",
+	"archived", "deleted", "previous_workflow_stage_id", "previous_role_id",
+	"release_id", "created_by", "created_at", "updated_at", "recommended_ready",
+	"pr_url", "started_at",
+}
+
+// ticketColumnCoalesce maps nullable columns to the SQL literal substituted via
+// COALESCE when selecting them, so scanTicket can scan into non-pointer fields.
+var ticketColumnCoalesce = map[string]string{
+	"author":            "''",
+	"created_by":        "''",
+	"recommended_ready": "0",
+	"pr_url":            "''",
+	"started_at":        "''",
+}
+
+// ticketSelectColumns returns the comma-separated SELECT expressions for reading a
+// ticket row in scanTicket order. When alias is non-empty (e.g. "t"), every column
+// reference is prefixed with it; COALESCE wrappers are applied per
+// ticketColumnCoalesce.
+func ticketSelectColumns(alias string) string {
+	prefix := ""
+	if alias != "" {
+		prefix = alias + "."
+	}
+	parts := make([]string, len(ticketColumnNames))
+	for i, col := range ticketColumnNames {
+		if def, ok := ticketColumnCoalesce[col]; ok {
+			parts[i] = "COALESCE(" + prefix + col + ", " + def + ")"
+		} else {
+			parts[i] = prefix + col
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
+// ticketColumnList returns the bare comma-separated column names in scanTicket
+// order, used for CTE column declarations and for selecting out of a CTE whose
+// values are already coalesced.
+func ticketColumnList() string {
+	return strings.Join(ticketColumnNames, ", ")
 }
 
 func scanTicket(s scanner) (Ticket, error) {
@@ -1835,7 +1871,7 @@ func recalculateParentLifecycle(ctx context.Context, db *sql.DB, id, actorID str
 
 func listStoredChildTickets(ctx context.Context, db *sql.DB, parentID string) ([]Ticket, error) {
 	rows, err := db.QueryContext(ctx, `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
+		SELECT `+ticketSelectColumns("")+`
 		FROM tickets
 		WHERE parent_id = ? AND deleted = 0
 		ORDER BY created_at, ticket_id
@@ -1858,7 +1894,7 @@ func listStoredChildTickets(ctx context.Context, db *sql.DB, parentID string) ([
 
 func getStoredTicket(ctx context.Context, db *sql.DB, id string) (Ticket, error) {
 	ticket, err := scanTicket(db.QueryRowContext(ctx, `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
+		SELECT `+ticketSelectColumns("")+`
 		FROM tickets
 		WHERE ticket_id = ?
 	`, id))
@@ -2100,7 +2136,7 @@ func ticketClaimable(ctx context.Context, db *sql.DB, ticket Ticket, projectID i
 
 func findAssignedTicketForUser(ctx context.Context, db *sql.DB, projectID int64, username, state string) (Ticket, bool, error) {
 	query := `
-		SELECT ticket_id, project_id, parent_id, clone_of, type, title, description, acceptance_criteria, dor_map, dod_map, ac_map, git_repository, git_branch, workflow_id, workflow_stage_id, role_id, stage, state, status, priority, sort_order, estimate_effort, estimate_complete, health_score, assignee, COALESCE(author, ''), draft, complete, archived, deleted, previous_workflow_stage_id, previous_role_id, release_id, COALESCE(created_by, ''), created_at, updated_at, COALESCE(recommended_ready, 0), COALESCE(pr_url, ''), COALESCE(started_at, '')
+		SELECT ` + ticketSelectColumns("") + `
 		FROM tickets
 		WHERE assignee = ? AND complete = 0 AND archived = 0 AND deleted = 0 AND state = ?
 	`
@@ -2133,7 +2169,7 @@ func findClaimCandidate(ctx context.Context, db *sql.DB, projectID int64, roleNa
 	if projectID == 0 {
 		return Ticket{}, false, errors.New("project is required")
 	}
-	query := `SELECT t.ticket_id, t.project_id, t.parent_id, t.clone_of, t.type, t.title, t.description, t.acceptance_criteria, t.dor_map, t.dod_map, t.ac_map, t.git_repository, t.git_branch, t.workflow_id, t.workflow_stage_id, t.role_id, t.stage, t.state, t.status, t.priority, t.sort_order, t.estimate_effort, t.estimate_complete, t.health_score, t.assignee, COALESCE(t.author, ''), t.draft, t.complete, t.archived, t.deleted, t.previous_workflow_stage_id, t.previous_role_id, t.release_id, COALESCE(t.created_by, ''), t.created_at, t.updated_at, COALESCE(t.recommended_ready, 0), COALESCE(t.pr_url, ''), COALESCE(t.started_at, '')
+	query := `SELECT ` + ticketSelectColumns("t") + `
 		FROM tickets t
 		JOIN projects p ON p.project_id = t.project_id
 		LEFT JOIN roles r ON r.role_id = t.role_id

--- a/internal/store/ticket.go
+++ b/internal/store/ticket.go
@@ -1231,6 +1231,7 @@ func ListTickets(ctx context.Context, db *sql.DB, params TicketListParams) ([]Ti
 		return nil, errors.New("project is required")
 	}
 
+	// #nosec G202 -- ticketSelectColumns returns a fixed, code-controlled column list (no user input); filter values are bound parameters.
 	query := `
 		SELECT ` + ticketSelectColumns("") + `
 		FROM tickets
@@ -1317,6 +1318,7 @@ func SearchTickets(ctx context.Context, db *sql.DB, projectID int64, query strin
 }
 
 func GetTicketByProject(ctx context.Context, db *sql.DB, projectID int64, id string) (Ticket, error) {
+	// #nosec G202 -- ticketSelectColumns is a fixed, code-controlled column list (no user input); values are bound parameters.
 	row := db.QueryRowContext(ctx, `
 		SELECT `+ticketSelectColumns("")+`
 		FROM tickets
@@ -1333,6 +1335,7 @@ func GetTicketByProject(ctx context.Context, db *sql.DB, projectID int64, id str
 }
 
 func GetTicket(ctx context.Context, db *sql.DB, id string) (Ticket, error) {
+	// #nosec G202 -- ticketSelectColumns is a fixed, code-controlled column list (no user input); values are bound parameters.
 	row := db.QueryRowContext(ctx, `
 		SELECT `+ticketSelectColumns("")+`
 		FROM tickets
@@ -1932,6 +1935,7 @@ func recalculateParentLifecycle(ctx context.Context, db *sql.DB, id, actorID str
 }
 
 func listStoredChildTickets(ctx context.Context, db *sql.DB, parentID string) ([]Ticket, error) {
+	// #nosec G202 -- ticketSelectColumns is a fixed, code-controlled column list (no user input); values are bound parameters.
 	rows, err := db.QueryContext(ctx, `
 		SELECT `+ticketSelectColumns("")+`
 		FROM tickets


### PR DESCRIPTION
Single merge of epic **TK-105** (stories TK-106–TK-115, each landed via its own PR into this branch). Schema version **10 → 12**.

## Why
Adding a field used to ripple through ~12 call sites and always needed a migration + version bump. This epic makes the *default* way to add an optional field a pure-Go change (no migration, no version bump), hardens migrations against data loss, keeps fields queryable on demand, and narrows the four high-churn tables.

## What landed
- **TK-106** — design doc (`docs/design/extensible-schema.md`), ADR, diagrams, per-column classification.
- **TK-107** — migration safety: WAL-checkpointed, integrity-verified backup taken *inside* `UpgradeInPlace`, automatic rollback on failure, retention.
- **TK-108** — centralized the tickets column list + scan (killed the positional SELECT fan-out).
- **TK-109** — `attrs` JSON attribute bag + typed accessor on tickets/projects/roles/workflow_stages, wired through CRUD/API/OpenAPI. (Stored as **TEXT JSON**, not binary JSONB — binary JSONB does not survive the snapshot export/import that backs backups and the migration rebuild path.)
- **TK-110** — queryable bag: allowlist-validated `json_extract` helpers + idempotent expression indexes (`EnsureAttrIndex`), EXPLAIN-verified.
- **TK-111–TK-115** — physical consolidation: moved soft/config/guidance columns into `attrs` and **dropped** them across all four entities (tickets: git_repository, git_branch, estimate_complete, health_score, author, pr_url + dead `open`; projects: agent_model_*; roles & stages: description/acceptance_criteria/definition_of_*; dor/dod/ac guidance maps folded everywhere). Typed struct fields are retained and hydrated from the bag, so the CLI/API contract is unchanged.

## Adding a field now
A new optional/per-type field is a Go-only change to a typed accessor — **no schema migration, no version bump**. Promote to a queryable, indexed field later via `EnsureAttrIndex` (no table rewrite).

## Migrations
The consolidation runs idempotently and non-clobberingly in both upgrade paths (in-place repair + snapshot rebuild), behind the reinforced verified-backup + auto-rollback. Each consolidation has a no-data-loss migration test from a simulated pre-consolidation shape.

## Testing
`go test ./internal/... ./cmd/... ./libticket/...` green except one **pre-existing** failure, `TestFailureEscalationInboxLifecycle`, which also fails on `main` (unrelated to this epic). `make lint`: 0 issues. `make validate-openapi`: ok.

> Note: a reference copy of the production DB was not available in this environment; migrations are covered by tests that reconstruct the pre-consolidation v11 shapes and exercise the v11→v12 upgrade end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)