### PR TITLE
fix: CSP blocked inline styles, collapsing the SPA layout (empty board)

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -360,8 +360,13 @@ func securityHeadersHandler(next http.Handler) http.Handler {
 		if requestIsSecure(r) {
 			w.Header().Set("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		}
+		// Scripts stay nonce-locked. Styles use 'unsafe-inline' because the SPA
+		// relies on inline style attributes for layout, and a CSP nonce cannot
+		// apply to style *attributes* (only to <style> elements) — so a nonce
+		// silently blocks them and breaks rendering. img-src allows inline data:
+		// SVG icons.
 		w.Header().Set("Content-Security-Policy",
-			fmt.Sprintf("default-src 'self'; script-src 'self' 'nonce-%s'; style-src 'self' 'nonce-%s'", nonce, nonce))
+			fmt.Sprintf("default-src 'self'; script-src 'self' 'nonce-%s'; style-src 'self' 'unsafe-inline'; img-src 'self' data:", nonce))
 		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), cspNonceKey{}, nonce)))
 	})
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -374,8 +374,11 @@ func TestServerServesHealthAndFrontend(t *testing.T) {
 	}
 	defer rootResp.Body.Close()
 	csp := rootResp.Header.Get("Content-Security-Policy")
-	if !strings.Contains(csp, "script-src 'self' 'nonce-") || !strings.Contains(csp, "style-src 'self' 'nonce-") {
-		t.Fatalf("root CSP missing nonce directives: %q", csp)
+	if !strings.Contains(csp, "script-src 'self' 'nonce-") {
+		t.Fatalf("root CSP missing script nonce directive: %q", csp)
+	}
+	if !strings.Contains(csp, "style-src 'self' 'unsafe-inline'") {
+		t.Fatalf("root CSP must allow inline styles (a nonce cannot cover style attributes): %q", csp)
 	}
 
 	body, err := io.ReadAll(rootResp.Body)


### PR DESCRIPTION
The web UI showed no tickets on 8080 (CLI + API had them). Root cause: the CSP used `style-src self nonce-…`, but a nonce cannot cover inline style ATTRIBUTES — only <style> elements. The SPA relies on inline style attributes for layout, so the browser stripped them and the board/views collapsed; tickets were in the DOM but not visibly laid out.

Fix: `style-src self unsafe-inline` (scripts stay nonce-locked) + `img-src self data:` for the inline SVG icons. Headless-verified: CSP violations 40+ → 0, no page errors; board renders. server_test CSP assertion updated; server suite + lint green.