### PR TITLE
Fix Playwright webServer cwd (browser smoke suite was 404ing)

### DIFF
--- a/tests/playwright.config.js
+++ b/tests/playwright.config.js
@@ -1,5 +1,11 @@
+const path = require("path");
 const { defineConfig } = require("@playwright/test");
 const { resolvePort } = require("./playwright.port");
+
+// Repo root, so the static-server `-d web/static` resolves regardless of where
+// playwright is invoked from (its webServer cwd otherwise defaults to this
+// config's directory, tests/, where web/static does not exist).
+const repoRoot = path.resolve(__dirname, "..");
 
 const port = resolvePort("PLAYWRIGHT_PORT", 4173);
 const workers = Number(process.env.PLAYWRIGHT_WORKERS || 4);
@@ -17,6 +23,7 @@ module.exports = defineConfig({
   },
   webServer: {
     command: `python3 -m http.server ${port} -d web/static`,
+    cwd: repoRoot,
     url: `http://127.0.0.1:${port}`,
     reuseExistingServer: true,
     timeout: 30000,


### PR DESCRIPTION
Playwright defaults webServer.cwd to the config dir (tests/), so `python3 -m http.server -d web/static` resolved to the nonexistent tests/web/static and every request 404'd. Anchoring cwd to the repo root fixes it: make test-browser now passes 55/55 smoke tests. Pre-existing harness issue, unrelated to the schema epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)