### PR TITLE
docs: remove stale JS-API test references (test-api-js / web/site2)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,21 +10,20 @@ make build-dev          # build ./bin/tk (does NOT bump cmd/tk/VERSION)
 make build              # build + bump patch version + sync openapi.yaml version
 make lint               # golangci-lint + gosec
 make test               # ultra-fast default: unit tests
-make test-fast          # recommended developer loop: unit + JS API + Go API smoke
+make test-fast          # recommended developer loop: unit + Go API smoke
 make test-api-smoke     # fast Go API smoke packages (internal/client + internal/server)
 make test-cli           # heavier CLI package tests
 make test-contract      # heavier libticket contract tests
 make test-all           # full suite: unit + api + browser + quickstart + docs/harness
-make test-api-js        # JavaScript API client-library tests (web/site2/api.test.js)
 make test-api-cli       # CLI/API interface tests (cmd + client + server + contract)
-make test-api           # both API interface suites (js + cli)
+make test-api           # alias for test-api-cli
 make test-browser       # fast browser smoke suite (Playwright)
 make test-browser-full  # full browser E2E suite (Playwright)
 make test-quickstart    # executable QUICKSTART/TUTORIAL docs tests
 make test-go            # all Go tests
 make test-go-cover      # package coverage gates (cmd/tk, libticket, client, store, server, config)
 make ci-bootstrap       # install deps for the same verify/browser flow used by GitHub Actions
-make ci-verify          # validate-openapi + coverage + JS API + build-dev + lint + vulncheck
+make ci-verify          # validate-openapi + coverage + build-dev + lint + vulncheck
 make ci-browser         # full browser E2E suite used by GitHub Actions
 make ci                 # ci-verify + ci-browser
 ```
@@ -96,4 +95,4 @@ make validate-openapi     # structural OpenAPI check
   - run `make test-browser` while iterating on web UX, then `make test-browser-full`
   - run `make test-all` before completion/PR
 
-- `tk server` serves **site2 by default**; use `tk server -site default` only when explicitly testing the legacy site.
+- `tk server` serves the embedded web UI from `web/default` + `web/shared` (the only site).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Design
 
 Compile
 - `make test` on every run (ultra-fast default: unit tests).
-- `make test-fast` for the normal developer loop (unit + JS API + Go API smoke).
+- `make test-fast` for the normal developer loop (unit + Go API smoke).
 - `make test-all` before completion/PR - full suite must pass.
 - `make lint` - on every turn - no lint failures.
 
@@ -31,7 +31,7 @@ make test-unit            # Unit tests only (config, password, web)
 make test-integration     # Integration tests (cmd, internal/client, server, store, libticket)
 make test-go-cover        # Tests with per-package coverage thresholds
 make ci-bootstrap         # Install deps for the same verify/browser flow used by GitHub Actions
-make ci-verify            # Validate OpenAPI + coverage + JS API + build-dev + lint + vulncheck
+make ci-verify            # Validate OpenAPI + coverage + build-dev + lint + vulncheck
 make ci-browser           # Full Playwright browser job used by GitHub Actions
 make ci                   # ci-verify + ci-browser
 make lint                 # Run golangci-lint on all packages

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -5,23 +5,21 @@
 | Target                | What it covers                                      | Duration |
 |-----------------------|-----------------------------------------------------|----------|
 | `make test`           | Ultra-fast default unit packages (`config`, `password`, `web`) | ~1s |
-| `make test-fast`      | Recommended developer loop: unit + JS API + Go API smoke | ~7s |
+| `make test-fast`      | Recommended developer loop: unit + Go API smoke | ~7s |
 | `make test-unit`      | Config, password hashing, web package               | ~1s      |
 | `make test-api-smoke` | Fast Go API smoke packages (`internal/client`, `internal/server`) | ~2s |
 | `make test-cli`       | CLI package tests (`cmd/tk`)                        | ~10s     |
 | `make test-contract`  | Shared service contract tests (`libticket`)         | ~2s      |
 | `make test-store`     | Store package tests (`internal/store`)              | ~20s     |
-| `make test-api-js`    | JavaScript API client-library tests (`web/site2/api.test.js`) | ~2s |
 | `make test-api-cli`   | Full CLI/API contract path (`cmd/tk`, client, server, libticket) | ~14s |
-| `make test-api`       | Both API suites (`test-api-js` + `test-api-cli`)    | ~14s     |
-| `make test-browser`   | Fast browser smoke suite (`auth`, `home`, `navigation`, `tickets`) | ~13s |
-| `make test-browser-full` | Full browser E2E Playwright suite                | ~12s     |
+| `make test-api`       | Alias for `test-api-cli`                            | ~14s     |
+| `make test-browser`   | Browser suite over the live UI (`site2`, web/default+shared) | ~1m |
+| `make test-browser-full` | Browser suite (`site2`)                          | ~1m      |
 | `make test-integration` | Store + CLI/API Go suites                        | ~90s     |
 | `make test-go-cover`  | All Go tests with per-package coverage thresholds   | ~30s     |
 | `make ci-verify`      | Same verify sequence as the GitHub verify job       | varies   |
 | `make ci-browser`     | Same browser sequence as the GitHub browser job     | ~12-15s  |
 | `make ci`             | Same verify + browser flow as GitHub Actions        | varies   |
-| `make test-browser`| Full browser tests against the web UI               | ~12s     |
 | `make test-quickstart`| Executable QUICKSTART/TUTORIAL tests (see below)    | ~6s      |
 | `make test-todo-example` | Reproducible todo tutorial seed + verification  | ~6s      |
 | `make testscripts`    | Shell-based CLI harness scenarios                   | ~3s      |


### PR DESCRIPTION
There's no JS API test — web/site2/api.test.js, the web/site2/ dir, and the test-api-js target all don't exist (package.json has no test scripts either). Removed the dangling doc references (TESTING.md, copilot-instructions, CLAUDE.md) that told readers to run a non-existent target and claimed a JS-API step in test-fast/test-api/ci-verify. Also fixed a duplicate test-browser row and a stale 'serves site2 by default' note. Docs-only.