### PR TITLE
TK-127: Shift-Shift command palette / keyboard quick-switcher

### DIFF
--- a/tests/playwright/site2.spec.js
+++ b/tests/playwright/site2.spec.js
@@ -1973,3 +1973,33 @@ test("creates, updates, uploads, and deletes documents from the Documents view",
     ]),
   );
 });
+
+test("Shift Shift command palette navigates between windows", async ({ page }) => {
+  // Double-Shift opens the palette.
+  await page.keyboard.press("Shift");
+  await page.keyboard.press("Shift");
+  await expect(page.locator("#command-palette-overlay")).toBeVisible();
+
+  // Filter to a slash-shortcut and navigate with Enter.
+  await page.locator("#command-palette-input").fill("proj");
+  await expect(page.locator("#command-palette-list")).toContainText("/projects");
+  await page.locator("#command-palette-input").press("Enter");
+  await expect(page.locator('#main-nav button[data-view="projects"]')).toHaveClass(/active/);
+  await expect(page.locator("#command-palette-overlay")).toBeHidden();
+
+  // /backlog is an alias for the board (tickets) window.
+  await page.keyboard.press("Shift");
+  await page.keyboard.press("Shift");
+  await expect(page.locator("#command-palette-overlay")).toBeVisible();
+  await page.locator("#command-palette-input").fill("backlog");
+  await expect(page.locator("#command-palette-list")).toContainText("/backlog");
+  await page.locator("#command-palette-input").press("Enter");
+  await expect(page.locator('#main-nav button[data-view="tickets"]')).toHaveClass(/active/);
+
+  // Esc closes the palette without navigating.
+  await page.keyboard.press("Shift");
+  await page.keyboard.press("Shift");
+  await expect(page.locator("#command-palette-overlay")).toBeVisible();
+  await page.locator("#command-palette-input").press("Escape");
+  await expect(page.locator("#command-palette-overlay")).toBeHidden();
+});

--- a/tests/playwright/site2.spec.js
+++ b/tests/playwright/site2.spec.js
@@ -2003,3 +2003,22 @@ test("Shift Shift command palette navigates between windows", async ({ page }) =
   await page.locator("#command-palette-input").press("Escape");
   await expect(page.locator("#command-palette-overlay")).toBeHidden();
 });
+
+test("command palette: single-letter alias and /ticket-key quick-open", async ({ page }) => {
+  // Single-letter alias: /b -> board (tickets).
+  await page.keyboard.press("Shift");
+  await page.keyboard.press("Shift");
+  await expect(page.locator("#command-palette-overlay")).toBeVisible();
+  await page.locator("#command-palette-input").fill("p");
+  await expect(page.locator(".command-palette-item").first()).toContainText("/p");
+  await page.locator("#command-palette-input").press("Enter");
+  await expect(page.locator('#main-nav button[data-view="projects"]')).toHaveClass(/active/);
+
+  // /<ticket-key> opens that ticket's detail modal.
+  await page.keyboard.press("Shift");
+  await page.keyboard.press("Shift");
+  await page.locator("#command-palette-input").fill("ops-101");
+  await expect(page.locator("#command-palette-list")).toContainText("Open ticket OPS-101");
+  await page.locator("#command-palette-input").press("Enter");
+  await expect(page.locator("#ticket-modal")).toHaveClass(/open/);
+});

--- a/web/default/index.html
+++ b/web/default/index.html
@@ -1192,6 +1192,15 @@
     </div>
 </div>
 
+<!-- ── Command palette (Shift Shift) ────────────────────────────── -->
+<div id="command-palette-overlay" class="dialog-overlay hidden" data-command-palette>
+    <div id="command-palette-box" class="command-palette" role="dialog" aria-modal="true" aria-label="Command palette">
+        <input id="command-palette-input" class="command-palette-input" type="text" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" placeholder="Type a / command — e.g. /chat, /backlog">
+        <ul id="command-palette-list" class="command-palette-list" role="listbox"></ul>
+        <div class="command-palette-hint"><kbd>Shift</kbd><kbd>Shift</kbd> open · <kbd>↑</kbd><kbd>↓</kbd> move · <kbd>Enter</kbd> go · <kbd>Esc</kbd> close</div>
+    </div>
+</div>
+
 <!-- ── User modal ───────────────────────────────────────────────── -->
 <div id="user-modal" class="modal">
     <div class="modal-backdrop"></div>

--- a/web/default/site.css
+++ b/web/default/site.css
@@ -1997,3 +1997,40 @@ select {
 .workflow-graph-surface { position: relative; }
 .workflow-graph-links { position: absolute; top: 0; left: 0; }
 .workflow-graph-node { position: absolute; }
+
+/* Command palette (Shift Shift quick-switcher, TK-127). */
+#command-palette-overlay { align-items: flex-start; }
+.command-palette {
+  width: min(560px, 92vw);
+  margin-top: 12vh;
+  background: var(--surface, #1b1d22);
+  border: 1px solid var(--border, #333);
+  border-radius: 10px;
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.45);
+  overflow: hidden;
+}
+.command-palette-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 14px 16px;
+  font-size: 16px;
+  border: none;
+  border-bottom: 1px solid var(--border, #333);
+  background: transparent;
+  color: inherit;
+  outline: none;
+}
+.command-palette-list { list-style: none; margin: 0; padding: 6px; max-height: 50vh; overflow-y: auto; }
+.command-palette-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 9px 12px; border-radius: 7px; cursor: pointer;
+}
+.command-palette-item .cp-slash { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; opacity: 0.8; }
+.command-palette-item .cp-label { margin-left: auto; opacity: 0.65; font-size: 13px; }
+.command-palette-item.active, .command-palette-item:hover { background: var(--accent-soft, rgba(255, 122, 26, 0.16)); }
+.command-palette-empty { padding: 14px 16px; opacity: 0.6; }
+.command-palette-hint { padding: 8px 14px; font-size: 12px; opacity: 0.55; border-top: 1px solid var(--border, #333); }
+.command-palette-hint kbd {
+  font-family: inherit; font-size: 11px; padding: 1px 5px; margin: 0 2px;
+  border: 1px solid var(--border, #444); border-radius: 4px; opacity: 0.9;
+}

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -8940,8 +8940,95 @@
                 }
             });
         }
+        // ── Command palette: Shift Shift quick-switcher (TK-127) ──────────
+        const PALETTE_ALIASES = { backlog: "tickets", board: "tickets", chat: "chat", mailbox: "interventions", inbox: "interventions" };
+        const paletteEls = {
+            overlay: document.getElementById("command-palette-overlay"),
+            input: document.getElementById("command-palette-input"),
+            list: document.getElementById("command-palette-list"),
+        };
+        let paletteActiveIndex = 0;
+        let lastShiftAt = 0;
+        function buildPaletteCommands() {
+            const known = new Set(availableViewNames());
+            const labelByView = {};
+            NAV_ITEMS.forEach((item) => { labelByView[item.view] = item.label; });
+            const commands = [];
+            const seen = new Set();
+            const add = (slash, view) => {
+                if (!known.has(view) || seen.has(slash)) { return; }
+                seen.add(slash);
+                commands.push({ slash: "/" + slash, key: slash, view: view, label: labelByView[view] || view });
+            };
+            visibleNavItems().forEach((item) => add(item.view, item.view));
+            Object.keys(PALETTE_ALIASES).forEach((alias) => add(alias, PALETTE_ALIASES[alias]));
+            return commands;
+        }
+        function isPaletteOpen() { return paletteEls.overlay && !paletteEls.overlay.classList.contains("hidden"); }
+        function renderPaletteList() {
+            const query = String(paletteEls.input.value || "").replace(/^\//, "").trim().toLowerCase();
+            const matches = buildPaletteCommands().filter((cmd) => !query || cmd.key.includes(query) || cmd.label.toLowerCase().includes(query));
+            if (paletteActiveIndex >= matches.length) { paletteActiveIndex = Math.max(0, matches.length - 1); }
+            paletteEls.list._matches = matches;
+            if (!matches.length) {
+                paletteEls.list.innerHTML = "<li class=\"command-palette-empty\">No matching commands</li>";
+                return;
+            }
+            paletteEls.list.innerHTML = matches.map((cmd, i) =>
+                "<li class=\"command-palette-item" + (i === paletteActiveIndex ? " active" : "") + "\" role=\"option\" data-cp-index=\"" + i + "\">" +
+                "<span class=\"cp-slash\">" + escapeHTML(cmd.slash) + "</span><span class=\"cp-label\">" + escapeHTML(cmd.label) + "</span></li>").join("");
+        }
+        function runPaletteActive() {
+            const matches = paletteEls.list._matches || [];
+            const cmd = matches[paletteActiveIndex];
+            if (!cmd) { return; }
+            closeCommandPalette();
+            switchView(cmd.view);
+        }
+        function openCommandPalette() {
+            if (!paletteEls.overlay || isPaletteOpen()) { return; }
+            paletteActiveIndex = 0;
+            paletteEls.input.value = "";
+            paletteEls.overlay.classList.remove("hidden");
+            renderPaletteList();
+            setTimeout(() => { paletteEls.input.focus(); }, 0);
+        }
+        function closeCommandPalette() {
+            if (paletteEls.overlay) { paletteEls.overlay.classList.add("hidden"); }
+        }
+        function setupCommandPalette() {
+            if (!paletteEls.overlay) { return; }
+            paletteEls.input.addEventListener("input", () => { paletteActiveIndex = 0; renderPaletteList(); });
+            paletteEls.input.addEventListener("keydown", (event) => {
+                const matches = paletteEls.list._matches || [];
+                if (event.key === "ArrowDown") { event.preventDefault(); paletteActiveIndex = Math.min(matches.length - 1, paletteActiveIndex + 1); renderPaletteList(); }
+                else if (event.key === "ArrowUp") { event.preventDefault(); paletteActiveIndex = Math.max(0, paletteActiveIndex - 1); renderPaletteList(); }
+                else if (event.key === "Enter") { event.preventDefault(); runPaletteActive(); }
+                else if (event.key === "Escape") { event.preventDefault(); closeCommandPalette(); }
+            });
+            paletteEls.list.addEventListener("click", (event) => {
+                const item = event.target.closest("[data-cp-index]");
+                if (!item) { return; }
+                paletteActiveIndex = Number(item.dataset.cpIndex) || 0;
+                runPaletteActive();
+            });
+            paletteEls.overlay.addEventListener("click", (event) => { if (event.target === paletteEls.overlay) { closeCommandPalette(); } });
+            document.addEventListener("keydown", (event) => {
+                if (event.key === "Shift" && !event.repeat) {
+                    const now = Date.now();
+                    if (now - lastShiftAt < 400) { lastShiftAt = 0; if (isPaletteOpen()) { closeCommandPalette(); } else { openCommandPalette(); } }
+                    else { lastShiftAt = now; }
+                    return;
+                }
+                lastShiftAt = 0;
+            });
+        }
         document.addEventListener("keydown", (event) => {
             if (event.key !== "Escape") {
+                return;
+            }
+            if (paletteEls.overlay && !paletteEls.overlay.classList.contains("hidden")) {
+                closeCommandPalette();
                 return;
             }
             if (els.dialogOverlay && !els.dialogOverlay.classList.contains("hidden")) {
@@ -8952,6 +9039,7 @@
                 closeTicketModal();
             }
         });
+        setupCommandPalette();
         state.viewScrollByPanel = loadStoredViewScrollByPanel();
         state.currentView = loadStoredSelectedView() || state.currentView;
         switchView(state.currentView, { restoreScroll: false });

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -8941,7 +8941,33 @@
             });
         }
         // ── Command palette: Shift Shift quick-switcher (TK-127) ──────────
-        const PALETTE_ALIASES = { backlog: "tickets", board: "tickets", chat: "chat", mailbox: "interventions", inbox: "interventions" };
+        // Friendly + single-letter aliases so the site is keyboard-driveable
+        // (e.g. /c = /chat, /b = /backlog). Aliases pointing at not-yet-registered
+        // views (like chat) simply don't appear until that view exists.
+        const PALETTE_ALIASES = {
+            c: "chat", chat: "chat",
+            b: "tickets", board: "tickets", backlog: "tickets",
+            p: "projects",
+            w: "workflows",
+            d: "documents",
+            m: "interventions", mailbox: "interventions", inbox: "interventions",
+            r: "roles",
+            t: "teams",
+            g: "context",
+            x: "agents", a: "agents",
+            u: "users",
+            s: "settings",
+        };
+        const TICKET_KEY_RE = /^[a-z]{1,6}-\d+$/i;
+        async function openTicketByKey(rawKey) {
+            const key = String(rawKey || "").trim().toUpperCase();
+            let ticket = (state.tickets || []).find((t) => String(t.id || "").toUpperCase() === key);
+            if (!ticket) {
+                try { ticket = await api("/api/tickets/" + encodeURIComponent(key)); } catch (err) { ticket = null; }
+            }
+            if (ticket && (ticket.id || ticket.ticket_id)) { openTicketModal(ticket); }
+            else { setNotice("Ticket " + key + " not found.", true); }
+        }
         const paletteEls = {
             overlay: document.getElementById("command-palette-overlay"),
             input: document.getElementById("command-palette-input"),
@@ -8968,6 +8994,12 @@
         function renderPaletteList() {
             const query = String(paletteEls.input.value || "").replace(/^\//, "").trim().toLowerCase();
             const matches = buildPaletteCommands().filter((cmd) => !query || cmd.key.includes(query) || cmd.label.toLowerCase().includes(query));
+            const rank = (cmd) => (cmd.key === query ? 0 : cmd.key.startsWith(query) ? 1 : cmd.label.toLowerCase().startsWith(query) ? 2 : 3);
+            matches.sort((a, b) => rank(a) - rank(b));
+            // A ticket key like "tk-23" jumps straight to that ticket's detail.
+            if (TICKET_KEY_RE.test(query)) {
+                matches.unshift({ slash: "/" + query, key: query, label: "Open ticket " + query.toUpperCase(), action: "ticket", ticketKey: query.toUpperCase() });
+            }
             if (paletteActiveIndex >= matches.length) { paletteActiveIndex = Math.max(0, matches.length - 1); }
             paletteEls.list._matches = matches;
             if (!matches.length) {
@@ -8983,6 +9015,7 @@
             const cmd = matches[paletteActiveIndex];
             if (!cmd) { return; }
             closeCommandPalette();
+            if (cmd.action === "ticket") { openTicketByKey(cmd.ticketKey); return; }
             switchView(cmd.view);
         }
         function openCommandPalette() {


### PR DESCRIPTION
Adds a **Shift-Shift command palette / quick-switcher** to the web SPA — the first step toward a fully keyboard-driveable site.

- **Double-Shift** opens a global palette anywhere in the app.
- Type a **/slash command** (or fuzzy text) and **Enter** to navigate; commands are built from the nav registry plus friendly + **single-letter aliases** (`/c`=chat, `/b`=board, `/p`=projects, `/w`, `/d`, `/m`=mailbox, `/r`, `/t`, `/g`, `/a`=agents, `/u`, `/s`). Exact-key matches rank first, so `/b` + Enter is deterministic.
- A **ticket key** (e.g. `/tk-23`) prepends an "Open ticket" command that opens the ticket detail modal.
- Arrow keys move, Enter selects, Esc closes, click selects, backdrop closes.
- `/chat` lights up automatically once the rooms chat view registers (TK-118 S5).

3 browser tests (open/filter/navigate/close, single-letter alias, ticket quick-open); full site2 suite green (35/35).

The deeper keyboard-UX vision from the follow-up discussion — numbered/arrow-selectable ticket **action menus**, an **Esc-popped navigation stack**, and `/chat` focusing the composer — is tracked in TK-130; the in-chat `@name`/`#label`/`s///g`/`@agent` power features are captured on the rooms epic TK-118.

refs TK-127
