### PR TITLE
docs: accuracy review — fix drift from the schema epic + recent changes

### DIFF
--- a/cmd/tk/help.go
+++ b/cmd/tk/help.go
@@ -661,9 +661,9 @@ const roleUsage = `Usage: tk role <command> [flags]
 Commands:
   ls                                      List all roles
   get -id <id>                            Show full role details
-  new -title <t> [-motivation m] [-goals g]
+  new -title <t> [-description d] [-ac criteria] [-dor text] [-dod text]
                                           Create a role
-  update -id <id> -title <t> [-motivation m] [-goals g]
+  update -id <id> -title <t> [-description d] [-ac criteria] [-dor text] [-dod text]
                                           Update a role
   rm -id <id>                             Delete a role`
 

--- a/docs/Agents.md
+++ b/docs/Agents.md
@@ -87,7 +87,7 @@ and act on.  For example an agent will complete a story, so the story will be ma
 
 ## Running
  
-Part of the server using -orchestrator as part of the `tk serve -orchestrator` call.
+Part of the server using -orchestrator as part of the `tk server -orchestrator` call.
 
 ## Config
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to the Ticket project are documented here.
 
+## [0.1.1103] - 2026-06-23
+
+### Added
+- **Extensible schema (attrs)** — high-churn entities (tickets, projects, roles,
+  workflow_stages) carry an `attrs` TEXT-JSON attribute bag; new optional/per-type
+  fields are added in Go with no schema migration or version bump, and become
+  queryable on demand via `json_extract` expression indexes (`EnsureAttrIndex`).
+  Design: `docs/design/extensible-schema.md`, `docs/adr/0001-json-attribute-bags.md`.
+- **Reinforced migrations** — `tk admin upgrade-database` / server-startup upgrade
+  take a WAL-checkpointed, integrity-verified backup and auto-roll-back on failure
+  (`docs/RUNBOOKS.md`).
+
+### Changed
+- **Schema version 10 → 12.** Soft/config/guidance columns consolidated into
+  `attrs` and dropped across all four entities (typed Go/API fields retained and
+  hydrated from the bag, so the CLI/API contract is unchanged).
+- **Go toolchain 1.26.3 → 1.26.4** (clears two `crypto/x509` stdlib advisories).
+- **Coverage gates recalibrated** to actual levels: `internal/store` 66%,
+  `internal/server` 57% (the old 69/63 were never met).
+- **`tk unassign <id>`** — the assignee name is now optional for admins (clears
+  whoever is assigned) (TK-92).
+
+### Removed
+- **Goals feature** removed entirely (entity, `clarify_goal` recommendation, and
+  related code). The "goal" concept is realized via the Feature/refinement model.
+
+### Fixed
+- **`tk edit` TUI** — letters `j/k/w/s` are now typed in text fields instead of
+  being captured as navigation; text-vs-control key handling separated (TK-86).
+- **Playwright harness** — the smoke suite serves `web/static` from the repo root
+  again and passes; `GET /api/releases/{id}` (405) handler added.
+
 ## [0.1.861] - 2026-04-28
 
 ### Changed

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -4,11 +4,11 @@ This is the single entrypoint for contributor and agent-facing implementation co
 
 ## Core references
 
-1. **Architecture / design**: `docs/DESIGN.md`
-2. **Workflow + SDLC method**: `docs/process/SDLC.md`
-3. **Contributor workflow**: `CONTRIBUTING.md`
-4. **Testing strategy**: `TESTING.md`
-5. **Agent execution rules**: `AGENTS.md`, `.github/copilot-instructions.md`, `CLAUDE.md`
+1. **Architecture / design**: `docs/DESIGN.md`, `docs/ENTITY_MODEL.md`
+2. **Workflow + SDLC method**: `docs/process/SDLC.md`, `docs/LIFECYCLE.md`
+3. **Contributor workflow**: `.github/CONTRIBUTING.md`
+4. **Testing strategy**: `docs/TESTING.md`
+5. **Agent execution rules**: `docs/Agents.md`, `.github/copilot-instructions.md`, `CLAUDE.md`
 
 ## Build and validation
 
@@ -27,7 +27,8 @@ make test-all
 
 The repository keeps user-facing and developer-facing docs intentionally compact:
 
-- User-facing docs: `README.md`, `docs/QUICKSTART.md`, `docs/TUTORIAL.md`, `USER_GUIDE.md`
-- Developer-facing docs: this file + architecture/process/instructions listed above
+- User-facing docs: `README.md`, `docs/QUICKSTART.md`, `docs/TUTORIAL.md`, `docs/ONBOARDING.md`
+- Developer-facing docs: this file + the architecture/process/instructions listed above
 
-Historical plans, old quickstarts, and superseded guidance are archived under `docs/archive/`.
+Superseded guidance is removed rather than archived; the authoritative current
+specs are `docs/SPEC.md`, `docs/api/openapi.yaml`, and the design docs above.

--- a/docs/GOAL.md
+++ b/docs/GOAL.md
@@ -1,5 +1,11 @@
 # GOAL
 
+> **Status: product vision / north-star, not a feature reference.** "Goal" here is
+> the conceptual outcome a unit of work refines from. The earlier standalone *goal*
+> entity/command was removed; that concept is now realized through the
+> Feature → Epic → Story refinement model (see `docs/RELEASES.md`, `docs/FACTORY.md`,
+> `docs/DESIGN_ORCHESTRATOR.md`). There is no `tk goal` command.
+
 ## Vision
 
 `ticket` should be a general-purpose **software development** system where:

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -108,9 +108,9 @@ make lint
 make test
 ```
 
-> `make build` auto-increments the patch version in `cmd/tk/VERSION` on
-> every run. Use `make build-dev` when you want a local rebuild without
-> changing the version.
+> `make build` does **not** change the version. The patch version in
+> `cmd/tk/VERSION` is only bumped when publishing/releasing (`make publish` /
+> `make release`). `make build` and `make build-dev` both leave it untouched.
 
 ---
 
@@ -158,7 +158,7 @@ tk admin workflow add-stage -id 1 -name develop
 tk admin workflow add-stage -id 1 -name test
 
 # Create a role
-tk role create -title Engineer -d "Software engineer"
+tk admin role create -title Engineer -description "Software engineer"
 
 # Assign a role to a stage
 tk workflow stage-role-add -workflow_id 1 -stage_id 1 -role_id 1
@@ -208,7 +208,7 @@ threshold will fail both locally (`make test-go-cover`) and in CI.
 
 | Pitfall | Fix |
 |---------|-----|
-| `make build` bumped the version and you wanted a stable dev binary | Use `make build-dev` for development builds |
+| Wanted a local dev binary without touching tracked files | Use `make build-dev` (neither it nor `make build` changes the version) |
 | Playwright tests fail because Chromium is missing | Run `make setup` once, or `make setup-playwright` if only the browser install is missing |
 | `tk` command not found | Run `make build-dev` and add `./bin` to your PATH, or copy `./bin/tk` to a directory in your PATH |
 | `tk` is talking to the wrong backend | Run `tk status` first. The CLI uses `TICKET_URL` plus stored credentials or environment variables; repo-local `.ticket/config.json` only provides project binding. |

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -83,6 +83,15 @@ modernc.org/sqlite v1.48.0
 
 ## 5. Core Entities
 
+> **Logical vs physical schema.** These tables enumerate each entity's *logical
+> fields* as exposed through the Go structs, JSON API, and CLI. They are not a
+> literal column list. The high-churn entities (Ticket, Project, Role, Workflow
+> Stage) physically store their soft, sparse, and per-type fields in a single
+> `attrs` TEXT-JSON column (schema version 12); fields marked **(attrs)** below are
+> hydrated from that bag rather than being dedicated columns. See
+> `docs/design/extensible-schema.md` for the column→`attrs` consolidation and the
+> promotion rules.
+
 ### 5.1 User
 
 Represents a human operator or service account.
@@ -133,6 +142,7 @@ Top-level namespace and container for tickets.
 | visibility | TEXT | `public` \| `private`, default `public` |
 | workflow_id | INTEGER | Nullable FK → workflows |
 | ticket_sequence | INTEGER | Auto-incrementing per project, default 0 |
+| attrs | TEXT | JSON attribute bag (default `{}`). Backs the agent-model config (`agent_model_provider`/`name`/`url`/`api_key`) and the `dor_map`/`dod_map`/`ac_map` guidance maps. |
 | created_by | TEXT | FK → users |
 | created_at | TEXT | Timestamp |
 | updated_at | TEXT | Timestamp |
@@ -184,8 +194,8 @@ The primary work artifact.
 | title | TEXT | Required |
 | description | TEXT | Default empty |
 | acceptance_criteria | TEXT | Default empty |
-| git_repository | TEXT | Default empty |
-| git_branch | TEXT | Default empty |
+| git_repository | TEXT | Default empty. **(attrs)** |
+| git_branch | TEXT | Default empty. **(attrs)** |
 | workflow_stage_id | INTEGER | Nullable FK → workflow_stages |
 | stage | TEXT | Default `design` |
 | state | TEXT | Default `idle` |
@@ -193,20 +203,22 @@ The primary work artifact.
 | priority | INTEGER | Default 3 |
 | sort_order | INTEGER | Default 0 |
 | estimate_effort | INTEGER | Default 0 |
-| estimate_complete | TEXT | Default empty |
-| health_score | INTEGER | Default 0 |
+| estimate_complete | TEXT | Default empty. **(attrs)** |
+| health_score | INTEGER | Default 0. **(attrs)** |
+| author | TEXT | Username of the creator. **(attrs)** |
 | assignee | TEXT | Default empty |
 | draft | INTEGER | Boolean, default 1. New tickets start as draft until explicitly readied for work. |
 | complete | INTEGER | Boolean, default 0. When true, ticket is finished (stage=done). |
 | archived | INTEGER | Boolean, default 0 |
 | deleted | INTEGER | Boolean, default 0. Soft-delete flag. |
 | recommended_ready | INTEGER | Boolean, default 0. Set when the refiner proposes the ticket is ready. |
-| dor_map / dod_map / ac_map | TEXT | JSON guidance maps (Definition of Ready / Done / Acceptance Criteria) keyed by stage with a `default` fallback. |
+| dor_map / dod_map / ac_map | JSON | Guidance maps (Definition of Ready / Done / Acceptance Criteria) keyed by stage with a `default` fallback. **(attrs)** |
 | workflow_id | INTEGER | Nullable FK → workflows. Explicit per-ticket workflow override. |
-| pr_url | TEXT | Pull-request URL recorded by agents. |
+| pr_url | TEXT | Pull-request URL recorded by agents. **(attrs)** |
 | role_id | INTEGER | FK → roles. Current active role within the stage. |
 | previous_workflow_stage_id | INTEGER | Saved stage for reopen after completion. |
 | previous_role_id | INTEGER | Saved role for reopen after completion. |
+| attrs | TEXT | JSON attribute bag (default `{}`). Backing store for the **(attrs)** fields above and any new optional/per-type fields. |
 | created_by | TEXT | FK → users |
 | created_at | TEXT | Timestamp |
 | updated_at | TEXT | Timestamp |
@@ -283,9 +295,12 @@ An individual stage within a workflow.
 | workflow_stage_id | INTEGER | Primary key, autoincrement |
 | workflow_id | INTEGER | FK → workflows |
 | stage_name | TEXT | Required, unique per workflow |
-| description | TEXT | Default empty |
+| description | TEXT | Default empty. **(attrs)** |
+| acceptance_criteria / definition_of_ready / definition_of_done | TEXT | Stage guidance text. **(attrs)** |
+| is_backlog_stage | INTEGER | Boolean, default 0 |
 | role_id | INTEGER | Nullable FK → roles |
 | sort_order | INTEGER | Default 0 |
+| attrs | TEXT | JSON attribute bag (default `{}`). Backs the stage's `description` and guidance text fields. |
 | created_at | TEXT | Timestamp |
 | updated_at | TEXT | Timestamp |
 
@@ -347,8 +362,9 @@ Custom role definition for workflow stages.
 | role_id | INTEGER | Primary key, autoincrement |
 | workflow_id | INTEGER | FK → workflows. Roles are scoped to an Workflow. |
 | title | TEXT | Unique per workflow_id, required |
-| description | TEXT | Default empty |
-| acceptance_criteria | TEXT | Default empty |
+| description | TEXT | Default empty. **(attrs)** |
+| acceptance_criteria | TEXT | Default empty. **(attrs)** |
+| attrs | TEXT | JSON attribute bag (default `{}`). Backs `description`, `acceptance_criteria`, and the `dor_map`/`dod_map`/`ac_map` guidance maps. |
 | created_at | TEXT | Timestamp |
 | updated_at | TEXT | Timestamp |
 

--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -55,7 +55,7 @@ Examples: `state`, `stage`, `status`, `project_id`, `parent_id`, `priority`,
 `sort_order`, lifecycle flags (`draft`/`complete`/`archived`/`deleted`),
 timestamps.
 
-### Tier 2 — The attribute bag (`attrs`, JSONB)
+### Tier 2 — The attribute bag (`attrs`, TEXT JSON)
 One `attrs` column per high-churn entity, storing a JSON object. This is the
 **default home** for:
 - new optional / sparse fields,
@@ -215,22 +215,22 @@ erDiagram
     int    project_id FK
     string state
     string stage
-    blob   attrs "JSONB: soft + per-type fields"
+    string attrs "TEXT JSON: soft + per-type fields"
   }
   PROJECTS {
     int  project_id PK
     string prefix
-    blob attrs "JSONB"
+    string attrs "TEXT JSON"
   }
   ROLES {
     int role_id PK
     int workflow_id FK
-    blob attrs "JSONB"
+    string attrs "TEXT JSON"
   }
   WORKFLOW_STAGES {
     int workflow_stage_id PK
     int workflow_id FK
-    blob attrs "JSONB"
+    string attrs "TEXT JSON"
   }
   PROJECTS ||--o{ TICKETS : has
   WORKFLOWS ||--o{ ROLES : defines
@@ -321,8 +321,9 @@ Conservative bias: anything filtered / sorted / FK'd / aggregated stays **Keep**
 
 See ADR `docs/adr/0001-json-attribute-bags.md`. Summary: status-quo additive
 columns (rejected: the churn this epic exists to remove), an EAV side table
-(rejected: join cost, loss of atomic row, reporting pain), and plain TEXT JSON
-(rejected in favour of JSONB for size/speed; TEXT retained only transitionally).
+(rejected: join cost, loss of atomic row, reporting pain), and binary JSONB
+(rejected because it does not survive snapshot export/import — see §4; plain TEXT
+JSON is the chosen, permanent format).
 
 ## 11. Rollout / sequencing
 


### PR DESCRIPTION
Parallel documentation-accuracy review across three clusters (schema/API, CLI/user, process/ops), cross-checked against current code. Fixes the concrete drift found:

**High**
- SPEC.md section 5 presented ~10 columns that were consolidated into attrs and dropped (schema v12) as physical columns. Added a logical-vs-physical note, marked attrs-backed fields with (attrs) on Ticket/Project/Role/Workflow Stage, and added the attrs row to each.
- CHANGELOG.md was far behind and still listed the removed Goals feature and old 70% threshold. Added a 0.1.1103 entry (attrs/v12, migration backup+rollback, Go 1.26.4, Goals removal, recalibrated coverage gates, unassign/edit fixes); historical entries untouched.
- ONBOARDING.md falsely claimed `make build` auto-increments the version; fixed, plus the bad role-create example flag.

**Medium**
- extensible-schema.md: removed leftover JSONB/blob refs that contradicted its own TEXT-JSON decision.
- help.go: role usage advertised removed -motivation/-goals flags, replaced with the real -description/-ac/-dor/-dod.
- Agents.md: corrected the server command name.
- DEVELOPER_GUIDE.md: fixed broken doc links (dropped missing USER_GUIDE.md and docs/archive references).
- GOAL.md: banner clarifying it is product vision, not the removed goal entity.

Build/lint/openapi-validate green; no test asserts the changed help string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
