### PR TITLE
Fix stale inbox test assertion (Goals feature removal left it expecting 3 recommendations)

### DIFF
--- a/internal/store/inbox_test.go
+++ b/internal/store/inbox_test.go
@@ -60,7 +60,8 @@ func TestFailureEscalationInboxLifecycle(t *testing.T) {
 	if entry.Status != InboxStatusOpen || entry.Kind != InboxKindFailureEscalation {
 		t.Fatalf("entry=%#v", entry)
 	}
-	if len(entry.Recommendations) != 3 {
+	// Two recommendations remain after the Goals feature (clarify_goal) was removed.
+	if len(entry.Recommendations) != 2 {
 		t.Fatalf("entry recommendations=%#v", entry.Recommendations)
 	}
 


### PR DESCRIPTION
`TestFailureEscalationInboxLifecycle` asserted 3 failure-escalation recommendations, but the third (`clarify_goal`) was removed in `341836a "Remove Goals feature entirely"` — that commit didn't update the test, so it has been red on `main` ever since.

`defaultFailureEscalationRecommendations()` correctly returns 2 (`start_again`, `refine_requirements`); this aligns the test with the intentional removal.

Full Go test suite (`go test ./...`) is now green; `make lint` reports 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)