### PR TITLE
TK-92: admin 'tk unassign <id>' works without the assignee name

### DIFF
--- a/cmd/tk/cmd_ticket.go
+++ b/cmd/tk/cmd_ticket.go
@@ -251,7 +251,7 @@ Commands:
   claim    -id <id>                           Assign to self
   unclaim  -id <id>                           Unassign self
   assign   -id <id> <user>                    Assign to someone
-  unassign -id <id> <user>                    Unassign someone
+  unassign -id <id> [user]                    Unassign someone (admin may omit the name)
   request                                     Next available ticket
   intervene -id <id> -outcome <decision>      Apply intervention decision
 
@@ -1776,10 +1776,16 @@ func runUnassign(args []string) error {
 		return err
 	}
 	idVal, rest, err := resolveIDFlag(*id, fs.Args())
-	if err != nil || len(rest) != 1 {
-		return errors.New("usage: tk unassign [-id] <id> <name> [-m comment]")
+	if err != nil || len(rest) > 1 {
+		return errors.New("usage: tk unassign [-id] <id> [name] [-m comment]")
 	}
-	return unassignTicket(idVal, rest[0], true, *message)
+	// The assignee name is optional: an admin may unassign whoever is currently
+	// assigned by omitting it (TK-92).
+	expected := ""
+	if len(rest) == 1 {
+		expected = rest[0]
+	}
+	return unassignTicket(idVal, expected, true, *message)
 }
 
 func runClaim(args []string) error {
@@ -1892,7 +1898,9 @@ func unassignTicket(idArg, expectedAssignee string, requireAdmin bool, message .
 	if requireAdmin && (status.User == nil || status.User.Role != "admin") {
 		return errors.New("user is not an admin")
 	}
-	if requireAdmin {
+	// Validate the named user only when a name was supplied. An admin may omit the
+	// name to clear whoever is currently assigned (TK-92).
+	if requireAdmin && expectedAssignee != "" {
 		users, usersErr := svc.ListUsers(context.Background())
 		if usersErr != nil {
 			return usersErr
@@ -1915,8 +1923,18 @@ func unassignTicket(idArg, expectedAssignee string, requireAdmin bool, message .
 	if err != nil {
 		return err
 	}
-	if strings.TrimSpace(current.Assignee) != strings.TrimSpace(expectedAssignee) {
-		return fmt.Errorf("ticket is not assigned to %s", expectedAssignee)
+	currentAssignee := strings.TrimSpace(current.Assignee)
+	if expectedAssignee != "" {
+		if currentAssignee != strings.TrimSpace(expectedAssignee) {
+			return fmt.Errorf("ticket is not assigned to %s", expectedAssignee)
+		}
+	} else if currentAssignee == "" {
+		// Nothing to do: no name given and the ticket is already unassigned.
+		if outputJSON {
+			return printJSON(current)
+		}
+		fmt.Printf("%s is already unassigned\n", ticketLabel(current))
+		return nil
 	}
 	var msg string
 	if len(message) > 0 {
@@ -1942,7 +1960,11 @@ func unassignTicket(idArg, expectedAssignee string, requireAdmin bool, message .
 	if outputJSON {
 		return printJSON(updated)
 	}
-	fmt.Printf("unassigned %s from %s\n", ticketLabel(updated), expectedAssignee)
+	removed := expectedAssignee
+	if removed == "" {
+		removed = currentAssignee
+	}
+	fmt.Printf("unassigned %s from %s\n", ticketLabel(updated), removed)
 	return nil
 }
 

--- a/cmd/tk/help.go
+++ b/cmd/tk/help.go
@@ -297,9 +297,9 @@ var helpIndex = map[string]commandHelp{
 		example: "tk assign TK-42 alice",
 	},
 	"unassign": {
-		usage:   "tk unassign [-id] <id> <name>",
-		details: []string{"Admin-only command that clears a ticket assignment from the named user.", "The named user must exist and be enabled."},
-		example: "tk unassign TK-42 alice",
+		usage:   "tk unassign [-id] <id> [name]",
+		details: []string{"Admin-only command that clears a ticket assignment.", "With a name, the named user must exist, be enabled, and be the current assignee.", "Without a name, an admin clears whoever is currently assigned (no-op if already unassigned)."},
+		example: "tk unassign TK-42",
 	},
 	"claim": {
 		usage:   "tk claim [-id] <id>",

--- a/cmd/tk/main_test.go
+++ b/cmd/tk/main_test.go
@@ -11122,3 +11122,42 @@ func TestRunListBubblesParentEpicByDescendantRecency(t *testing.T) {
 		t.Fatalf("list output missing child ticket:\n%s", output)
 	}
 }
+
+func TestUnassignWithoutNameAsAdmin(t *testing.T) {
+	setupLocalCLI(t)
+	id := createLocalTask(t, []string{"add", "Assign me"})
+	if err := run([]string{"assign", id, "admin"}); err != nil {
+		t.Fatalf("assign error = %v", err)
+	}
+	svc := localCLIService(t)
+	if tk, err := svc.GetTicket(context.Background(), id); err != nil {
+		t.Fatalf("GetTicket error = %v", err)
+	} else if strings.TrimSpace(tk.Assignee) != "admin" {
+		t.Fatalf("precondition: assignee = %q, want admin", tk.Assignee)
+	}
+
+	// TK-92: admin unassigns without naming the assignee.
+	out := captureStdout(t, func() {
+		if err := run([]string{"unassign", id}); err != nil {
+			t.Fatalf("unassign (no name) error = %v", err)
+		}
+	})
+	if tk, err := svc.GetTicket(context.Background(), id); err != nil {
+		t.Fatalf("GetTicket error = %v", err)
+	} else if strings.TrimSpace(tk.Assignee) != "" {
+		t.Fatalf("assignee not cleared: %q", tk.Assignee)
+	}
+	if !strings.Contains(out, "unassigned") || !strings.Contains(out, "admin") {
+		t.Fatalf("unexpected output = %q", out)
+	}
+
+	// Idempotent: a second unassign with no name reports already-unassigned.
+	out2 := captureStdout(t, func() {
+		if err := run([]string{"unassign", id}); err != nil {
+			t.Fatalf("second unassign error = %v", err)
+		}
+	})
+	if !strings.Contains(out2, "already unassigned") {
+		t.Fatalf("expected already-unassigned message, got %q", out2)
+	}
+}


### PR DESCRIPTION
Makes the assignee name optional on `tk unassign`. An admin can run `tk unassign <id>` / `tk unassign -id <id>` to clear whoever is currently assigned. Named-user behaviour is unchanged; an already-unassigned ticket is a friendly no-op. Usage/help updated; test added (TestUnassignWithoutNameAsAdmin). cmd tests + lint green.

refs TK-92

🤖 Generated with [Claude Code](https://claude.com/claude-code)