### PR TITLE
TK-86: fix tk edit TUI key handling (type letters in text fields)

### DIFF
--- a/internal/tui/model_forms.go
+++ b/internal/tui/model_forms.go
@@ -376,53 +376,73 @@ func (m Model) handleKeyEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	// A text field (Title/Description/Acceptance) is being edited. In a text field
+	// every printable key must reach the input — including j/k/w/s/a/d — so the
+	// vim/wasd single-key navigation only applies on the non-text control fields.
+	inText := f.focus == efTitle || f.focus == efDesc || f.focus == efAC
+
 	switch key {
 	case "esc":
 		return m.goBack()
 	case "ctrl+s", "ctrl+d":
 		return m, m.saveTicket()
-	case "up", "k", "w":
-		switch f.focus {
-		case efDesc:
-			if !textareaAtFirstLine(f.desc) {
-				f.desc, _ = f.desc.Update(msg)
-				return m, nil
-			}
-		case efAC:
-			if !textareaAtFirstLine(f.acceptCrit) {
-				f.acceptCrit, _ = f.acceptCrit.Update(msg)
-				return m, nil
-			}
-		}
-		f.prevField()
-		f.applyFocus(m.width - 2)
-	case "down", "j", "s":
-		switch f.focus {
-		case efDesc:
-			if !textareaAtLastLine(f.desc) {
-				f.desc, _ = f.desc.Update(msg)
-				return m, nil
-			}
-		case efAC:
-			if !textareaAtLastLine(f.acceptCrit) {
-				f.acceptCrit, _ = f.acceptCrit.Update(msg)
-				return m, nil
-			}
-		}
-		f.nextField()
-		f.applyFocus(m.width - 2)
 	case "tab":
 		f.nextField()
 		f.applyFocus(m.width - 2)
+		return m, nil
 	case "shift+tab":
 		f.prevField()
 		f.applyFocus(m.width - 2)
-	case "enter", " ":
-		// Space must reach text input fields, not trigger picker/save actions
-		if key == " " && (f.focus == efTitle || f.focus == efDesc || f.focus == efAC) {
-			cmd := f.update(msg)
-			return m, cmd
+		return m, nil
+	case "up":
+		// Within a textarea, move the cursor; jump fields only at the boundary.
+		if f.focus == efDesc && !textareaAtFirstLine(f.desc) {
+			f.desc, _ = f.desc.Update(msg)
+			return m, nil
 		}
+		if f.focus == efAC && !textareaAtFirstLine(f.acceptCrit) {
+			f.acceptCrit, _ = f.acceptCrit.Update(msg)
+			return m, nil
+		}
+		f.prevField()
+		f.applyFocus(m.width - 2)
+		return m, nil
+	case "down":
+		if f.focus == efDesc && !textareaAtLastLine(f.desc) {
+			f.desc, _ = f.desc.Update(msg)
+			return m, nil
+		}
+		if f.focus == efAC && !textareaAtLastLine(f.acceptCrit) {
+			f.acceptCrit, _ = f.acceptCrit.Update(msg)
+			return m, nil
+		}
+		f.nextField()
+		f.applyFocus(m.width - 2)
+		return m, nil
+	}
+
+	if inText {
+		// Enter advances out of the single-line title; in the textareas it inserts
+		// a newline. All other keys (letters, space, punctuation) are typed.
+		if key == "enter" && f.focus == efTitle {
+			f.nextField()
+			f.applyFocus(m.width - 2)
+			return m, nil
+		}
+		cmd := f.update(msg)
+		return m, cmd
+	}
+
+	// Control fields: type/status/draft/workflow/save. Single-key navigation and
+	// enter/space activation (open the picker, or save).
+	switch key {
+	case "k", "w":
+		f.prevField()
+		f.applyFocus(m.width - 2)
+	case "j", "s":
+		f.nextField()
+		f.applyFocus(m.width - 2)
+	case "enter", " ":
 		switch f.focus {
 		case efType:
 			f.picker = &pickerPopup{items: ticketTypes, cursor: indexOf(ticketTypes, f.ticketType), forField: "type"}
@@ -436,11 +456,6 @@ func (m Model) handleKeyEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			f.picker = &pickerPopup{items: items, cursor: workflowPickerCursor(items, f.workflowID), forField: "workflow"}
 		case efSave:
 			return m, m.saveTicket()
-		}
-	default:
-		if f.focus == efTitle || f.focus == efDesc || f.focus == efAC {
-			cmd := f.update(msg)
-			return m, cmd
 		}
 	}
 	return m, nil

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -411,3 +411,50 @@ func fieldGapLines(lines []string, label, nextLabel string) int {
 	}
 	return end - start - 1
 }
+
+func TestHandleKeyEditTypesNavLettersInTitle(t *testing.T) {
+	m := newModel(nil, config.Config{}, Themes[ThemeTheGrey])
+	m.width = 100
+	m.mode = modeEdit
+	m.form = newEditForm(store.Ticket{Title: "", Type: "task"})
+	m.form.focus = efTitle
+	m.form.applyFocus(m.width - 2)
+
+	// TK-86: in the title field, j/k/w/s/a/d must be typed, not treated as
+	// navigation, and focus must stay on the title.
+	for _, ch := range []string{"w", "a", "s", "d", "j", "k"} {
+		updatedAny, _ := m.handleKeyEdit(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(ch)})
+		updated, ok := updatedAny.(Model)
+		if !ok {
+			t.Fatalf("handleKeyEdit type = %T, want Model", updatedAny)
+		}
+		m = updated
+		if m.form.focus != efTitle {
+			t.Fatalf("focus moved off title while typing %q (focus=%d)", ch, m.form.focus)
+		}
+	}
+	if got := m.form.title.Value(); got != "wasdjk" {
+		t.Fatalf("title value = %q, want %q", got, "wasdjk")
+	}
+}
+
+func TestHandleKeyEditControlFieldNavigation(t *testing.T) {
+	m := newModel(nil, config.Config{}, Themes[ThemeTheGrey])
+	m.width = 100
+	m.mode = modeEdit
+	m.form = newEditForm(store.Ticket{Title: "x", Type: "task"})
+	m.form.focus = efType // a control (non-text) field
+	m.form.applyFocus(m.width - 2)
+
+	// j advances control fields; k goes back.
+	updatedAny, _ := m.handleKeyEdit(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	updated := updatedAny.(Model)
+	if updated.form.focus != efStatus {
+		t.Fatalf("j on control field: focus = %d, want efStatus(%d)", updated.form.focus, efStatus)
+	}
+	updatedAny, _ = updated.handleKeyEdit(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	updated = updatedAny.(Model)
+	if updated.form.focus != efType {
+		t.Fatalf("k on control field: focus = %d, want efType(%d)", updated.form.focus, efType)
+	}
+}


### PR DESCRIPTION
In the edit form, j/k/w/s were bound to field navigation for every field, so in the single-line Title (and at textarea boundaries) they moved focus instead of typing — you could not type those letters into a title. Reworked `handleKeyEdit` to split text fields (Title/Description/Acceptance) from control fields:

- Text fields: every printable key types (incl. j/k/w/s/a/d/space); only tab/shift+tab + arrows navigate (arrows still move within a textarea, jump fields at the boundary); enter advances out of the title / newlines in textareas.
- Control fields: keep single-key j/k/w/s nav + enter/space activation.

Also untangles the overloaded key switch (the \"hard to code against\" part). Tests added; existing arrow-boundary test still passes; tui suite + lint green.

refs TK-86

🤖 Generated with [Claude Code](https://claude.com/claude-code)