### PR TITLE
TK-128: board keyboard focus nav (arrow keys + wasd, Enter to open)

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -18,6 +18,10 @@ The web UI is keyboard-driveable through a **command palette**.
 - **Esc** pops one level back (action menu → command list → closed); **↑/↓** move,
   **Enter** selects, click also works.
 
+On the **board**, the **arrow keys** or **w/a/s/d** move focus between ticket
+cards (left/right across lanes, up/down within a lane) and **Enter** opens the
+focused ticket — instead of scrolling the page.
+
 ## Chat & rooms
 
 Open **Chat** from the sidebar (or `/chat`, which also focuses the message box).

--- a/tests/playwright/site2.spec.js
+++ b/tests/playwright/site2.spec.js
@@ -2144,3 +2144,18 @@ test("login boots even when an admin-only load (roles) returns 403", async ({ pa
   await expect(page.getByRole("heading", { name: "Board" })).toBeVisible();
   await expect(page.locator("#app-shell")).not.toHaveClass(/hidden/);
 });
+
+test("board: arrow/wasd move card focus and Enter opens the ticket", async ({ page }) => {
+  // Seeded board has OPS-101 ("Move me") in the design lane.
+  await expect(page.locator('[data-lane-stage="design"] [data-ticket-id="OPS-101"]')).toBeVisible();
+  // No card focused yet; the first nav keypress focuses the first card.
+  await page.locator("body").press("ArrowDown");
+  await expect(page.locator(".ticket-card.kbd-focus")).toHaveCount(1);
+  // wasd also navigates (focus stays on a card, page does not lose the focus ring).
+  await page.locator("body").press("d");
+  await page.locator("body").press("s");
+  await expect(page.locator(".ticket-card.kbd-focus")).toHaveCount(1);
+  // Enter opens the focused ticket's modal.
+  await page.locator("body").press("Enter");
+  await expect(page.locator("#ticket-modal")).toHaveClass(/open/);
+});

--- a/web/default/site.css
+++ b/web/default/site.css
@@ -2054,3 +2054,6 @@ select {
 .chat-room-item .chat-room-count { float: right; opacity: .5; font-size: 11px; }
 .chat-room-item.unread { font-weight: 700; }
 .chat-unread-dot { color: var(--accent, #ff7a1a); font-weight: 800; }
+
+/* Board keyboard navigation focus ring (TK-128). */
+.ticket-card.kbd-focus { outline: 2px solid var(--accent, #ff7a1a); outline-offset: 1px; }

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -2382,6 +2382,97 @@
             }
         }
 
+        // ── Board keyboard navigation (TK-128) ───────────────────────────
+        // Arrow keys and w/a/s/d move focus between ticket cards on the board
+        // (and Enter opens the focused ticket) instead of scrolling the page.
+        let focusedBoardTicketID = "";
+        function boardLanesWithCards() {
+            if (!els.ticketBoard) { return []; }
+            return Array.from(els.ticketBoard.querySelectorAll("[data-lane-stage]"))
+                .map((lane) => Array.from(lane.querySelectorAll("[data-ticket-id]")))
+                .filter((cards) => cards.length > 0);
+        }
+        function focusBoardCard(el) {
+            if (!els.ticketBoard) { return; }
+            els.ticketBoard.querySelectorAll(".ticket-card.kbd-focus").forEach((c) => c.classList.remove("kbd-focus"));
+            if (!el) { return; }
+            el.classList.add("kbd-focus");
+            el.scrollIntoView({ block: "nearest", inline: "nearest" });
+            focusedBoardTicketID = el.dataset.ticketId;
+        }
+        function moveBoardFocus(dir) {
+            const lanes = boardLanesWithCards();
+            if (!lanes.length) { return; }
+            let li = -1;
+            let ci = -1;
+            for (let i = 0; i < lanes.length && li < 0; i += 1) {
+                for (let j = 0; j < lanes[i].length; j += 1) {
+                    if (lanes[i][j].dataset.ticketId === focusedBoardTicketID) {
+                        li = i;
+                        ci = j;
+                        break;
+                    }
+                }
+            }
+            if (li < 0) {
+                focusBoardCard(lanes[0][0]);
+                return;
+            }
+            if (dir === "up") {
+                ci = Math.max(0, ci - 1);
+            } else if (dir === "down") {
+                ci = Math.min(lanes[li].length - 1, ci + 1);
+            } else if (dir === "left") {
+                li = Math.max(0, li - 1);
+                ci = Math.min(ci, lanes[li].length - 1);
+            } else if (dir === "right") {
+                li = Math.min(lanes.length - 1, li + 1);
+                ci = Math.min(ci, lanes[li].length - 1);
+            }
+            focusBoardCard(lanes[li][ci]);
+        }
+        function openFocusedBoardCard() {
+            if (!focusedBoardTicketID) { return false; }
+            const ticket = (state.tickets || []).find((t) => String(t.id) === focusedBoardTicketID);
+            if (ticket) {
+                openTicketModal(ticket);
+                return true;
+            }
+            return false;
+        }
+        function boardKeyboardNavActive() {
+            if (state.currentView !== "tickets") { return false; }
+            if (paletteEls.overlay && !paletteEls.overlay.classList.contains("hidden")) { return false; }
+            if (els.dialogOverlay && !els.dialogOverlay.classList.contains("hidden")) { return false; }
+            if (els.ticketModal && els.ticketModal.classList.contains("open")) { return false; }
+            if (state.accountModalOpen) { return false; }
+            const a = document.activeElement;
+            if (a && (a.tagName === "INPUT" || a.tagName === "TEXTAREA" || a.tagName === "SELECT" || a.isContentEditable)) { return false; }
+            return true;
+        }
+        function setupBoardKeyboardNav() {
+            document.addEventListener("keydown", (event) => {
+                if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) { return; }
+                if (!boardKeyboardNavActive()) { return; }
+                let dir = null;
+                switch (event.key) {
+                    case "ArrowUp": case "w": case "W": dir = "up"; break;
+                    case "ArrowDown": case "s": case "S": dir = "down"; break;
+                    case "ArrowLeft": case "a": case "A": dir = "left"; break;
+                    case "ArrowRight": case "d": case "D": dir = "right"; break;
+                    default: break;
+                }
+                if (dir) {
+                    event.preventDefault();
+                    moveBoardFocus(dir);
+                    return;
+                }
+                if (event.key === "Enter" && openFocusedBoardCard()) {
+                    event.preventDefault();
+                }
+            });
+        }
+
         function connectLiveUpdates() {
             if (window.__site2MockFetch || state.liveSocket) {
                 return;
@@ -9331,6 +9422,7 @@
         });
         setupCommandPalette();
         setupChat();
+        setupBoardKeyboardNav();
         state.viewScrollByPanel = loadStoredViewScrollByPanel();
         state.currentView = loadStoredSelectedView() || state.currentView;
         switchView(state.currentView, { restoreScroll: false });


### PR DESCRIPTION
The board had no keyboard navigation, so arrow keys / wasd just scrolled the page. Added focus movement between ticket cards — Up/Down (or w/s) within a lane, Left/Right (or a/d) across lanes, Enter opens the focused ticket — with preventDefault so it no longer scrolls. Gated to the tickets view when no overlay/modal is open and focus is not in an input (board search etc. still type normally). Confirmed this was a missing feature, not a regression from the double-shift palette handler.

Browser test covers arrow + wasd focus + Enter-to-open; full site2 suite green. USER_GUIDE updated.

refs TK-128