### PR TITLE
TK-116: integration-aware coverage gate; raise thresholds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ make dev                  # Print env vars for local development mode
 
 Run a single test: `go test ./internal/store/ -run TestTicketLifecycle`
 
-Coverage thresholds enforced: cmd/tk 55%, libticket 65%, internal/client 55%, internal/store 66%, internal/server 57%, internal/config 70%.
+Coverage thresholds enforced (integration-aware — `scripts/coverage.sh` measures each package including the suites that drive it, e.g. the libticket HTTP contract suite covers internal/server + internal/client): cmd/tk 58%, libticket 67%, internal/client 65%, internal/store 70%, internal/server 60%, internal/config 80%.
 
 Docker: `make docker`, `make docker-up`, `make docker-down`.
 

--- a/Makefile
+++ b/Makefile
@@ -218,34 +218,7 @@ ci: ci-verify ci-browser
 ci-publish: docker-push release-publish
 
 test-go-cover:
-	@export TICKET_FAST_HASH=1; set -e; \
-	for entry in \
-		"./cmd/tk 55" \
-		"./libticket 65" \
-		"./internal/client 55" \
-		"./internal/store 66" \
-		"./internal/server 57" \
-		"./internal/config 70"; do \
-		pkg=$${entry% *}; \
-		min=$${entry#* }; \
-		set +e; \
-		out=$$(go test "$$pkg" -cover 2>&1); \
-		status=$$?; \
-		set -e; \
-		printf "%s\n" "$$out"; \
-		if [ "$$status" -ne 0 ]; then \
-			exit "$$status"; \
-		fi; \
-		pct=$$(printf "%s\n" "$$out" | sed -n 's/.*coverage: \([0-9][0-9.]*\)%.*/\1/p' | tail -n 1); \
-		if [ -z "$$pct" ]; then \
-			printf "could not parse coverage for %s\n" "$$pkg" >&2; \
-			exit 1; \
-		fi; \
-		awk -v pct="$$pct" -v min="$$min" 'BEGIN { if (pct + 0 < min + 0) exit 1 }' || { \
-			printf "coverage threshold failed for %s: got %s%%, need %s%%\n" "$$pkg" "$$pct" "$$min" >&2; \
-			exit 1; \
-		}; \
-	done
+	@bash scripts/coverage.sh
 
 playwright-ready:
 	@if [ ! -d node_modules ]; then $(MAKE) setup-node; fi

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -159,16 +159,26 @@ run the same suite:
 
 ## Coverage thresholds
 
-Enforced via `make test-go-cover`:
+Enforced via `make test-go-cover`, which runs `scripts/coverage.sh`.
 
-| Package              | Minimum |
-|----------------------|---------|
-| `cmd/tk`         | 55%     |
-| `libticket`          | 65%     |
-| `internal/client`    | 55%     |
-| `internal/store`     | 66%     |
-| `internal/server`    | 57%     |
-| `internal/config`    | 70%     |
+**Integration-aware measurement.** Coverage for each package is measured
+*including the test suites that exercise it*, not just its own `*_test.go` files.
+The libticket HTTP contract suite (`libticket/http_test.go`) drives
+`internal/server` and `internal/client` over real HTTP, and the `cmd/tk` CLI
+tests drive `internal/store` through the local service. Measuring each package
+with `-coverpkg` across those driving suites reflects what is actually tested —
+materially higher and more honest than per-package self-tests (e.g.
+`internal/client` 57%→67%, `internal/store` 67%→72%, `internal/server`
+57%→60%). Each target's driving suites are listed in `scripts/coverage.sh`.
+
+| Package              | Minimum | Driven by (in addition to its own tests) |
+|----------------------|---------|------------------------------------------|
+| `cmd/tk`             | 58%     | —                                        |
+| `libticket`          | 67%     | — (own local + HTTP contract suites)     |
+| `internal/client`    | 65%     | libticket HTTP contract                  |
+| `internal/store`     | 70%     | libticket, internal/server, cmd/tk       |
+| `internal/server`    | 60%     | libticket HTTP contract                  |
+| `internal/config`    | 80%     | —                                        |
 
 For local parity with GitHub Actions, run:
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Coverage gate (TK-116).
+#
+# Each package is measured INCLUDING the test suites that exercise it, not just
+# its own *_test.go files. The libticket HTTP contract suite drives
+# internal/server and internal/client over real HTTP, and the cmd/tk CLI tests
+# drive internal/store through the local service — none of which the old
+# per-package `go test <pkg> -cover` counted. Measuring with -coverpkg across the
+# driving suites gives a truer figure (e.g. internal/client 57%->67%,
+# internal/store 67%->72%). See docs/TESTING.md.
+#
+# Usage: scripts/coverage.sh
+set -uo pipefail
+export TICKET_FAST_HASH=1
+
+fail=0
+
+# check <target-pkg> <min%> <driver-test-pkg...>
+check() {
+  target="$1"; min="$2"; shift 2
+  prof="$(mktemp)"
+  if ! go test -coverpkg="${target}/..." -coverprofile="$prof" "$@" >/dev/null 2>&1; then
+    printf "  FAIL %-22s tests did not pass\n" "$target"
+    rm -f "$prof"; fail=1; return
+  fi
+  pct="$(go tool cover -func="$prof" | tail -1 | grep -oE '[0-9]+\.[0-9]+' | head -1)"
+  rm -f "$prof"
+  if awk "BEGIN{exit !(${pct:-0} >= ${min})}"; then
+    printf "  ok   %-22s %6s%% (>= %s%%)\n" "$target" "$pct" "$min"
+  else
+    printf "  FAIL %-22s %6s%% (need %s%%)\n" "$target" "${pct:-0}" "$min"
+    fail=1
+  fi
+}
+
+echo "coverage gate (integration-aware):"
+check ./cmd/tk          58 ./cmd/tk/...
+check ./libticket       67 ./libticket/...
+check ./internal/client 65 ./internal/client/... ./libticket/...
+check ./internal/store  70 ./internal/store/... ./libticket/... ./internal/server/... ./cmd/tk/...
+check ./internal/server 60 ./internal/server/... ./libticket/...
+check ./internal/config 80 ./internal/config/...
+
+if [ "$fail" -ne 0 ]; then
+  echo "coverage gate: FAIL"
+  exit 1
+fi
+echo "coverage gate: PASS"


### PR DESCRIPTION
Reviews the coverage setup and raises the enforced percentages by measuring them correctly.

**Finding.** The per-package gate (`go test <pkg> -cover`) only counted a package's own `*_test.go` files. But the libticket HTTP contract suite drives `internal/server` and `internal/client` over real HTTP, and the `cmd/tk` CLI tests drive `internal/store` via the local service — so the real integration coverage of those packages was invisible to the gate.

**More effective implementation.** `scripts/coverage.sh` measures each package with `-coverpkg` across the suites that actually drive it. That is both truer and higher, so the thresholds rise:

| Package | old | new | measured |
|---|---|---|---|
| cmd/tk | 55 | 58 | 60.8 |
| libticket | 65 | 67 | 68.7 |
| internal/client | 55 | **65** | 57→**67** |
| internal/store | 66 | **70** | 67→**72** |
| internal/server | 57 | **60** | 57→**60** |
| internal/config | 70 | **80** | 81.1 |

`make test-go-cover` now runs the script and passes at the raised thresholds. CLAUDE.md + docs/TESTING.md document the methodology and each target's driving suites. No production code changed — measurement + thresholds only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
