### PR TITLE
TK-91: close browser-harness scope; split site2.spec.js revival to TK-117

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,9 +261,11 @@ test-browser-smoke: playwright-ready
 
 test-browser-full: test-playwright
 
-# Mock-API browser tests for the live SPA (web/default + web/shared). Not part
-# of test-all yet: most of the suite predates the site2→default rename and
-# needs reviving (see docs/TODO.md). Run specific tests with PLAYWRIGHT_GREP.
+# Mock-API browser tests for the live SPA (web/default + web/shared). The harness
+# (tests/serve-site.py) serves correctly; the suite itself is NOT part of test-all
+# because most of it predates the site2→default rename and has drifted against the
+# current SPA (dead selectors, moved panels). Reviving it is tracked in TK-117.
+# Run specific tests with PLAYWRIGHT_GREP.
 test-browser-site2: playwright-ready
 	@PLAYWRIGHT_SITE2_PORT=$$(python3 -c "import socket; s=socket.socket(); s.bind(('127.0.0.1', 0)); print(s.getsockname()[1]); s.close()"); \
 	PLAYWRIGHT_SITE2_PORT=$$PLAYWRIGHT_SITE2_PORT npx playwright test -c tests/playwright.site2.config.js $(if $(PLAYWRIGHT_GREP),-g "$(PLAYWRIGHT_GREP)",)

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,9 +1,9 @@
 FOLLOW-UPS (2026-06-10)
-    - Revive tests/playwright/site2.spec.js: the harness is fixed (make test-browser-site2
-      serves web/default+web/shared via tests/serve-site.py and the app honours
-      window.__site2MockFetch again), and the context/reorder tests pass, but ~28 older
-      tests predate the site2→default UI rename and need their selectors/flows updated.
-      Once green, wire test-browser-site2 into test-all.
+    - Revive tests/playwright/site2.spec.js (tracked in TK-117): the harness is fixed
+      (make test-browser-site2 serves web/default+web/shared via tests/serve-site.py and
+      the app honours window.__site2MockFetch again), and the context/reorder tests pass,
+      but the older tests predate the site2→default UI rename and need their selectors/
+      flows updated. Once green, wire test-browser-site2 into test-all.
     - Enforce the ticket parenting matrix (SPEC.md 5.4.2): validateTicketParenting
       currently only validates type names, not the feature→epic→story hierarchy.
 


### PR DESCRIPTION
The Playwright browser-test harness is fixed: main smoke suite 55/55 green and in test-all (PR #36, webServer cwd), and `tests/serve-site.py` serves web/default+web/shared correctly. The remaining item — reviving the drifted `site2.spec.js` mock-API SPA suite (~34 tests, per-test UI drift vs current SPA) — is a large separate effort, split into **TK-117**. Updates the Makefile comment + docs/TODO.md to reference it.

refs TK-91

🤖 Generated with [Claude Code](https://claude.com/claude-code)