### PR TITLE
TK-118: multiplayer chat rooms with conversational + taskable agents

### DIFF
--- a/docs/design/multiplayer-rooms.md
+++ b/docs/design/multiplayer-rooms.md
@@ -1,0 +1,147 @@
+# Multiplayer rooms (Slack-style) with taskable agents
+
+Status: design (TK-118 / S1 = TK-119). Authoritative spec for the rooms feature.
+
+## 1. Goal
+
+Real-time multiplayer chat with **rooms** you create, join, and leave, where
+**humans and agents** collaborate. Agents are first-class room members that can
+(a) **converse** live in the room and (b) be **tasked** with tracked work via
+`/task`, which creates a ticket assigned to the agent; the existing
+orchestrator/agent loop does the work and reports progress + result back into the
+room.
+
+## 2. Scope model — one `rooms` table, three scopes
+
+A room carries an optional `project_id` and optional `ticket_id`:
+
+| Scope        | project_id | ticket_id | Example |
+|--------------|-----------|-----------|---------|
+| **global**   | null      | null      | `#general`, `#random` |
+| **project**  | set       | null      | a project's `#ops` channel |
+| **breakout** | set       | set       | a room around epic `TK-118` |
+
+Membership and visibility are independent of scope: every room is `public`
+(discoverable + joinable) or `private` (invite-only). Project/breakout rooms
+default their joinable audience to members with access to the project, but the
+room is still its own membership list.
+
+## 3. Data model
+
+```mermaid
+erDiagram
+  ROOMS {
+    int     room_id PK
+    string  slug
+    string  name
+    string  topic
+    string  visibility "public|private"
+    int     project_id FK "nullable"
+    string  ticket_id FK  "nullable (breakout)"
+    int     archived
+    string  created_by FK
+    string  attrs "TEXT JSON"
+  }
+  ROOM_MEMBERS {
+    int    room_id FK
+    string member_id FK "user_id or agent user_id"
+    string role "owner|member"
+    string joined_at
+    string last_read_at
+  }
+  ROOM_MESSAGES {
+    int    message_id PK
+    int    room_id FK
+    string sender_id FK
+    string kind "text|system|task|agent_event"
+    string body
+    string attrs "TEXT JSON (task_id, mentions, ...)"
+    string created_at
+  }
+  ROOMS ||--o{ ROOM_MEMBERS : has
+  ROOMS ||--o{ ROOM_MESSAGES : has
+```
+
+Notes:
+- Agents and humans share the `users` id space (an agent is found by
+  `GetUserByUsername`), so `member_id`/`sender_id` reference users uniformly; a
+  member's `is_agent` is derived from the user record.
+- `attrs` follows the extensible-schema convention (see
+  `docs/design/extensible-schema.md`): per-message `task_id`, `mentions[]`, and
+  agent-event payloads live there — no migration to add message metadata.
+- `kind`: `text` (human/agent chat), `system` (joins/leaves/topic changes),
+  `task` (a `/task` was issued), `agent_event` (orchestrator progress/result).
+
+## 4. Realtime — room-scoped WebSocket hub (S4)
+
+A hub keyed by `room_id`. On join, a client subscribes; the hub broadcasts to the
+room's connected members only:
+- `message` — a new `room_message`
+- `presence` — member joined/left/online/offline
+- `typing` — transient typing indicator
+- `agent_event` — orchestrator progress for a tasked ticket
+
+Built on the existing `chat_ws.go` connection patterns (upgrade, read/write
+pumps, heartbeat) but membership/broadcast aware. Auth reuses the session/bearer
+(humans) and Basic (agents) model.
+
+## 5. Agents in rooms
+
+### 5a. Conversational (S6)
+An agent member responds when **@-mentioned**. The server starts a per-room agent
+bridge (reusing the `chat_ws.go` process bridge) seeded with the recent room
+transcript + the mention; the agent's streamed reply is posted as `room_messages`
+of kind `text` (sender = the agent) and broadcast live. Typing/presence reflect
+the agent.
+
+### 5b. Tasked — `/task` (S7)
+`/task @agent <description>` in a room:
+1. Creates a **ticket** (type `task`) — scoped to the room's `project_id` (and
+   parented to `ticket_id` for breakout rooms); falls back to a default project
+   for global rooms.
+2. Assigns the agent and links ticket ↔ room (`room_messages.attrs.task_id`, and
+   the ticket records the originating room).
+3. The existing **orchestrator/agent** picks it up; lifecycle transitions and the
+   completion/PR are posted back into the room as `agent_event` / `system`
+   messages. The room becomes the live feed for that ticket's progress.
+
+This reuses the entire ticket lifecycle, audit trail, and PR flow — chat is just
+the originating + reporting surface.
+
+## 6. REST API (S3)
+
+```
+POST   /api/rooms                      create
+GET    /api/rooms                      list (scope + visibility + membership filters)
+GET    /api/rooms/{id}                 detail
+PATCH  /api/rooms/{id}                 rename/topic/visibility
+DELETE /api/rooms/{id}                 archive
+POST   /api/rooms/{id}/join            join
+POST   /api/rooms/{id}/leave           leave
+GET    /api/rooms/{id}/members         members (+ presence)
+POST   /api/rooms/{id}/members         invite (user or agent)
+GET    /api/rooms/{id}/messages        history (paginated, before/after cursor)
+POST   /api/rooms/{id}/messages        post a message (also the /task entrypoint)
+GET    /api/rooms/ws?room={id}         upgrade to the room WebSocket
+```
+
+## 7. Web UI (S5)
+
+Slack-like view in the SPA (`data-view="chat"`): left sidebar lists rooms grouped
+by scope (Global / This project / Breakouts), a message feed with sender avatars +
+agent badges, a composer supporting `@mentions` and `/task`/`/`-commands, a
+members panel with presence, and create/join/leave controls. Live over the WS hub.
+
+## 8. Command palette integration (TK-127)
+
+Double-Shift opens a global quick-switcher; slash-shortcuts route to SPA views via
+a command **registry**. The chat view self-registers `/chat`; existing views
+register `/backlog` (tickets), `/board`, `/projects`, `/workflows`, etc. The
+palette is shipped independently (TK-127) and the rooms view plugs `/chat` into it
+in S5.
+
+## 9. Story sequencing
+
+S1 design (this) → S2 schema/store → S3 REST → S4 WS hub → S5 web UI →
+S6 conversational agents → S7 `/task` → S8 breakout rooms. Each story branches off
+the epic branch and PRs into it; the epic merges to `main` once green.

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -72,6 +72,7 @@ func registerAPI(mux *http.ServeMux, db *sql.DB, version string, live *liveHub, 
 	r.registerTeamHandlers()
 	r.registerProjectHandlers()
 	r.registerDocumentHandlers()
+	r.registerRoomHandlers()
 	r.registerTicketHandlers()
 	r.registerReleaseHandlers()
 	r.registerOrgHandlers()

--- a/internal/server/api_rooms.go
+++ b/internal/server/api_rooms.go
@@ -1,7 +1,9 @@
 package server
 
 import (
+	"context"
 	"database/sql"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -131,7 +133,7 @@ func (r *router) registerRoomHandlers() {
 		case "members":
 			handleRoomMembers(w, req, db, roomID)
 		case "messages":
-			handleRoomMessages(w, req, db, user, roomID, r.live)
+			handleRoomMessages(w, req, db, user, room, r.live)
 		default:
 			writeError(w, http.StatusNotFound, "unknown room subresource")
 		}
@@ -218,7 +220,8 @@ func handleRoomMembers(w http.ResponseWriter, req *http.Request, db *sql.DB, roo
 	}
 }
 
-func handleRoomMessages(w http.ResponseWriter, req *http.Request, db *sql.DB, user store.User, roomID int64, hub *liveHub) {
+func handleRoomMessages(w http.ResponseWriter, req *http.Request, db *sql.DB, user store.User, room store.Room, hub *liveHub) {
+	roomID := room.ID
 	switch req.Method {
 	case http.MethodGet:
 		limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
@@ -241,6 +244,20 @@ func handleRoomMessages(w http.ResponseWriter, req *http.Request, db *sql.DB, us
 			writeError(w, http.StatusBadRequest, "message body is required")
 			return
 		}
+		// "/task [@agent] <description>" creates a tracked ticket assigned to the
+		// agent and posts a task message linking it (S7).
+		if assignee, desc, isTask := parseTaskCommand(body.Body); isTask {
+			msg, terr := createRoomTask(req.Context(), db, room, user, assignee, desc)
+			if terr != nil {
+				writeError(w, http.StatusBadRequest, terr.Error())
+				return
+			}
+			if hub != nil {
+				hub.broadcastRoomMessage(roomID, msg)
+			}
+			writeJSON(w, http.StatusCreated, msg)
+			return
+		}
 		msg, err := store.PostRoomMessage(req.Context(), db, store.RoomMessage{
 			RoomID:   roomID,
 			SenderID: user.ID,
@@ -259,4 +276,64 @@ func handleRoomMessages(w http.ResponseWriter, req *http.Request, db *sql.DB, us
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 	}
+}
+
+// parseTaskCommand parses "/task [@assignee] <description>". ok is false when the
+// body is not a /task command.
+func parseTaskCommand(body string) (assignee, description string, ok bool) {
+	s := strings.TrimSpace(body)
+	if s != "/task" && !strings.HasPrefix(s, "/task ") {
+		return "", "", false
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(s, "/task"))
+	if strings.HasPrefix(rest, "@") {
+		fields := strings.SplitN(rest, " ", 2)
+		assignee = strings.TrimPrefix(fields[0], "@")
+		if len(fields) > 1 {
+			rest = strings.TrimSpace(fields[1])
+		} else {
+			rest = ""
+		}
+	}
+	return assignee, rest, true
+}
+
+// createRoomTask creates a tracked ticket from a /task command and posts a task
+// message into the room linking it. The existing orchestrator/agent loop then
+// picks the ticket up.
+func createRoomTask(ctx context.Context, db *sql.DB, room store.Room, user store.User, assignee, description string) (store.RoomMessage, error) {
+	if room.ProjectID == nil {
+		return store.RoomMessage{}, fmt.Errorf("tasking requires a project or breakout room")
+	}
+	if strings.TrimSpace(description) == "" {
+		return store.RoomMessage{}, fmt.Errorf("describe the work after /task")
+	}
+	var parent *string
+	if strings.TrimSpace(room.TicketID) != "" {
+		tid := room.TicketID
+		parent = &tid
+	}
+	ticket, err := store.CreateTicket(ctx, db, store.TicketCreateParams{
+		ProjectID: *room.ProjectID,
+		ParentID:  parent,
+		Type:      "task",
+		Title:     description,
+		Assignee:  assignee,
+		CreatedBy: user.ID,
+		Author:    user.Username,
+	})
+	if err != nil {
+		return store.RoomMessage{}, err
+	}
+	label := "📋 Created " + ticket.ID + ": " + description
+	if assignee != "" {
+		label += " — assigned @" + assignee
+	}
+	return store.PostRoomMessage(ctx, db, store.RoomMessage{
+		RoomID:   room.ID,
+		SenderID: user.ID,
+		Kind:     "task",
+		Body:     label,
+		Attrs:    store.Attrs{"task_id": ticket.ID, "assignee": assignee},
+	})
 }

--- a/internal/server/api_rooms.go
+++ b/internal/server/api_rooms.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -258,11 +259,16 @@ func handleRoomMessages(w http.ResponseWriter, req *http.Request, db *sql.DB, us
 			writeJSON(w, http.StatusCreated, msg)
 			return
 		}
+		attrs := store.Attrs{}
+		if mentions := parseMentions(body.Body); len(mentions) > 0 {
+			attrs["mentions"] = mentions
+		}
 		msg, err := store.PostRoomMessage(req.Context(), db, store.RoomMessage{
 			RoomID:   roomID,
 			SenderID: user.ID,
 			Kind:     body.Kind,
 			Body:     body.Body,
+			Attrs:    attrs,
 		})
 		if err != nil {
 			writeError(w, http.StatusBadRequest, err.Error())
@@ -336,4 +342,21 @@ func createRoomTask(ctx context.Context, db *sql.DB, room store.Room, user store
 		Body:     label,
 		Attrs:    store.Attrs{"task_id": ticket.ID, "assignee": assignee},
 	})
+}
+
+var roomMentionRe = regexp.MustCompile(`@([A-Za-z0-9][A-Za-z0-9_-]*)`)
+
+// parseMentions extracts unique @-mentioned names from a message body.
+func parseMentions(body string) []string {
+	matches := roomMentionRe.FindAllStringSubmatch(body, -1)
+	seen := map[string]bool{}
+	var out []string
+	for _, m := range matches {
+		name := m[1]
+		if !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	return out
 }

--- a/internal/server/api_rooms.go
+++ b/internal/server/api_rooms.go
@@ -1,0 +1,260 @@
+package server
+
+import (
+	"database/sql"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/simonski/ticket/internal/store"
+)
+
+// registerRoomHandlers wires the multiplayer-rooms REST API (TK-118 / S3).
+func (r *router) registerRoomHandlers() {
+	db := r.db
+	mux := r.mux
+
+	// Collection: list + create.
+	mux.HandleFunc("/api/rooms", func(w http.ResponseWriter, req *http.Request) {
+		user, err := requireUser(db, req)
+		if err != nil {
+			writeAuthError(w, err)
+			return
+		}
+		switch req.Method {
+		case http.MethodGet:
+			filter := store.RoomFilter{MemberID: user.ID}
+			q := req.URL.Query()
+			if q.Get("scope") == "global" {
+				filter.GlobalOnly = true
+			}
+			if pid := strings.TrimSpace(q.Get("project_id")); pid != "" {
+				if v, perr := strconv.ParseInt(pid, 10, 64); perr == nil {
+					filter.ProjectID = &v
+				}
+			}
+			if tk := strings.TrimSpace(q.Get("ticket_id")); tk != "" {
+				filter.TicketID = tk
+			}
+			rooms, lerr := store.ListRooms(req.Context(), db, filter)
+			if lerr != nil {
+				writeStoreError(w, lerr)
+				return
+			}
+			if rooms == nil {
+				rooms = []store.Room{}
+			}
+			writeJSON(w, http.StatusOK, rooms)
+		case http.MethodPost:
+			var body struct {
+				Name       string `json:"name"`
+				Topic      string `json:"topic"`
+				Visibility string `json:"visibility"`
+				ProjectID  *int64 `json:"project_id"`
+				TicketID   string `json:"ticket_id"`
+			}
+			if derr := decodeJSONBody(req, &body); derr != nil {
+				writeError(w, http.StatusBadRequest, "invalid request body")
+				return
+			}
+			room, cerr := store.CreateRoom(req.Context(), db, store.Room{
+				Name:       body.Name,
+				Topic:      body.Topic,
+				Visibility: body.Visibility,
+				ProjectID:  body.ProjectID,
+				TicketID:   body.TicketID,
+				CreatedBy:  user.ID,
+			})
+			if cerr != nil {
+				writeError(w, http.StatusBadRequest, cerr.Error())
+				return
+			}
+			writeJSON(w, http.StatusCreated, room)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+	})
+
+	// Item + subresources.
+	mux.HandleFunc("/api/rooms/", func(w http.ResponseWriter, req *http.Request) {
+		user, err := requireUser(db, req)
+		if err != nil {
+			writeAuthError(w, err)
+			return
+		}
+		trimmed := strings.Trim(strings.TrimPrefix(req.URL.Path, "/api/rooms/"), "/")
+		parts := strings.Split(trimmed, "/")
+		roomID, perr := strconv.ParseInt(parts[0], 10, 64)
+		if perr != nil || roomID <= 0 {
+			writeError(w, http.StatusBadRequest, "invalid room id")
+			return
+		}
+		room, gerr := store.GetRoom(req.Context(), db, roomID)
+		if gerr != nil {
+			writeError(w, http.StatusNotFound, "room not found")
+			return
+		}
+		isMember, _ := store.IsRoomMember(req.Context(), db, roomID, user.ID)
+		if room.Visibility == "private" && !isMember {
+			writeError(w, http.StatusForbidden, "not a member of this room")
+			return
+		}
+
+		sub := ""
+		if len(parts) > 1 {
+			sub = parts[1]
+		}
+		switch sub {
+		case "":
+			handleRoomItem(w, req, db, user, room)
+		case "join":
+			if req.Method != http.MethodPost {
+				writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+				return
+			}
+			if jerr := store.JoinRoom(req.Context(), db, roomID, user.ID, "member"); jerr != nil {
+				writeStoreError(w, jerr)
+				return
+			}
+			fresh, _ := store.GetRoom(req.Context(), db, roomID)
+			writeJSON(w, http.StatusOK, fresh)
+		case "leave":
+			if req.Method != http.MethodPost {
+				writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+				return
+			}
+			if lerr := store.LeaveRoom(req.Context(), db, roomID, user.ID); lerr != nil {
+				writeStoreError(w, lerr)
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]string{"status": "left"})
+		case "members":
+			handleRoomMembers(w, req, db, roomID)
+		case "messages":
+			handleRoomMessages(w, req, db, user, roomID)
+		default:
+			writeError(w, http.StatusNotFound, "unknown room subresource")
+		}
+	})
+}
+
+func handleRoomItem(w http.ResponseWriter, req *http.Request, db *sql.DB, user store.User, room store.Room) {
+	switch req.Method {
+	case http.MethodGet:
+		writeJSON(w, http.StatusOK, room)
+	case http.MethodPatch:
+		if room.CreatedBy != user.ID && user.Role != "admin" {
+			writeError(w, http.StatusForbidden, "only the room owner or an admin can edit a room")
+			return
+		}
+		var body struct {
+			Name       *string `json:"name"`
+			Topic      *string `json:"topic"`
+			Visibility *string `json:"visibility"`
+		}
+		if derr := decodeJSONBody(req, &body); derr != nil {
+			writeError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		name, topic, visibility := room.Name, room.Topic, room.Visibility
+		if body.Name != nil {
+			name = *body.Name
+		}
+		if body.Topic != nil {
+			topic = *body.Topic
+		}
+		if body.Visibility != nil {
+			visibility = *body.Visibility
+		}
+		updated, uerr := store.UpdateRoom(req.Context(), db, room.ID, name, topic, visibility)
+		if uerr != nil {
+			writeError(w, http.StatusBadRequest, uerr.Error())
+			return
+		}
+		writeJSON(w, http.StatusOK, updated)
+	case http.MethodDelete:
+		if room.CreatedBy != user.ID && user.Role != "admin" {
+			writeError(w, http.StatusForbidden, "only the room owner or an admin can archive a room")
+			return
+		}
+		if aerr := store.ArchiveRoom(req.Context(), db, room.ID); aerr != nil {
+			writeStoreError(w, aerr)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]string{"status": "archived"})
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func handleRoomMembers(w http.ResponseWriter, req *http.Request, db *sql.DB, roomID int64) {
+	switch req.Method {
+	case http.MethodGet:
+		members, err := store.ListRoomMembers(req.Context(), db, roomID)
+		if err != nil {
+			writeStoreError(w, err)
+			return
+		}
+		if members == nil {
+			members = []store.RoomMember{}
+		}
+		writeJSON(w, http.StatusOK, members)
+	case http.MethodPost:
+		var body struct {
+			MemberID string `json:"member_id"`
+		}
+		if derr := decodeJSONBody(req, &body); derr != nil || strings.TrimSpace(body.MemberID) == "" {
+			writeError(w, http.StatusBadRequest, "member_id is required")
+			return
+		}
+		if jerr := store.JoinRoom(req.Context(), db, roomID, body.MemberID, "member"); jerr != nil {
+			writeStoreError(w, jerr)
+			return
+		}
+		members, _ := store.ListRoomMembers(req.Context(), db, roomID)
+		writeJSON(w, http.StatusCreated, members)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
+func handleRoomMessages(w http.ResponseWriter, req *http.Request, db *sql.DB, user store.User, roomID int64) {
+	switch req.Method {
+	case http.MethodGet:
+		limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
+		before, _ := strconv.ParseInt(req.URL.Query().Get("before"), 10, 64)
+		msgs, err := store.ListRoomMessages(req.Context(), db, roomID, limit, before)
+		if err != nil {
+			writeStoreError(w, err)
+			return
+		}
+		if msgs == nil {
+			msgs = []store.RoomMessage{}
+		}
+		writeJSON(w, http.StatusOK, msgs)
+	case http.MethodPost:
+		var body struct {
+			Body string `json:"body"`
+			Kind string `json:"kind"`
+		}
+		if derr := decodeJSONBody(req, &body); derr != nil || strings.TrimSpace(body.Body) == "" {
+			writeError(w, http.StatusBadRequest, "message body is required")
+			return
+		}
+		msg, err := store.PostRoomMessage(req.Context(), db, store.RoomMessage{
+			RoomID:   roomID,
+			SenderID: user.ID,
+			Kind:     body.Kind,
+			Body:     body.Body,
+		})
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		// Broadcast to live room subscribers (no-op until the WS hub lands, S4).
+		broadcastRoomMessage(roomID, msg)
+		writeJSON(w, http.StatusCreated, msg)
+	default:
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}

--- a/internal/server/api_rooms.go
+++ b/internal/server/api_rooms.go
@@ -131,7 +131,7 @@ func (r *router) registerRoomHandlers() {
 		case "members":
 			handleRoomMembers(w, req, db, roomID)
 		case "messages":
-			handleRoomMessages(w, req, db, user, roomID)
+			handleRoomMessages(w, req, db, user, roomID, r.live)
 		default:
 			writeError(w, http.StatusNotFound, "unknown room subresource")
 		}
@@ -218,7 +218,7 @@ func handleRoomMembers(w http.ResponseWriter, req *http.Request, db *sql.DB, roo
 	}
 }
 
-func handleRoomMessages(w http.ResponseWriter, req *http.Request, db *sql.DB, user store.User, roomID int64) {
+func handleRoomMessages(w http.ResponseWriter, req *http.Request, db *sql.DB, user store.User, roomID int64, hub *liveHub) {
 	switch req.Method {
 	case http.MethodGet:
 		limit, _ := strconv.Atoi(req.URL.Query().Get("limit"))
@@ -251,8 +251,10 @@ func handleRoomMessages(w http.ResponseWriter, req *http.Request, db *sql.DB, us
 			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
-		// Broadcast to live room subscribers (no-op until the WS hub lands, S4).
-		broadcastRoomMessage(roomID, msg)
+		// Fan the message out to live room subscribers (S4 hub).
+		if hub != nil {
+			hub.broadcastRoomMessage(roomID, msg)
+		}
 		writeJSON(w, http.StatusCreated, msg)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")

--- a/internal/server/api_rooms_test.go
+++ b/internal/server/api_rooms_test.go
@@ -1,0 +1,159 @@
+package server
+
+import (
+	"net/http"
+	"strconv"
+	"testing"
+
+	"github.com/simonski/ticket/internal/store"
+)
+
+func roomLoginToken(t *testing.T, handler http.Handler, username, password string) string {
+	t.Helper()
+	resp := doJSONRequest(t, handler, http.MethodPost, "/api/login", map[string]string{
+		"username": username,
+		"password": password,
+	}, "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("login %s: status = %d", username, resp.Code)
+	}
+	var payload struct {
+		Token string `json:"token"`
+	}
+	decodeResponse(t, resp, &payload)
+	if payload.Token == "" {
+		t.Fatalf("login %s: empty token", username)
+	}
+	return payload.Token
+}
+
+func registerUser(t *testing.T, handler http.Handler, username, password string) {
+	t.Helper()
+	resp := doJSONRequest(t, handler, http.MethodPost, "/api/register", map[string]string{
+		"username": username,
+		"password": password,
+	}, "")
+	if resp.Code != http.StatusCreated {
+		t.Fatalf("register %s: status = %d", username, resp.Code)
+	}
+}
+
+func TestRoomAPICRUDAndMessages(t *testing.T) {
+	t.Parallel()
+	handler, db := testHandler(t)
+	defer db.Close()
+	admin := roomLoginToken(t, handler, "admin", "password")
+
+	// Create a room.
+	createResp := doJSONRequest(t, handler, http.MethodPost, "/api/rooms", map[string]any{
+		"name":  "General",
+		"topic": "Everything",
+	}, admin)
+	if createResp.Code != http.StatusCreated {
+		t.Fatalf("create room status = %d, body=%s", createResp.Code, createResp.Body.String())
+	}
+	var room store.Room
+	decodeResponse(t, createResp, &room)
+	if room.ID == 0 || room.Slug != "general" {
+		t.Fatalf("created room = %+v", room)
+	}
+
+	// List shows it.
+	listResp := doJSONRequest(t, handler, http.MethodGet, "/api/rooms", nil, admin)
+	if listResp.Code != http.StatusOK {
+		t.Fatalf("list status = %d", listResp.Code)
+	}
+	var rooms []store.Room
+	decodeResponse(t, listResp, &rooms)
+	if len(rooms) != 1 || rooms[0].ID != room.ID {
+		t.Fatalf("list = %+v", rooms)
+	}
+
+	// Post + list messages.
+	roomPath := "/api/rooms/" + itoa(room.ID)
+	postResp := doJSONRequest(t, handler, http.MethodPost, roomPath+"/messages", map[string]string{"body": "hello room"}, admin)
+	if postResp.Code != http.StatusCreated {
+		t.Fatalf("post message status = %d, body=%s", postResp.Code, postResp.Body.String())
+	}
+	msgResp := doJSONRequest(t, handler, http.MethodGet, roomPath+"/messages", nil, admin)
+	var msgs []store.RoomMessage
+	decodeResponse(t, msgResp, &msgs)
+	if len(msgs) != 1 || msgs[0].Body != "hello room" {
+		t.Fatalf("messages = %+v", msgs)
+	}
+
+	// Empty body rejected.
+	badResp := doJSONRequest(t, handler, http.MethodPost, roomPath+"/messages", map[string]string{"body": ""}, admin)
+	if badResp.Code != http.StatusBadRequest {
+		t.Fatalf("empty message status = %d, want 400", badResp.Code)
+	}
+
+	// Archive.
+	delResp := doJSONRequest(t, handler, http.MethodDelete, roomPath, nil, admin)
+	if delResp.Code != http.StatusOK {
+		t.Fatalf("archive status = %d", delResp.Code)
+	}
+	listResp = doJSONRequest(t, handler, http.MethodGet, "/api/rooms", nil, admin)
+	decodeResponse(t, listResp, &rooms)
+	if len(rooms) != 0 {
+		t.Fatalf("archived room still listed: %+v", rooms)
+	}
+}
+
+func TestRoomAPIJoinLeaveAndPrivateVisibility(t *testing.T) {
+	t.Parallel()
+	handler, db := testHandler(t)
+	defer db.Close()
+	admin := roomLoginToken(t, handler, "admin", "password")
+	registerUser(t, handler, "bob", "password123")
+	bob := roomLoginToken(t, handler, "bob", "password123")
+
+	// Public room: bob can see and join.
+	pubResp := doJSONRequest(t, handler, http.MethodPost, "/api/rooms", map[string]any{"name": "Public"}, admin)
+	var pub store.Room
+	decodeResponse(t, pubResp, &pub)
+	pubPath := "/api/rooms/" + itoa(pub.ID)
+
+	var bobRooms []store.Room
+	decodeResponse(t, doJSONRequest(t, handler, http.MethodGet, "/api/rooms", nil, bob), &bobRooms)
+	if !roomListed(bobRooms, pub.ID) {
+		t.Fatalf("bob should see the public room")
+	}
+	if joinResp := doJSONRequest(t, handler, http.MethodPost, pubPath+"/join", nil, bob); joinResp.Code != http.StatusOK {
+		t.Fatalf("bob join status = %d", joinResp.Code)
+	}
+	var members []store.RoomMember
+	decodeResponse(t, doJSONRequest(t, handler, http.MethodGet, pubPath+"/members", nil, admin), &members)
+	if len(members) != 2 {
+		t.Fatalf("members after join = %d, want 2", len(members))
+	}
+	if leaveResp := doJSONRequest(t, handler, http.MethodPost, pubPath+"/leave", nil, bob); leaveResp.Code != http.StatusOK {
+		t.Fatalf("bob leave status = %d", leaveResp.Code)
+	}
+
+	// Private room: bob cannot see or fetch it.
+	privResp := doJSONRequest(t, handler, http.MethodPost, "/api/rooms", map[string]any{"name": "Secret", "visibility": "private"}, admin)
+	var priv store.Room
+	decodeResponse(t, privResp, &priv)
+	decodeResponse(t, doJSONRequest(t, handler, http.MethodGet, "/api/rooms", nil, bob), &bobRooms)
+	if roomListed(bobRooms, priv.ID) {
+		t.Fatalf("bob should not see the private room")
+	}
+	getResp := doJSONRequest(t, handler, http.MethodGet, "/api/rooms/"+itoa(priv.ID), nil, bob)
+	if getResp.Code != http.StatusForbidden {
+		t.Fatalf("bob fetch private room status = %d, want 403", getResp.Code)
+	}
+}
+
+func roomListed(rooms []store.Room, id int64) bool {
+	for _, r := range rooms {
+		if r.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func itoa(n int64) string {
+	return strconv.FormatInt(n, 10)
+}

--- a/internal/server/api_rooms_test.go
+++ b/internal/server/api_rooms_test.go
@@ -240,3 +240,31 @@ func TestRoomTaskCommandCreatesTicket(t *testing.T) {
 		t.Fatalf("/task in global room status = %d, want 400", badTask.Code)
 	}
 }
+
+func TestParseMentions(t *testing.T) {
+	got := parseMentions("hey @alice and @bob-1, see #backend and @alice again")
+	want := []string{"alice", "bob-1"}
+	if len(got) != len(want) || got[0] != "alice" || got[1] != "bob-1" {
+		t.Fatalf("parseMentions = %v, want %v", got, want)
+	}
+	if len(parseMentions("no mentions here")) != 0 {
+		t.Fatalf("expected no mentions")
+	}
+}
+
+func TestRoomMessageStoresMentions(t *testing.T) {
+	t.Parallel()
+	handler, db := testHandler(t)
+	defer db.Close()
+	admin := roomLoginToken(t, handler, "admin", "password")
+	var room store.Room
+	decodeResponse(t, doJSONRequest(t, handler, http.MethodPost, "/api/rooms", map[string]any{"name": "Standup"}, admin), &room)
+
+	var msg store.RoomMessage
+	decodeResponse(t, doJSONRequest(t, handler, http.MethodPost, "/api/rooms/"+itoa(room.ID)+"/messages",
+		map[string]string{"body": "ping @agent-1 about #deploy"}, admin), &msg)
+	mentions, ok := msg.Attrs["mentions"].([]any)
+	if !ok || len(mentions) != 1 || mentions[0] != "agent-1" {
+		t.Fatalf("message mentions = %v (ok=%v)", msg.Attrs["mentions"], ok)
+	}
+}

--- a/internal/server/api_rooms_test.go
+++ b/internal/server/api_rooms_test.go
@@ -157,3 +157,86 @@ func roomListed(rooms []store.Room, id int64) bool {
 func itoa(n int64) string {
 	return strconv.FormatInt(n, 10)
 }
+
+func TestParseTaskCommand(t *testing.T) {
+	cases := []struct {
+		body     string
+		assignee string
+		desc     string
+		ok       bool
+	}{
+		{"/task fix the login bug", "", "fix the login bug", true},
+		{"/task @agent-1 ship the feature", "agent-1", "ship the feature", true},
+		{"  /task   @bob   do it  ", "bob", "do it", true},
+		{"/task", "", "", true},
+		{"hello world", "", "", false},
+		{"/taskfoo", "", "", false},
+	}
+	for _, tc := range cases {
+		a, d, ok := parseTaskCommand(tc.body)
+		if ok != tc.ok || a != tc.assignee || d != tc.desc {
+			t.Errorf("parseTaskCommand(%q) = (%q,%q,%v), want (%q,%q,%v)", tc.body, a, d, ok, tc.assignee, tc.desc, tc.ok)
+		}
+	}
+}
+
+func TestRoomTaskCommandCreatesTicket(t *testing.T) {
+	t.Parallel()
+	handler, db := testHandler(t)
+	defer db.Close()
+	admin := roomLoginToken(t, handler, "admin", "password")
+
+	// A project to scope the room/ticket to.
+	projResp := doJSONRequest(t, handler, http.MethodPost, "/api/projects", map[string]any{
+		"prefix": "ROOM",
+		"title":  "Room Project",
+	}, admin)
+	if projResp.Code != http.StatusCreated {
+		t.Fatalf("create project status = %d, body=%s", projResp.Code, projResp.Body.String())
+	}
+	var project store.Project
+	decodeResponse(t, projResp, &project)
+
+	// A project-scoped room.
+	roomResp := doJSONRequest(t, handler, http.MethodPost, "/api/rooms", map[string]any{
+		"name":       "Build",
+		"project_id": project.ID,
+	}, admin)
+	var room store.Room
+	decodeResponse(t, roomResp, &room)
+	if room.ProjectID == nil {
+		t.Fatalf("project room missing project_id: %+v", room)
+	}
+
+	// /task creates a ticket and posts a task message linking it.
+	taskResp := doJSONRequest(t, handler, http.MethodPost, "/api/rooms/"+itoa(room.ID)+"/messages",
+		map[string]string{"body": "/task wire up the deploy script"}, admin)
+	if taskResp.Code != http.StatusCreated {
+		t.Fatalf("/task status = %d, body=%s", taskResp.Code, taskResp.Body.String())
+	}
+	var msg store.RoomMessage
+	decodeResponse(t, taskResp, &msg)
+	if msg.Kind != "task" {
+		t.Fatalf("task message kind = %q, want task", msg.Kind)
+	}
+	ticketKey := msg.Attrs.GetString("task_id")
+	if ticketKey == "" {
+		t.Fatalf("task message has no task_id: %+v", msg.Attrs)
+	}
+
+	// The ticket exists.
+	getTicket := doJSONRequest(t, handler, http.MethodGet, "/api/tickets/"+ticketKey, nil, admin)
+	if getTicket.Code != http.StatusOK {
+		t.Fatalf("created ticket %s not found, status = %d", ticketKey, getTicket.Code)
+	}
+
+	// Tasking a global room is rejected.
+	globalResp := doJSONRequest(t, handler, http.MethodPost, "/api/rooms", map[string]any{"name": "Global"}, admin)
+	var global store.Room
+	decodeResponse(t, globalResp, &global)
+	badTask := doJSONRequest(t, handler, http.MethodPost, "/api/rooms/"+itoa(global.ID)+"/messages",
+		map[string]string{"body": "/task do something"}, admin)
+	if badTask.Code != http.StatusBadRequest {
+		t.Fatalf("/task in global room status = %d, want 400", badTask.Code)
+	}
+}

--- a/internal/server/realtime.go
+++ b/internal/server/realtime.go
@@ -13,6 +13,8 @@ import (
 	"net"
 	"net/http"
 	"strings"
+
+	"github.com/simonski/ticket/internal/store"
 	"sync"
 	"time"
 )
@@ -24,6 +26,8 @@ type liveEvent struct {
 	ChangeType string `json:"change_type,omitempty"`
 	ProjectID  int64  `json:"project_id,omitempty"`
 	TicketID   string `json:"ticket_id,omitempty"`
+	RoomID     int64  `json:"room_id,omitempty"`
+	Payload    any    `json:"payload,omitempty"`
 	At         string `json:"at"`
 }
 
@@ -38,6 +42,7 @@ type liveClient struct {
 	done      chan struct{}
 	once      sync.Once
 	projectID int64 // if set, only receive events for this project
+	roomID    int64 // if set, also receive room events for this room
 }
 
 func newLiveHub() *liveHub {
@@ -74,8 +79,7 @@ func (h *liveHub) broadcast(event liveEvent) {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 	for client := range h.clients {
-		// Skip clients subscribed to a different project.
-		if client.projectID != 0 && event.ProjectID != 0 && client.projectID != event.ProjectID {
+		if !deliverToClient(client, event) {
 			continue
 		}
 		select {
@@ -83,6 +87,24 @@ func (h *liveHub) broadcast(event liveEvent) {
 		default:
 		}
 	}
+}
+
+// deliverToClient decides whether a live event should be delivered to a client.
+// Room events go only to clients subscribed to that room; other events respect
+// the optional project subscription filter.
+func deliverToClient(client *liveClient, event liveEvent) bool {
+	if event.RoomID != 0 {
+		return client.roomID == event.RoomID
+	}
+	if client.projectID != 0 && event.ProjectID != 0 && client.projectID != event.ProjectID {
+		return false
+	}
+	return true
+}
+
+// broadcastRoomMessage fans a newly-posted room message out to subscribers.
+func (h *liveHub) broadcastRoomMessage(roomID int64, msg store.RoomMessage) {
+	h.broadcast(liveEvent{Type: "room_message", RoomID: roomID, Payload: msg})
 }
 
 func (c *liveClient) close() {
@@ -142,9 +164,15 @@ func websocketServe(hub *liveHub, w http.ResponseWriter, r *http.Request) error 
 			var msg struct {
 				Type      string `json:"type"`
 				ProjectID int64  `json:"project_id"`
+				RoomID    int64  `json:"room_id"`
 			}
-			if json.Unmarshal(payload, &msg) == nil && msg.Type == "subscribe" && msg.ProjectID > 0 {
-				client.projectID = msg.ProjectID
+			if json.Unmarshal(payload, &msg) == nil && msg.Type == "subscribe" {
+				if msg.ProjectID > 0 {
+					client.projectID = msg.ProjectID
+				}
+				if msg.RoomID > 0 {
+					client.roomID = msg.RoomID
+				}
 			}
 		}
 	}

--- a/internal/server/room_hub.go
+++ b/internal/server/room_hub.go
@@ -1,0 +1,11 @@
+package server
+
+import "github.com/simonski/ticket/internal/store"
+
+// broadcastRoomMessage delivers a freshly-posted message to live room
+// subscribers. It is a no-op until the room WebSocket hub is implemented in
+// TK-118 / S4, which will replace this with real fan-out.
+func broadcastRoomMessage(roomID int64, msg store.RoomMessage) {
+	_ = roomID
+	_ = msg
+}

--- a/internal/server/room_hub_test.go
+++ b/internal/server/room_hub_test.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"encoding/json"
+	"net"
+	"testing"
+
+	"github.com/simonski/ticket/internal/store"
+)
+
+func TestDeliverToClientRoomFilter(t *testing.T) {
+	cases := []struct {
+		name   string
+		client *liveClient
+		event  liveEvent
+		want   bool
+	}{
+		{"room event to matching room", &liveClient{roomID: 5}, liveEvent{RoomID: 5}, true},
+		{"room event to other room", &liveClient{roomID: 9}, liveEvent{RoomID: 5}, false},
+		{"room event to non-room client", &liveClient{}, liveEvent{RoomID: 5}, false},
+		{"project event respects project filter", &liveClient{projectID: 2}, liveEvent{ProjectID: 3}, false},
+		{"project event to matching project", &liveClient{projectID: 3}, liveEvent{ProjectID: 3}, true},
+		{"unscoped event to room client still delivered", &liveClient{roomID: 5}, liveEvent{Type: "ping"}, true},
+	}
+	for _, tc := range cases {
+		if got := deliverToClient(tc.client, tc.event); got != tc.want {
+			t.Errorf("%s: deliverToClient = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestRoomHubBroadcastReachesOnlySubscribers(t *testing.T) {
+	hub := newLiveHub()
+	connA, _ := net.Pipe()
+	connB, _ := net.Pipe()
+	defer connA.Close()
+	defer connB.Close()
+
+	inRoom := hub.add(connA)
+	inRoom.roomID = 5
+	elsewhere := hub.add(connB)
+	elsewhere.roomID = 9
+
+	hub.broadcastRoomMessage(5, store.RoomMessage{ID: 1, RoomID: 5, SenderID: "alice", Body: "hello"})
+
+	select {
+	case payload := <-inRoom.send:
+		var ev struct {
+			Type    string `json:"type"`
+			RoomID  int64  `json:"room_id"`
+			Payload struct {
+				Body string `json:"body"`
+			} `json:"payload"`
+		}
+		if err := json.Unmarshal(payload, &ev); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if ev.Type != "room_message" || ev.RoomID != 5 || ev.Payload.Body != "hello" {
+			t.Fatalf("subscriber event = %+v", ev)
+		}
+	default:
+		t.Fatal("room-5 subscriber did not receive the message")
+	}
+
+	select {
+	case <-elsewhere.send:
+		t.Fatal("room-9 subscriber should not have received the room-5 message")
+	default:
+	}
+}

--- a/internal/store/room.go
+++ b/internal/store/room.go
@@ -12,18 +12,18 @@ import (
 // TicketID: both nil/empty = global; ProjectID set = project room; ProjectID +
 // TicketID set = a breakout room around an epic/story.
 type Room struct {
-	ID         int64
-	Slug       string
-	Name       string
-	Topic      string
-	Visibility string // public | private
-	ProjectID  *int64
-	TicketID   string // breakout ticket key, "" when not a breakout
-	Archived   bool
-	CreatedBy  string
-	Attrs      Attrs
-	CreatedAt  string
-	UpdatedAt  string
+	ID         int64  `json:"room_id"`
+	Slug       string `json:"slug"`
+	Name       string `json:"name"`
+	Topic      string `json:"topic"`
+	Visibility string `json:"visibility"` // public | private
+	ProjectID  *int64 `json:"project_id,omitempty"`
+	TicketID   string `json:"ticket_id,omitempty"` // breakout ticket key, "" when not a breakout
+	Archived   bool   `json:"archived"`
+	CreatedBy  string `json:"created_by"`
+	Attrs      Attrs  `json:"attrs,omitempty"`
+	CreatedAt  string `json:"created_at"`
+	UpdatedAt  string `json:"updated_at"`
 }
 
 // Scope returns "global", "project", or "breakout".
@@ -39,22 +39,22 @@ func (r Room) Scope() string {
 
 // RoomMember is a participant (human or agent) in a room.
 type RoomMember struct {
-	RoomID     int64
-	MemberID   string
-	Role       string // owner | member
-	JoinedAt   string
-	LastReadAt string
+	RoomID     int64  `json:"room_id"`
+	MemberID   string `json:"member_id"`
+	Role       string `json:"role"` // owner | member
+	JoinedAt   string `json:"joined_at"`
+	LastReadAt string `json:"last_read_at"`
 }
 
 // RoomMessage is a single message in a room.
 type RoomMessage struct {
-	ID        int64
-	RoomID    int64
-	SenderID  string
-	Kind      string // text | system | task | agent_event
-	Body      string
-	Attrs     Attrs
-	CreatedAt string
+	ID        int64  `json:"message_id"`
+	RoomID    int64  `json:"room_id"`
+	SenderID  string `json:"sender_id"`
+	Kind      string `json:"kind"` // text | system | task | agent_event
+	Body      string `json:"body"`
+	Attrs     Attrs  `json:"attrs,omitempty"`
+	CreatedAt string `json:"created_at"`
 }
 
 // RoomFilter narrows ListRooms. A zero filter lists all non-archived rooms.

--- a/internal/store/room.go
+++ b/internal/store/room.go
@@ -1,0 +1,347 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Room is a multiplayer chat room (TK-118). Scope is derived from ProjectID and
+// TicketID: both nil/empty = global; ProjectID set = project room; ProjectID +
+// TicketID set = a breakout room around an epic/story.
+type Room struct {
+	ID         int64
+	Slug       string
+	Name       string
+	Topic      string
+	Visibility string // public | private
+	ProjectID  *int64
+	TicketID   string // breakout ticket key, "" when not a breakout
+	Archived   bool
+	CreatedBy  string
+	Attrs      Attrs
+	CreatedAt  string
+	UpdatedAt  string
+}
+
+// Scope returns "global", "project", or "breakout".
+func (r Room) Scope() string {
+	if r.ProjectID == nil {
+		return "global"
+	}
+	if strings.TrimSpace(r.TicketID) != "" {
+		return "breakout"
+	}
+	return "project"
+}
+
+// RoomMember is a participant (human or agent) in a room.
+type RoomMember struct {
+	RoomID     int64
+	MemberID   string
+	Role       string // owner | member
+	JoinedAt   string
+	LastReadAt string
+}
+
+// RoomMessage is a single message in a room.
+type RoomMessage struct {
+	ID        int64
+	RoomID    int64
+	SenderID  string
+	Kind      string // text | system | task | agent_event
+	Body      string
+	Attrs     Attrs
+	CreatedAt string
+}
+
+// RoomFilter narrows ListRooms. A zero filter lists all non-archived rooms.
+type RoomFilter struct {
+	ProjectID  *int64 // nil = any scope; non-nil = rooms for that project (incl. breakouts)
+	GlobalOnly bool   // only rooms with no project
+	TicketID   string // only breakout rooms for this ticket
+	MemberID   string // if set, private rooms are included only when this member belongs
+}
+
+var roomSlugInvalid = regexp.MustCompile(`[^a-z0-9-]+`)
+
+// SlugifyRoomName produces a url-safe slug from a room name.
+func SlugifyRoomName(name string) string {
+	s := strings.ToLower(strings.TrimSpace(name))
+	s = strings.ReplaceAll(s, " ", "-")
+	s = roomSlugInvalid.ReplaceAllString(s, "")
+	s = strings.Trim(s, "-")
+	if s == "" {
+		s = "room"
+	}
+	return s
+}
+
+func normalizeVisibility(v string) string {
+	if strings.ToLower(strings.TrimSpace(v)) == "private" {
+		return "private"
+	}
+	return "public"
+}
+
+// CreateRoom inserts a room and joins the creator as its owner.
+func CreateRoom(ctx context.Context, db *sql.DB, room Room) (Room, error) {
+	name := strings.TrimSpace(room.Name)
+	if name == "" {
+		return Room{}, fmt.Errorf("room name is required")
+	}
+	slug := strings.TrimSpace(room.Slug)
+	if slug == "" {
+		slug = SlugifyRoomName(name)
+	}
+	attrsJSON, err := marshalAttrs(room.Attrs)
+	if err != nil {
+		return Room{}, err
+	}
+	res, err := db.ExecContext(ctx, `
+		INSERT INTO rooms (slug, name, topic, visibility, project_id, ticket_id, archived, created_by, attrs)
+		VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?)`,
+		slug, name, strings.TrimSpace(room.Topic), normalizeVisibility(room.Visibility),
+		room.ProjectID, strings.TrimSpace(room.TicketID), strings.TrimSpace(room.CreatedBy), attrsJSON)
+	if err != nil {
+		return Room{}, fmt.Errorf("create room: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return Room{}, err
+	}
+	if creator := strings.TrimSpace(room.CreatedBy); creator != "" {
+		if err := JoinRoom(ctx, db, id, creator, "owner"); err != nil {
+			return Room{}, err
+		}
+	}
+	return GetRoom(ctx, db, id)
+}
+
+const roomColumns = `room_id, slug, name, topic, visibility, project_id, ticket_id, archived, created_by, attrs, created_at, updated_at`
+
+func scanRoom(s interface{ Scan(...any) error }) (Room, error) {
+	var (
+		r         Room
+		projectID sql.NullInt64
+		ticketID  sql.NullString
+		archived  int
+		attrsJSON string
+	)
+	if err := s.Scan(&r.ID, &r.Slug, &r.Name, &r.Topic, &r.Visibility, &projectID, &ticketID, &archived, &r.CreatedBy, &attrsJSON, &r.CreatedAt, &r.UpdatedAt); err != nil {
+		return Room{}, err
+	}
+	if projectID.Valid {
+		pid := projectID.Int64
+		r.ProjectID = &pid
+	}
+	r.TicketID = ticketID.String
+	r.Archived = archived != 0
+	attrs, err := parseAttrs(attrsJSON)
+	if err != nil {
+		return Room{}, err
+	}
+	r.Attrs = attrs
+	return r, nil
+}
+
+// GetRoom returns a single room by id.
+func GetRoom(ctx context.Context, db *sql.DB, id int64) (Room, error) {
+	row := db.QueryRowContext(ctx, `SELECT `+roomColumns+` FROM rooms WHERE room_id = ?`, id)
+	r, err := scanRoom(row)
+	if err == sql.ErrNoRows {
+		return Room{}, fmt.Errorf("room %d not found", id)
+	}
+	return r, err
+}
+
+// ListRooms returns non-archived rooms matching the filter, newest activity first.
+func ListRooms(ctx context.Context, db *sql.DB, filter RoomFilter) ([]Room, error) {
+	var clauses []string
+	var args []any
+	clauses = append(clauses, "archived = 0")
+	if filter.GlobalOnly {
+		clauses = append(clauses, "project_id IS NULL")
+	} else if filter.ProjectID != nil {
+		clauses = append(clauses, "project_id = ?")
+		args = append(args, *filter.ProjectID)
+	}
+	if strings.TrimSpace(filter.TicketID) != "" {
+		clauses = append(clauses, "ticket_id = ?")
+		args = append(args, strings.TrimSpace(filter.TicketID))
+	}
+	// Private rooms are only visible to members.
+	if member := strings.TrimSpace(filter.MemberID); member != "" {
+		clauses = append(clauses, "(visibility = 'public' OR room_id IN (SELECT room_id FROM room_members WHERE member_id = ?))")
+		args = append(args, member)
+	} else {
+		clauses = append(clauses, "visibility = 'public'")
+	}
+	query := `SELECT ` + roomColumns + ` FROM rooms WHERE ` + strings.Join(clauses, " AND ") + ` ORDER BY updated_at DESC, room_id DESC`
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var rooms []Room
+	for rows.Next() {
+		r, err := scanRoom(rows)
+		if err != nil {
+			return nil, err
+		}
+		rooms = append(rooms, r)
+	}
+	return rooms, rows.Err()
+}
+
+// UpdateRoom updates the mutable room fields (name/topic/visibility).
+func UpdateRoom(ctx context.Context, db *sql.DB, id int64, name, topic, visibility string) (Room, error) {
+	if strings.TrimSpace(name) == "" {
+		return Room{}, fmt.Errorf("room name is required")
+	}
+	_, err := db.ExecContext(ctx, `UPDATE rooms SET name = ?, topic = ?, visibility = ?, updated_at = CURRENT_TIMESTAMP WHERE room_id = ?`,
+		strings.TrimSpace(name), strings.TrimSpace(topic), normalizeVisibility(visibility), id)
+	if err != nil {
+		return Room{}, err
+	}
+	return GetRoom(ctx, db, id)
+}
+
+// ArchiveRoom soft-deletes a room.
+func ArchiveRoom(ctx context.Context, db *sql.DB, id int64) error {
+	_, err := db.ExecContext(ctx, `UPDATE rooms SET archived = 1, updated_at = CURRENT_TIMESTAMP WHERE room_id = ?`, id)
+	return err
+}
+
+// JoinRoom adds a member (idempotent). role defaults to "member".
+func JoinRoom(ctx context.Context, db *sql.DB, roomID int64, memberID, role string) error {
+	memberID = strings.TrimSpace(memberID)
+	if memberID == "" {
+		return fmt.Errorf("member id is required")
+	}
+	if role != "owner" {
+		role = "member"
+	}
+	_, err := db.ExecContext(ctx, `INSERT OR IGNORE INTO room_members (room_id, member_id, role) VALUES (?, ?, ?)`, roomID, memberID, role)
+	return err
+}
+
+// LeaveRoom removes a member from a room.
+func LeaveRoom(ctx context.Context, db *sql.DB, roomID int64, memberID string) error {
+	_, err := db.ExecContext(ctx, `DELETE FROM room_members WHERE room_id = ? AND member_id = ?`, roomID, strings.TrimSpace(memberID))
+	return err
+}
+
+// IsRoomMember reports whether a member belongs to a room.
+func IsRoomMember(ctx context.Context, db *sql.DB, roomID int64, memberID string) (bool, error) {
+	var n int
+	err := db.QueryRowContext(ctx, `SELECT COUNT(1) FROM room_members WHERE room_id = ? AND member_id = ?`, roomID, strings.TrimSpace(memberID)).Scan(&n)
+	return n > 0, err
+}
+
+// ListRoomMembers returns a room's members, owners first.
+func ListRoomMembers(ctx context.Context, db *sql.DB, roomID int64) ([]RoomMember, error) {
+	rows, err := db.QueryContext(ctx, `SELECT room_id, member_id, role, joined_at, last_read_at FROM room_members WHERE room_id = ? ORDER BY (role = 'owner') DESC, joined_at ASC`, roomID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var members []RoomMember
+	for rows.Next() {
+		var m RoomMember
+		if err := rows.Scan(&m.RoomID, &m.MemberID, &m.Role, &m.JoinedAt, &m.LastReadAt); err != nil {
+			return nil, err
+		}
+		members = append(members, m)
+	}
+	return members, rows.Err()
+}
+
+// PostRoomMessage appends a message to a room and bumps the room's updated_at.
+func PostRoomMessage(ctx context.Context, db *sql.DB, msg RoomMessage) (RoomMessage, error) {
+	if strings.TrimSpace(msg.SenderID) == "" {
+		return RoomMessage{}, fmt.Errorf("sender id is required")
+	}
+	kind := strings.TrimSpace(msg.Kind)
+	if kind == "" {
+		kind = "text"
+	}
+	attrsJSON, err := marshalAttrs(msg.Attrs)
+	if err != nil {
+		return RoomMessage{}, err
+	}
+	res, err := db.ExecContext(ctx, `INSERT INTO room_messages (room_id, sender_id, kind, body, attrs) VALUES (?, ?, ?, ?, ?)`,
+		msg.RoomID, strings.TrimSpace(msg.SenderID), kind, msg.Body, attrsJSON)
+	if err != nil {
+		return RoomMessage{}, fmt.Errorf("post room message: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return RoomMessage{}, err
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE rooms SET updated_at = CURRENT_TIMESTAMP WHERE room_id = ?`, msg.RoomID); err != nil {
+		return RoomMessage{}, err
+	}
+	return GetRoomMessage(ctx, db, id)
+}
+
+// GetRoomMessage returns a single message by id.
+func GetRoomMessage(ctx context.Context, db *sql.DB, id int64) (RoomMessage, error) {
+	row := db.QueryRowContext(ctx, `SELECT message_id, room_id, sender_id, kind, body, attrs, created_at FROM room_messages WHERE message_id = ?`, id)
+	return scanRoomMessage(row)
+}
+
+func scanRoomMessage(s interface{ Scan(...any) error }) (RoomMessage, error) {
+	var (
+		m         RoomMessage
+		attrsJSON string
+	)
+	if err := s.Scan(&m.ID, &m.RoomID, &m.SenderID, &m.Kind, &m.Body, &attrsJSON, &m.CreatedAt); err != nil {
+		return RoomMessage{}, err
+	}
+	attrs, err := parseAttrs(attrsJSON)
+	if err != nil {
+		return RoomMessage{}, err
+	}
+	m.Attrs = attrs
+	return m, nil
+}
+
+// ListRoomMessages returns up to limit messages for a room in chronological
+// order. When beforeID > 0 it returns the page of messages strictly older than
+// beforeID (for "load earlier" pagination).
+func ListRoomMessages(ctx context.Context, db *sql.DB, roomID int64, limit int, beforeID int64) ([]RoomMessage, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	args := []any{roomID}
+	where := "room_id = ?"
+	if beforeID > 0 {
+		where += " AND message_id < ?"
+		args = append(args, beforeID)
+	}
+	args = append(args, limit)
+	// Fetch newest-first with the limit, then reverse to chronological order.
+	rows, err := db.QueryContext(ctx, `SELECT message_id, room_id, sender_id, kind, body, attrs, created_at FROM room_messages WHERE `+where+` ORDER BY message_id DESC LIMIT ?`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var msgs []RoomMessage
+	for rows.Next() {
+		m, err := scanRoomMessage(rows)
+		if err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for i, j := 0, len(msgs)-1; i < j; i, j = i+1, j-1 {
+		msgs[i], msgs[j] = msgs[j], msgs[i]
+	}
+	return msgs, nil
+}

--- a/internal/store/room_test.go
+++ b/internal/store/room_test.go
@@ -1,0 +1,188 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRoomScopeAndCreate(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+	pid := int64(7)
+
+	global, err := CreateRoom(ctx, db, Room{Name: "General", CreatedBy: "alice"})
+	if err != nil {
+		t.Fatalf("create global: %v", err)
+	}
+	if global.Scope() != "global" {
+		t.Fatalf("global scope = %q", global.Scope())
+	}
+	if global.Slug != "general" {
+		t.Fatalf("slug = %q, want general", global.Slug)
+	}
+
+	proj, err := CreateRoom(ctx, db, Room{Name: "Ops Channel", CreatedBy: "alice", ProjectID: &pid})
+	if err != nil {
+		t.Fatalf("create project room: %v", err)
+	}
+	if proj.Scope() != "project" {
+		t.Fatalf("project scope = %q", proj.Scope())
+	}
+
+	breakout, err := CreateRoom(ctx, db, Room{Name: "Epic TK-118", CreatedBy: "alice", ProjectID: &pid, TicketID: "TK-118"})
+	if err != nil {
+		t.Fatalf("create breakout: %v", err)
+	}
+	if breakout.Scope() != "breakout" {
+		t.Fatalf("breakout scope = %q", breakout.Scope())
+	}
+
+	// The creator is auto-joined as owner.
+	members, err := ListRoomMembers(ctx, db, global.ID)
+	if err != nil {
+		t.Fatalf("members: %v", err)
+	}
+	if len(members) != 1 || members[0].MemberID != "alice" || members[0].Role != "owner" {
+		t.Fatalf("creator membership = %+v", members)
+	}
+}
+
+func TestRoomJoinLeaveAndMembership(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+	room, err := CreateRoom(ctx, db, Room{Name: "team", CreatedBy: "alice"})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := JoinRoom(ctx, db, room.ID, "bob", "member"); err != nil {
+		t.Fatalf("join: %v", err)
+	}
+	// Idempotent join.
+	if err := JoinRoom(ctx, db, room.ID, "bob", "member"); err != nil {
+		t.Fatalf("re-join: %v", err)
+	}
+	if ok, _ := IsRoomMember(ctx, db, room.ID, "bob"); !ok {
+		t.Fatalf("bob should be a member")
+	}
+	members, _ := ListRoomMembers(ctx, db, room.ID)
+	if len(members) != 2 {
+		t.Fatalf("members = %d, want 2", len(members))
+	}
+	if err := LeaveRoom(ctx, db, room.ID, "bob"); err != nil {
+		t.Fatalf("leave: %v", err)
+	}
+	if ok, _ := IsRoomMember(ctx, db, room.ID, "bob"); ok {
+		t.Fatalf("bob should have left")
+	}
+}
+
+func TestRoomListVisibilityAndScope(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+	pid := int64(3)
+
+	pub, _ := CreateRoom(ctx, db, Room{Name: "public room", CreatedBy: "alice"})
+	priv, _ := CreateRoom(ctx, db, Room{Name: "secret", CreatedBy: "alice", Visibility: "private"})
+	_, _ = CreateRoom(ctx, db, Room{Name: "proj room", CreatedBy: "alice", ProjectID: &pid})
+
+	// A non-member sees only public rooms.
+	rooms, err := ListRooms(ctx, db, RoomFilter{MemberID: "bob"})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if containsRoom(rooms, priv.ID) {
+		t.Fatalf("bob should not see the private room")
+	}
+	if !containsRoom(rooms, pub.ID) {
+		t.Fatalf("bob should see the public room")
+	}
+
+	// alice (a member/owner of the private room) sees it.
+	rooms, _ = ListRooms(ctx, db, RoomFilter{MemberID: "alice"})
+	if !containsRoom(rooms, priv.ID) {
+		t.Fatalf("alice should see her private room")
+	}
+
+	// Global-only filter excludes the project room.
+	globals, _ := ListRooms(ctx, db, RoomFilter{GlobalOnly: true, MemberID: "alice"})
+	for _, r := range globals {
+		if r.ProjectID != nil {
+			t.Fatalf("global filter returned a project room: %+v", r)
+		}
+	}
+
+	// Project filter returns only that project's rooms.
+	projRooms, _ := ListRooms(ctx, db, RoomFilter{ProjectID: &pid, MemberID: "alice"})
+	for _, r := range projRooms {
+		if r.ProjectID == nil || *r.ProjectID != pid {
+			t.Fatalf("project filter returned wrong room: %+v", r)
+		}
+	}
+}
+
+func TestRoomMessagesAndPagination(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+	room, _ := CreateRoom(ctx, db, Room{Name: "chat", CreatedBy: "alice"})
+
+	for i := range 5 {
+		body := []string{"one", "two", "three", "four", "five"}[i]
+		if _, err := PostRoomMessage(ctx, db, RoomMessage{RoomID: room.ID, SenderID: "alice", Body: body}); err != nil {
+			t.Fatalf("post %d: %v", i, err)
+		}
+	}
+
+	all, err := ListRoomMessages(ctx, db, room.ID, 50, 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(all) != 5 {
+		t.Fatalf("messages = %d, want 5", len(all))
+	}
+	if all[0].Body != "one" || all[4].Body != "five" {
+		t.Fatalf("chronological order wrong: %q .. %q", all[0].Body, all[4].Body)
+	}
+
+	// Latest page of 2.
+	page, _ := ListRoomMessages(ctx, db, room.ID, 2, 0)
+	if len(page) != 2 || page[0].Body != "four" || page[1].Body != "five" {
+		t.Fatalf("latest page wrong: %+v", page)
+	}
+	// Older page before the first of that page.
+	older, _ := ListRoomMessages(ctx, db, room.ID, 2, page[0].ID)
+	if len(older) != 2 || older[1].Body != "three" {
+		t.Fatalf("older page wrong: %+v", older)
+	}
+
+	// Attrs round-trip on a task message.
+	msg, err := PostRoomMessage(ctx, db, RoomMessage{RoomID: room.ID, SenderID: "alice", Kind: "task", Body: "tasked", Attrs: Attrs{"task_id": "TK-200"}})
+	if err != nil {
+		t.Fatalf("task msg: %v", err)
+	}
+	got, _ := GetRoomMessage(ctx, db, msg.ID)
+	if got.Kind != "task" || got.Attrs.GetString("task_id") != "TK-200" {
+		t.Fatalf("task message round-trip wrong: kind=%q attrs=%+v", got.Kind, got.Attrs)
+	}
+}
+
+func TestRoomArchiveHidesFromList(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+	room, _ := CreateRoom(ctx, db, Room{Name: "temp", CreatedBy: "alice"})
+	if err := ArchiveRoom(ctx, db, room.ID); err != nil {
+		t.Fatalf("archive: %v", err)
+	}
+	rooms, _ := ListRooms(ctx, db, RoomFilter{MemberID: "alice"})
+	if containsRoom(rooms, room.ID) {
+		t.Fatalf("archived room should not be listed")
+	}
+}
+
+func containsRoom(rooms []Room, id int64) bool {
+	for _, r := range rooms {
+		if r.ID == id {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/store/schema_version.go
+++ b/internal/store/schema_version.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	LegacySchemaVersion  = 1
-	CurrentSchemaVersion = 12
+	CurrentSchemaVersion = 13
 	schemaMetaTable      = "schema_meta"
 	schemaVersionKey     = "schema_version"
 	// DefaultBackupRetention is the number of timestamped pre-upgrade backups

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -787,6 +787,48 @@ CREATE INDEX IF NOT EXISTS idx_time_entries_user_id ON time_entries(user_id);
 CREATE INDEX IF NOT EXISTS idx_pull_requests_ticket_id ON pull_requests(ticket_id);
 CREATE INDEX IF NOT EXISTS idx_pull_requests_project_id ON pull_requests(project_id);
 
+CREATE TABLE IF NOT EXISTS rooms (
+	room_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	slug TEXT NOT NULL,
+	name TEXT NOT NULL,
+	topic TEXT NOT NULL DEFAULT '',
+	visibility TEXT NOT NULL DEFAULT 'public',
+	project_id INTEGER,
+	ticket_id TEXT,
+	archived INTEGER NOT NULL DEFAULT 0,
+	created_by TEXT NOT NULL DEFAULT '',
+	attrs TEXT NOT NULL DEFAULT '{}',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS room_members (
+	room_id INTEGER NOT NULL,
+	member_id TEXT NOT NULL,
+	role TEXT NOT NULL DEFAULT 'member',
+	joined_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	last_read_at TEXT NOT NULL DEFAULT '',
+	PRIMARY KEY (room_id, member_id),
+	FOREIGN KEY(room_id) REFERENCES rooms(room_id)
+);
+
+CREATE TABLE IF NOT EXISTS room_messages (
+	message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	room_id INTEGER NOT NULL,
+	sender_id TEXT NOT NULL,
+	kind TEXT NOT NULL DEFAULT 'text',
+	body TEXT NOT NULL DEFAULT '',
+	attrs TEXT NOT NULL DEFAULT '{}',
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	FOREIGN KEY(room_id) REFERENCES rooms(room_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_rooms_slug ON rooms(slug);
+CREATE INDEX IF NOT EXISTS idx_rooms_project_id ON rooms(project_id);
+CREATE INDEX IF NOT EXISTS idx_rooms_ticket_id ON rooms(ticket_id);
+CREATE INDEX IF NOT EXISTS idx_room_members_member_id ON room_members(member_id);
+CREATE INDEX IF NOT EXISTS idx_room_messages_room_id ON room_messages(room_id, message_id);
+
 `
 
 	if _, err := db.ExecContext(ctx, schema); err != nil {

--- a/tests/playwright/site2.spec.js
+++ b/tests/playwright/site2.spec.js
@@ -2111,3 +2111,13 @@ test("chat: rooms list, messages, send, and create a room", async ({ page }) => 
   await page.locator("#dialog-ok").click();
   await expect(page.locator("#chat-rooms-list")).toContainText("Engineering");
 });
+
+test("chat: breakout room from a ticket", async ({ page }) => {
+  // Open a ticket and start a breakout room scoped to it.
+  await page.getByText("Move me").click();
+  await expect(page.locator("#ticket-modal")).toHaveClass(/open/);
+  await page.locator("#ticket-breakout-button").click();
+  await expect(page.locator('#main-nav button[data-view="chat"]')).toHaveClass(/active/);
+  await expect(page.locator("#chat-room-title")).toContainText("Breakout");
+  await expect(page.locator("#chat-rooms-list")).toContainText("Breakout");
+});

--- a/tests/playwright/site2.spec.js
+++ b/tests/playwright/site2.spec.js
@@ -193,6 +193,11 @@ function installSite2Mock(page, seed = {}) {
             },
           ],
       defaultPlanSlug: String(mockSeed.defaultPlanSlug || "starter"),
+      rooms: [{ room_id: 1, slug: "general", name: "General", topic: "Everything", visibility: "public", project_id: null, ticket_id: "", archived: 0, created_by: "admin" }],
+      roomMembers: [{ room_id: 1, member_id: "admin", role: "owner", joined_at: "now", last_read_at: "" }],
+      roomMessages: [{ message_id: 1, room_id: 1, sender_id: "admin", kind: "text", body: "welcome to the room", created_at: "now" }],
+      nextRoomID: 2,
+      nextRoomMessageID: 2,
       agents: [{ user_id: "agent-1", enabled: true }],
       teams: [{ team_id: 21, name: "Platform", parent_team_id: null }],
       myProjectAccessRequests: Array.isArray(mockSeed.myProjectAccessRequests)
@@ -1011,6 +1016,52 @@ function installSite2Mock(page, seed = {}) {
         const roleID = Number(parts[7]);
         stage.roles = (stage.roles || []).filter((item) => Number(item.role_id) !== roleID);
         return json({ status: "removed" });
+      }
+
+      if (path === "/api/rooms" && method === "GET") {
+        return json(db.rooms.filter((r) => !r.archived));
+      }
+      if (path === "/api/rooms" && method === "POST") {
+        const room = {
+          room_id: db.nextRoomID++, slug: String(body.name || "room").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, ""),
+          name: body.name || "room", topic: body.topic || "", visibility: body.visibility === "private" ? "private" : "public",
+          project_id: body.project_id || null, ticket_id: body.ticket_id || "", archived: 0, created_by: "admin",
+        };
+        db.rooms.push(room);
+        db.roomMembers.push({ room_id: room.room_id, member_id: "admin", role: "owner", joined_at: "now", last_read_at: "" });
+        return json(room, 201);
+      }
+      {
+        const roomMatch = path.match(/^\/api\/rooms\/(\d+)(\/(join|leave|members|messages))?$/);
+        if (roomMatch) {
+          const roomID = Number(roomMatch[1]);
+          const sub = roomMatch[3] || "";
+          const room = db.rooms.find((r) => r.room_id === roomID);
+          if (!room) { return json({ error: "room not found" }, 404); }
+          if (sub === "" && method === "GET") { return json(room); }
+          if (sub === "" && method === "DELETE") { room.archived = 1; return json({ status: "archived" }); }
+          if (sub === "join" && method === "POST") {
+            if (!db.roomMembers.some((m) => m.room_id === roomID && m.member_id === "admin")) {
+              db.roomMembers.push({ room_id: roomID, member_id: "admin", role: "member", joined_at: "now", last_read_at: "" });
+            }
+            return json(room);
+          }
+          if (sub === "leave" && method === "POST") {
+            db.roomMembers = db.roomMembers.filter((m) => !(m.room_id === roomID && m.member_id === "admin"));
+            return json({ status: "left" });
+          }
+          if (sub === "members" && method === "GET") {
+            return json(db.roomMembers.filter((m) => m.room_id === roomID));
+          }
+          if (sub === "messages" && method === "GET") {
+            return json(db.roomMessages.filter((m) => m.room_id === roomID));
+          }
+          if (sub === "messages" && method === "POST") {
+            const msg = { message_id: db.nextRoomMessageID++, room_id: roomID, sender_id: "admin", kind: body.kind || "text", body: body.body || "", created_at: "now" };
+            db.roomMessages.push(msg);
+            return json(msg, 201);
+          }
+        }
       }
 
       return json({ error: `Unhandled ${method} ${path}` }, 500);
@@ -2032,4 +2083,31 @@ test("command palette: single-letter alias and /ticket-key quick-open", async ({
   await page.locator("#command-palette-input").press("Enter");
   await page.locator("#command-palette-input").press("1");
   await expect(page.locator("#ticket-modal")).toHaveClass(/open/);
+});
+
+test("chat: rooms list, messages, send, and create a room", async ({ page }) => {
+  // /chat (now registered) navigates to the chat view.
+  await page.keyboard.press("Shift");
+  await page.keyboard.press("Shift");
+  await page.locator("#command-palette-input").fill("chat");
+  await page.locator("#command-palette-input").press("Enter");
+  await expect(page.locator('#main-nav button[data-view="chat"]')).toHaveClass(/active/);
+
+  // Seeded room appears; selecting it shows its messages.
+  await expect(page.locator("#chat-rooms-list")).toContainText("General");
+  await page.locator('.chat-room-item[data-room-id="1"]').click();
+  await expect(page.locator("#chat-room-title")).toHaveText("General");
+  await expect(page.locator("#chat-messages")).toContainText("welcome to the room");
+
+  // Send a message.
+  await page.locator("#chat-composer-input").fill("hello there");
+  await page.locator("#chat-send-button").click();
+  await expect(page.locator("#chat-messages")).toContainText("hello there");
+
+  // Create a new room from the prompt.
+  await page.locator("#new-room-button").click();
+  await expect(page.locator("#dialog-input")).toBeVisible();
+  await page.locator("#dialog-input").fill("Engineering");
+  await page.locator("#dialog-ok").click();
+  await expect(page.locator("#chat-rooms-list")).toContainText("Engineering");
 });

--- a/web/default/index.html
+++ b/web/default/index.html
@@ -1001,7 +1001,10 @@
     <div class="modal-box">
         <div class="modal-header">
             <h2 id="ticket-modal-title">Ticket</h2>
-            <button id="close-ticket-modal" class="icon-btn" type="button" aria-label="Close">&#10005;</button>
+            <div class="modal-header-actions">
+                <button id="ticket-breakout-button" class="btn btn-ghost" type="button" title="Open a chat room for this ticket">💬 Breakout</button>
+                <button id="close-ticket-modal" class="icon-btn" type="button" aria-label="Close">&#10005;</button>
+            </div>
         </div>
         <form id="ticket-form" class="modal-grid-tabbed">
             <div class="segmented ticket-subnav" id="ticket-subnav">

--- a/web/default/index.html
+++ b/web/default/index.html
@@ -514,6 +514,41 @@
                     </div>
                 </section>
 
+                <!-- Chat / multiplayer rooms -->
+                <section id="view-chat" class="view split">
+                    <div class="card">
+                        <div class="card-header">
+                            <div>
+                                <h2>Rooms</h2>
+                                <p class="meta">Chat with your team and agents.</p>
+                            </div>
+                            <button id="new-room-button" class="btn btn-primary" type="button">New room</button>
+                        </div>
+                        <div id="chat-rooms-list" class="item-list"></div>
+                    </div>
+                    <div class="card" id="chat-room-view">
+                        <div class="card-header">
+                            <div>
+                                <h2 id="chat-room-title">Select a room</h2>
+                                <p class="meta" id="chat-room-topic"></p>
+                            </div>
+                            <div class="view-actions">
+                                <button id="chat-join-button" class="btn" type="button" hidden>Join</button>
+                                <button id="chat-leave-button" class="btn btn-ghost" type="button" hidden>Leave</button>
+                            </div>
+                        </div>
+                        <div id="chat-messages" class="chat-messages"></div>
+                        <form id="chat-composer" class="chat-composer">
+                            <input id="chat-composer-input" type="text" autocomplete="off" placeholder="Message — @name, #label, /task @agent …" disabled>
+                            <button id="chat-send-button" class="btn btn-primary" type="submit" disabled>Send</button>
+                        </form>
+                        <div class="card-section">
+                            <div class="card-section-head"><h3>Members</h3></div>
+                            <div id="chat-members" class="item-list"></div>
+                        </div>
+                    </div>
+                </section>
+
                 <!-- Context graph -->
                 <section id="view-context" class="view">
                     <div class="card">

--- a/web/default/site.css
+++ b/web/default/site.css
@@ -2034,3 +2034,18 @@ select {
   font-family: inherit; font-size: 11px; padding: 1px 5px; margin: 0 2px;
   border: 1px solid var(--border, #444); border-radius: 4px; opacity: 0.9;
 }
+
+/* Chat / multiplayer rooms (TK-118 S5). */
+#view-chat .chat-room-group { padding: 8px 10px 4px; font-size: 11px; text-transform: uppercase; letter-spacing: .06em; opacity: .55; }
+#view-chat .chat-room-item { display: block; width: 100%; text-align: left; padding: 7px 12px; border: none; background: transparent; color: inherit; cursor: pointer; border-radius: 6px; }
+#view-chat .chat-room-item:hover { background: var(--accent-soft, rgba(255,122,26,.12)); }
+#view-chat .chat-room-item.active { background: var(--accent-soft, rgba(255,122,26,.2)); font-weight: 600; }
+#chat-room-view { display: flex; flex-direction: column; }
+.chat-messages { flex: 1; min-height: 220px; max-height: 52vh; overflow-y: auto; padding: 10px 4px; display: flex; flex-direction: column; gap: 6px; }
+.chat-msg { padding: 5px 8px; border-radius: 6px; }
+.chat-msg-sender { font-weight: 600; margin-right: 6px; opacity: .85; }
+.chat-msg-system, .chat-msg-agent_event { opacity: .7; font-style: italic; }
+.chat-msg-task { background: var(--accent-soft, rgba(255,122,26,.12)); }
+.chat-composer { display: flex; gap: 8px; padding: 8px 4px; border-top: 1px solid var(--border, #333); }
+.chat-composer-input, #chat-composer-input { flex: 1; padding: 9px 12px; border-radius: 7px; border: 1px solid var(--border, #444); background: transparent; color: inherit; }
+.chat-member { padding: 4px 8px; }

--- a/web/default/site.css
+++ b/web/default/site.css
@@ -2049,3 +2049,5 @@ select {
 .chat-composer { display: flex; gap: 8px; padding: 8px 4px; border-top: 1px solid var(--border, #333); }
 .chat-composer-input, #chat-composer-input { flex: 1; padding: 9px 12px; border-radius: 7px; border: 1px solid var(--border, #444); background: transparent; color: inherit; }
 .chat-member { padding: 4px 8px; }
+.chat-mention { color: var(--accent, #ff7a1a); font-weight: 600; }
+.chat-label { color: #5aa9e6; font-weight: 600; }

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -77,6 +77,8 @@
             dependencyIndex: {},
             drag: null,
             liveSocket: null,
+            activeRoomID: 0,
+            rooms: [],
             liveRefreshTimer: null,
             refinementSocket: null,
             refinementTicketId: null,
@@ -113,6 +115,7 @@
         const NAV_ITEMS = [
             { view: "tickets", label: "Board", section: "general", icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M4 7h16\"></path><path d=\"M4 12h16\"></path><path d=\"M4 17h10\"></path></svg>" },
             { view: "projects", label: "Projects", section: "general", icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M3 7h18\"></path><path d=\"M6 7v10\"></path><path d=\"M12 7v10\"></path><path d=\"M18 7v10\"></path><path d=\"M3 17h18\"></path></svg>" },
+            { view: "chat", label: "Chat", section: "general", icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M4 5h16v11H7l-3 3z\"></path><path d=\"M8 9h8\"></path><path d=\"M8 12h5\"></path></svg>" },
             { view: "interventions", label: "Mailbox", section: "general", icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M12 4v8\"></path><path d=\"M12 16h.01\"></path><circle cx=\"12\" cy=\"12\" r=\"9\"></circle></svg>" },
             { view: "workflows", label: "Workflows", section: "process", icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M5 6h14\"></path><path d=\"M5 12h9\"></path><path d=\"M5 18h14\"></path><path d=\"M17 10l2 2-2 2\"></path></svg>" },
             { view: "roles", label: "Roles", section: "process", icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M7 8a3 3 0 1 0 0.001 0\"></path><path d=\"M17 16a3 3 0 1 0 0.001 0\"></path><path d=\"M9.5 10.5l5 3\"></path></svg>" },
@@ -1629,6 +1632,9 @@
             if (viewName === "context") {
                 refreshContextView();
             }
+            if (viewName === "chat") {
+                refreshChatView();
+            }
             if (viewName === "settings") {
                 let tab = "organisation";
                 try { tab = localStorage.getItem("site2.settingsTab") || "organisation"; } catch (e) { /* ignore */ }
@@ -2193,6 +2199,142 @@
             }, 15000);
         }
 
+        // ── Chat / multiplayer rooms (TK-118 / S5) ───────────────────────
+        function roomScope(room) {
+            if (!room.project_id) { return "global"; }
+            return room.ticket_id ? "breakout" : "project";
+        }
+        function refreshChatView() {
+            loadRooms().then(() => {
+                renderRoomsList();
+                if (state.activeRoomID && state.rooms.some((r) => r.room_id === state.activeRoomID)) {
+                    selectRoom(state.activeRoomID);
+                }
+            });
+        }
+        function loadRooms() {
+            return api("/api/rooms").then((rooms) => {
+                state.rooms = Array.isArray(rooms) ? rooms : [];
+            }).catch(() => { state.rooms = []; });
+        }
+        function renderRoomsList() {
+            const list = document.getElementById("chat-rooms-list");
+            if (!list) { return; }
+            if (!state.rooms.length) {
+                list.innerHTML = "<div class=\"meta\" style=\"padding:10px\">No rooms yet — create one.</div>";
+                return;
+            }
+            const groups = [["global", "Global"], ["project", "Project"], ["breakout", "Breakouts"]];
+            let html = "";
+            groups.forEach((g) => {
+                const scoped = state.rooms.filter((r) => roomScope(r) === g[0]);
+                if (!scoped.length) { return; }
+                html += "<div class=\"chat-room-group\">" + escapeHTML(g[1]) + "</div>";
+                html += scoped.map((r) =>
+                    "<button type=\"button\" class=\"chat-room-item" + (r.room_id === state.activeRoomID ? " active" : "") + "\" data-room-id=\"" + r.room_id + "\">" +
+                    (r.visibility === "private" ? "🔒 " : "# ") + escapeHTML(r.name) + "</button>").join("");
+            });
+            list.innerHTML = html;
+        }
+        function selectRoom(roomID) {
+            state.activeRoomID = roomID;
+            const room = state.rooms.find((r) => r.room_id === roomID);
+            const titleEl = document.getElementById("chat-room-title");
+            const topicEl = document.getElementById("chat-room-topic");
+            if (titleEl) { titleEl.textContent = room ? room.name : "Room"; }
+            if (topicEl) { topicEl.textContent = room ? (room.topic || "") : ""; }
+            renderRoomsList();
+            const input = document.getElementById("chat-composer-input");
+            const sendBtn = document.getElementById("chat-send-button");
+            if (input) { input.disabled = false; }
+            if (sendBtn) { sendBtn.disabled = false; }
+            const joinBtn = document.getElementById("chat-join-button");
+            const leaveBtn = document.getElementById("chat-leave-button");
+            if (joinBtn) { joinBtn.hidden = false; }
+            if (leaveBtn) { leaveBtn.hidden = false; }
+            subscribeRoom(roomID);
+            loadRoomMessages(roomID);
+            loadRoomMembers(roomID);
+        }
+        function loadRoomMessages(roomID) {
+            return api("/api/rooms/" + roomID + "/messages").then((msgs) => {
+                if (state.activeRoomID !== roomID) { return; }
+                const box = document.getElementById("chat-messages");
+                if (!box) { return; }
+                box.innerHTML = (Array.isArray(msgs) ? msgs : []).map((m) =>
+                    "<div class=\"chat-msg chat-msg-" + escapeHTML(m.kind || "text") + "\" data-message-id=\"" + m.message_id + "\">" +
+                    "<span class=\"chat-msg-sender\">" + escapeHTML(m.sender_id) + "</span> " +
+                    "<span class=\"chat-msg-body\">" + escapeHTML(m.body) + "</span></div>").join("");
+                box.scrollTop = box.scrollHeight;
+            }).catch(() => {});
+        }
+        function loadRoomMembers(roomID) {
+            return api("/api/rooms/" + roomID + "/members").then((members) => {
+                if (state.activeRoomID !== roomID) { return; }
+                const box = document.getElementById("chat-members");
+                if (!box) { return; }
+                box.innerHTML = (Array.isArray(members) ? members : []).map((m) =>
+                    "<div class=\"chat-member\">" + escapeHTML(m.member_id) + (m.role === "owner" ? " <span class=\"meta\">owner</span>" : "") + "</div>").join("");
+            }).catch(() => {});
+        }
+        function sendRoomMessage() {
+            const input = document.getElementById("chat-composer-input");
+            if (!input || !state.activeRoomID) { return; }
+            const body = String(input.value || "").trim();
+            if (!body) { return; }
+            const roomID = state.activeRoomID;
+            input.value = "";
+            apiClient.post("/api/rooms/" + roomID + "/messages", { body: body })
+                .then(() => loadRoomMessages(roomID))
+                .catch((err) => setNotice("Send failed: " + err.message, true));
+        }
+        function createRoomFromPrompt() {
+            Promise.resolve(uiPrompt("New room name", "", "Create")).then((name) => {
+                const trimmed = String(name || "").trim();
+                if (!trimmed) { return; }
+                return apiClient.post("/api/rooms", { name: trimmed }).then((room) => {
+                    return loadRooms().then(() => {
+                        renderRoomsList();
+                        if (room && room.room_id) { selectRoom(room.room_id); }
+                    });
+                });
+            }).catch((err) => setNotice("Create room failed: " + err.message, true));
+        }
+        function subscribeRoom(roomID) {
+            try {
+                if (state.liveSocket && state.liveSocket.readyState === 1) {
+                    state.liveSocket.send(JSON.stringify({ type: "subscribe", room_id: roomID }));
+                }
+            } catch (e) { /* ignore */ }
+        }
+        function setupChat() {
+            const list = document.getElementById("chat-rooms-list");
+            if (list) {
+                list.addEventListener("click", (event) => {
+                    const item = event.target.closest("[data-room-id]");
+                    if (item) { selectRoom(Number(item.dataset.roomId)); }
+                });
+            }
+            const newBtn = document.getElementById("new-room-button");
+            if (newBtn) { newBtn.addEventListener("click", createRoomFromPrompt); }
+            const composer = document.getElementById("chat-composer");
+            if (composer) { composer.addEventListener("submit", (event) => { event.preventDefault(); sendRoomMessage(); }); }
+            const joinBtn = document.getElementById("chat-join-button");
+            if (joinBtn) {
+                joinBtn.addEventListener("click", () => {
+                    if (!state.activeRoomID) { return; }
+                    apiClient.post("/api/rooms/" + state.activeRoomID + "/join").then(() => loadRoomMembers(state.activeRoomID)).catch(() => {});
+                });
+            }
+            const leaveBtn = document.getElementById("chat-leave-button");
+            if (leaveBtn) {
+                leaveBtn.addEventListener("click", () => {
+                    if (!state.activeRoomID) { return; }
+                    apiClient.post("/api/rooms/" + state.activeRoomID + "/leave").then(() => loadRoomMembers(state.activeRoomID)).catch(() => {});
+                });
+            }
+        }
+
         function connectLiveUpdates() {
             if (window.__site2MockFetch || state.liveSocket) {
                 return;
@@ -2204,6 +2346,12 @@
                 try {
                     const payload = JSON.parse(event.data);
                     if (!payload || payload.type === "connected") {
+                        return;
+                    }
+                    if (payload.type === "room_message") {
+                        if (state.activeRoomID && Number(payload.room_id) === state.activeRoomID) {
+                            loadRoomMessages(state.activeRoomID);
+                        }
                         return;
                     }
                     scheduleLiveRefresh();
@@ -9135,6 +9283,7 @@
             }
         });
         setupCommandPalette();
+        setupChat();
         state.viewScrollByPanel = loadStoredViewScrollByPanel();
         state.currentView = loadStoredSelectedView() || state.currentView;
         switchView(state.currentView, { restoreScroll: false });

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -2204,6 +2204,12 @@
             if (!room.project_id) { return "global"; }
             return room.ticket_id ? "breakout" : "project";
         }
+        // @name and #label become highlighted entities in the message feed (S6).
+        function highlightRoomText(body) {
+            return escapeHTML(String(body || ""))
+                .replace(/@([A-Za-z0-9][A-Za-z0-9_-]*)/g, "<span class=\"chat-mention\">@$1</span>")
+                .replace(/#([A-Za-z0-9][A-Za-z0-9_-]*)/g, "<span class=\"chat-label\">#$1</span>");
+        }
         function refreshChatView() {
             loadRooms().then(() => {
                 renderRoomsList();
@@ -2264,7 +2270,7 @@
                 box.innerHTML = (Array.isArray(msgs) ? msgs : []).map((m) =>
                     "<div class=\"chat-msg chat-msg-" + escapeHTML(m.kind || "text") + "\" data-message-id=\"" + m.message_id + "\">" +
                     "<span class=\"chat-msg-sender\">" + escapeHTML(m.sender_id) + "</span> " +
-                    "<span class=\"chat-msg-body\">" + escapeHTML(m.body) + "</span></div>").join("");
+                    "<span class=\"chat-msg-body\">" + highlightRoomText(m.body) + "</span></div>").join("");
                 box.scrollTop = box.scrollHeight;
             }).catch(() => {});
         }

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -2300,6 +2300,24 @@
                 });
             }).catch((err) => setNotice("Create room failed: " + err.message, true));
         }
+        // Open (or create) a breakout room scoped to a ticket (S8).
+        function openBreakoutRoom(ticket) {
+            if (!ticket || !ticket.id) { return; }
+            const ticketKey = ticket.id;
+            const projectID = ticket.project_id || state.selectedProjectID || null;
+            const go = (roomID) => {
+                if (typeof closeTicketModal === "function") { closeTicketModal(); }
+                switchView("chat");
+                loadRooms().then(() => { renderRoomsList(); selectRoom(roomID); });
+            };
+            loadRooms().then(() => {
+                const existing = state.rooms.find((r) => r.ticket_id === ticketKey);
+                if (existing) { go(existing.room_id); return; }
+                apiClient.post("/api/rooms", { name: "Breakout " + ticketKey, topic: ticket.title || "", project_id: projectID, ticket_id: ticketKey })
+                    .then((room) => { if (room && room.room_id) { go(room.room_id); } })
+                    .catch((err) => setNotice("Breakout failed: " + err.message, true));
+            });
+        }
         function subscribeRoom(roomID) {
             try {
                 if (state.liveSocket && state.liveSocket.readyState === 1) {
@@ -2317,6 +2335,8 @@
             }
             const newBtn = document.getElementById("new-room-button");
             if (newBtn) { newBtn.addEventListener("click", createRoomFromPrompt); }
+            const breakoutBtn = document.getElementById("ticket-breakout-button");
+            if (breakoutBtn) { breakoutBtn.addEventListener("click", () => openBreakoutRoom(state.activeTicket)); }
             const composer = document.getElementById("chat-composer");
             if (composer) { composer.addEventListener("submit", (event) => { event.preventDefault(); sendRoomMessage(); }); }
             const joinBtn = document.getElementById("chat-join-button");


### PR DESCRIPTION
Implements **multiplayer chat rooms with conversational + taskable agents** (epic TK-118), built on the existing WebSocket hub, agent identities, and ticket/orchestrator lifecycle.

**Stories**
- **S1** design doc (`docs/design/multiplayer-rooms.md`).
- **S2** schema v13 + store layer: `rooms` (scope: global / project / breakout via `project_id`+`ticket_id`, visibility, `attrs`), `room_members`, `room_messages` (kinds: text/system/task/agent_event); CRUD, join/leave, visibility-aware listing, paginated messages.
- **S3** REST API: `/api/rooms` CRUD + `/join` `/leave` `/members` `/messages`, private-room enforcement, owner/admin gating.
- **S4** realtime: extended the live hub for room fan-out (`room_id` filter, `broadcastRoomMessage`, `subscribe room_id`).
- **S5** Slack-like web UI: rooms sidebar grouped by scope, message feed, composer, create/join/leave, members; live; `/chat` command-palette entry focuses the composer.
- **S6** `@mention` / `#label` parsed into `attrs.mentions` and highlighted in the feed. (Live LLM agent replies → follow-up TK-131.)
- **S7** `/task [@agent] <desc>` in a room creates a tracked ticket (scoped to the room's project / parented to the breakout ticket), assigns the agent, and posts a linking task message; the orchestrator works it.
- **S8** breakout rooms: a "Breakout" button on a ticket opens/creates a room scoped to that ticket.

**Tests**: store contract/unit, server handler + hub + parser tests, and Playwright coverage (chat navigate/list/select/send/create, breakout, command palette). Full Go store+server suites + the 36-test browser suite pass; lint clean.

Remaining follow-up: **TK-131** (live conversational agent streaming — needs the agent runtime). OpenAPI/USER_GUIDE sync to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
