### PR TITLE
TK-135: access roles — per-panel feature flags (RBAC)

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -87,6 +87,25 @@ Agents are first-class room members. There are two ways to involve them:
   /task investigate the flaky deploy
   ```
 
+## Access roles (admin)
+
+Admins can gate which panels each user sees from the **Access** panel (admin
+sidebar section):
+
+- **Access roles** are named sets of panels (Board, Projects, Chat, Mailbox,
+  Workflows, Roles, Documents, Context, Teams). A user sees the **union** of
+  their roles' panels.
+- A user with **no** assigned roles sees all standard panels (so existing users
+  are never locked out); **admins always see everything**, including the
+  admin-only panels (Users, Settings, Agents, Programmes, Summary), which cannot
+  be granted through an access role.
+- Create/edit roles (tick the panels they grant), then **assign roles to a
+  user** in the same panel. The builtin **Member** role grants every standard
+  panel and cannot be deleted.
+- Hiding a panel also blocks its self-contained API (Chat, Documents); panels
+  whose data backs the board (Workflows, Roles, Teams) are hidden in the nav but
+  their shared data stays reachable so ticket flows keep working.
+
 ## More
 
 - Tickets, the board, projects, workflows, roles, and the mailbox are reachable

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -70,6 +70,21 @@ components:
       description: Agent UUID as username, agent password as password
 
   schemas:
+    AccessRole:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        description: { type: string }
+        builtin: { type: boolean }
+        panels: { type: array, items: { type: string } }
+    AccessRoleInput:
+      type: object
+      required: [name]
+      properties:
+        name: { type: string }
+        description: { type: string }
+        panels: { type: array, items: { type: string } }
     Room:
       type: object
       description: A multiplayer chat room. Scope is global (no project), project, or breakout (project + ticket).
@@ -1633,6 +1648,103 @@ components:
         error: "ticket not found"
 
 paths:
+  # ── Access roles (per-panel feature flags) ───────────────────────────
+  /api/me/panels:
+    get:
+      tags: [Access]
+      summary: Effective panel set for the current user
+      operationId: getMyPanels
+      responses:
+        '200':
+          description: Panels
+          content:
+            application/json:
+              schema: { type: object, properties: { panels: { type: array, items: { type: string } } } }
+  /api/panels:
+    get:
+      tags: [Access]
+      summary: Catalogue of grantable and all panels (admin)
+      operationId: listPanels
+      responses:
+        '200': { description: Panel catalogue }
+  /api/access-roles:
+    get:
+      tags: [Access]
+      summary: List access roles (admin)
+      operationId: listAccessRoles
+      responses:
+        '200':
+          description: Access roles
+          content:
+            application/json:
+              schema: { type: array, items: { $ref: '#/components/schemas/AccessRole' } }
+    post:
+      tags: [Access]
+      summary: Create an access role (admin)
+      operationId: createAccessRole
+      requestBody:
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AccessRoleInput' }
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AccessRole' }
+  /api/access-roles/memberships:
+    get:
+      tags: [Access]
+      summary: Get a user's access-role ids (admin)
+      operationId: getUserAccessRoles
+      parameters:
+        - { name: user_id, in: query, required: true, schema: { type: string } }
+      responses:
+        '200': { description: Membership }
+    put:
+      tags: [Access]
+      summary: Replace a user's access-role membership (admin)
+      operationId: setUserAccessRoles
+      requestBody:
+        content:
+          application/json:
+            schema: { type: object, properties: { user_id: { type: string }, role_ids: { type: array, items: { type: integer } } } }
+      responses:
+        '200': { description: Updated }
+  /api/access-roles/{id}:
+    parameters:
+      - { name: id, in: path, required: true, schema: { type: integer } }
+    get:
+      tags: [Access]
+      summary: Get an access role (admin)
+      operationId: getAccessRole
+      responses:
+        '200':
+          description: Access role
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AccessRole' }
+    put:
+      tags: [Access]
+      summary: Update an access role (admin)
+      operationId: updateAccessRole
+      requestBody:
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/AccessRoleInput' }
+      responses:
+        '200':
+          description: Updated
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/AccessRole' }
+    delete:
+      tags: [Access]
+      summary: Delete an access role (admin)
+      operationId: deleteAccessRole
+      responses:
+        '200': { description: Deleted }
+
   # ── Chat rooms ───────────────────────────────────────────────────────
   /api/rooms:
     get:

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -73,6 +73,7 @@ func registerAPI(mux *http.ServeMux, db *sql.DB, version string, live *liveHub, 
 	r.registerProjectHandlers()
 	r.registerDocumentHandlers()
 	r.registerRoomHandlers()
+	r.registerAccessRoleHandlers()
 	r.registerTicketHandlers()
 	r.registerReleaseHandlers()
 	r.registerOrgHandlers()

--- a/internal/server/api_access_roles.go
+++ b/internal/server/api_access_roles.go
@@ -11,19 +11,19 @@ import (
 )
 
 // gatedPanelPrefixes maps API path prefixes to the panel that guards them.
-// Only clearly panel-scoped, non-foundational endpoints are server-enforced;
-// foundational data (projects, tickets, status) stays ungated so restricting a
-// panel never breaks the board. Admin-tier panels keep their own requireAdmin
-// checks. The web nav additionally hides panels a user cannot access.
+// Only SELF-CONTAINED panels are server-enforced — their data backs only that
+// panel. Panels whose data is shared with the board/ticket flows (workflows,
+// roles, teams) and foundational endpoints (projects, tickets, status) stay
+// ungated so restricting a panel never breaks ticket creation; those panels are
+// hidden in the nav (UI gating) only. Admin-tier panels keep their own
+// requireAdmin checks. The map is data-driven, so more panels can be enforced
+// once their endpoints are decoupled from the shared flows.
 var gatedPanelPrefixes = []struct {
 	prefix string
 	panel  string
 }{
 	{"/api/rooms", store.PanelChat},
-	{"/api/workflows", store.PanelWorkflows},
-	{"/api/roles", store.PanelRoles},
 	{"/api/documents", store.PanelDocuments},
-	{"/api/teams", store.PanelTeams},
 }
 
 func panelForPath(path string) (string, bool) {

--- a/internal/server/api_access_roles.go
+++ b/internal/server/api_access_roles.go
@@ -1,0 +1,247 @@
+package server
+
+import (
+	"database/sql"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/simonski/ticket/internal/store"
+)
+
+// gatedPanelPrefixes maps API path prefixes to the panel that guards them.
+// Only clearly panel-scoped, non-foundational endpoints are server-enforced;
+// foundational data (projects, tickets, status) stays ungated so restricting a
+// panel never breaks the board. Admin-tier panels keep their own requireAdmin
+// checks. The web nav additionally hides panels a user cannot access.
+var gatedPanelPrefixes = []struct {
+	prefix string
+	panel  string
+}{
+	{"/api/rooms", store.PanelChat},
+	{"/api/workflows", store.PanelWorkflows},
+	{"/api/roles", store.PanelRoles},
+	{"/api/documents", store.PanelDocuments},
+	{"/api/teams", store.PanelTeams},
+}
+
+func panelForPath(path string) (string, bool) {
+	for _, g := range gatedPanelPrefixes {
+		if path == g.prefix || strings.HasPrefix(path, g.prefix+"/") {
+			return g.panel, true
+		}
+	}
+	return "", false
+}
+
+// panelAccessMiddleware enforces per-panel access for authenticated non-admin
+// users on gated endpoints. Unauthenticated requests fall through so the handler
+// can return its own 401; admins always pass.
+func panelAccessMiddleware(next http.Handler, db *sql.DB) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panel, gated := panelForPath(r.URL.Path)
+		if !gated {
+			next.ServeHTTP(w, r)
+			return
+		}
+		user, err := requireUser(db, r)
+		if err != nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+		if user.Role == "admin" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		ok, cerr := store.UserCanAccessPanel(r.Context(), db, user.ID, false, panel)
+		if cerr != nil {
+			writeError(w, http.StatusInternalServerError, cerr.Error())
+			return
+		}
+		if !ok {
+			writeError(w, http.StatusForbidden, "access to this panel is not permitted")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// registerAccessRoleHandlers wires the access-role (per-panel feature flag) API
+// (TK-135). All endpoints are admin-only except GET /api/me/panels, which lets
+// the current user discover their own effective panel set.
+func (r *router) registerAccessRoleHandlers() {
+	db := r.db
+	mux := r.mux
+
+	// Current user's effective panel set — used by the web nav to decide what to render.
+	mux.HandleFunc("/api/me/panels", func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		user, err := requireUser(db, req)
+		if err != nil {
+			writeAuthError(w, err)
+			return
+		}
+		panels, perr := store.EffectivePanels(req.Context(), db, user.ID, user.Role == "admin")
+		if perr != nil {
+			writeStoreError(w, perr)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"panels": panels})
+	})
+
+	// Catalogue of panels an access role may grant (admin, for the editor UI).
+	mux.HandleFunc("/api/panels", func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		if _, err := requireAdmin(db, req); err != nil {
+			writeAuthError(w, err)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"all":       store.AllPanels(),
+			"grantable": store.GrantablePanels(),
+		})
+	})
+
+	// Collection: list + create.
+	mux.HandleFunc("/api/access-roles", func(w http.ResponseWriter, req *http.Request) {
+		if _, err := requireAdmin(db, req); err != nil {
+			writeAuthError(w, err)
+			return
+		}
+		switch req.Method {
+		case http.MethodGet:
+			roles, lerr := store.ListAccessRoles(req.Context(), db)
+			if lerr != nil {
+				writeStoreError(w, lerr)
+				return
+			}
+			if roles == nil {
+				roles = []store.AccessRole{}
+			}
+			writeJSON(w, http.StatusOK, roles)
+		case http.MethodPost:
+			var body accessRoleBody
+			if derr := decodeJSONBody(req, &body); derr != nil {
+				writeError(w, http.StatusBadRequest, "invalid request body")
+				return
+			}
+			role, cerr := store.CreateAccessRole(req.Context(), db, body.Name, body.Description, body.Panels)
+			if cerr != nil {
+				writeStoreError(w, cerr)
+				return
+			}
+			writeJSON(w, http.StatusCreated, role)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+	})
+
+	// Membership: read/replace a user's access-role assignments.
+	mux.HandleFunc("/api/access-roles/memberships", func(w http.ResponseWriter, req *http.Request) {
+		if _, err := requireAdmin(db, req); err != nil {
+			writeAuthError(w, err)
+			return
+		}
+		switch req.Method {
+		case http.MethodGet:
+			userID := strings.TrimSpace(req.URL.Query().Get("user_id"))
+			if userID == "" {
+				writeError(w, http.StatusBadRequest, "user_id is required")
+				return
+			}
+			ids, gerr := store.UserAccessRoleIDs(req.Context(), db, userID)
+			if gerr != nil {
+				writeStoreError(w, gerr)
+				return
+			}
+			if ids == nil {
+				ids = []int64{}
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"user_id": userID, "role_ids": ids})
+		case http.MethodPut:
+			var body struct {
+				UserID  string  `json:"user_id"`
+				RoleIDs []int64 `json:"role_ids"`
+			}
+			if derr := decodeJSONBody(req, &body); derr != nil {
+				writeError(w, http.StatusBadRequest, "invalid request body")
+				return
+			}
+			if strings.TrimSpace(body.UserID) == "" {
+				writeError(w, http.StatusBadRequest, "user_id is required")
+				return
+			}
+			if serr := store.SetUserAccessRoles(req.Context(), db, body.UserID, body.RoleIDs); serr != nil {
+				writeStoreError(w, serr)
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"user_id": body.UserID, "role_ids": body.RoleIDs})
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+	})
+
+	// Item: get / update / delete by id.
+	mux.HandleFunc("/api/access-roles/", func(w http.ResponseWriter, req *http.Request) {
+		if _, err := requireAdmin(db, req); err != nil {
+			writeAuthError(w, err)
+			return
+		}
+		idStr := strings.TrimPrefix(req.URL.Path, "/api/access-roles/")
+		id, perr := strconv.ParseInt(idStr, 10, 64)
+		if perr != nil {
+			writeError(w, http.StatusNotFound, "access role not found")
+			return
+		}
+		switch req.Method {
+		case http.MethodGet:
+			role, gerr := store.GetAccessRole(req.Context(), db, id)
+			if gerr != nil {
+				writeAccessRoleError(w, gerr)
+				return
+			}
+			writeJSON(w, http.StatusOK, role)
+		case http.MethodPut:
+			var body accessRoleBody
+			if derr := decodeJSONBody(req, &body); derr != nil {
+				writeError(w, http.StatusBadRequest, "invalid request body")
+				return
+			}
+			role, uerr := store.UpdateAccessRole(req.Context(), db, id, body.Name, body.Description, body.Panels)
+			if uerr != nil {
+				writeAccessRoleError(w, uerr)
+				return
+			}
+			writeJSON(w, http.StatusOK, role)
+		case http.MethodDelete:
+			if derr := store.DeleteAccessRole(req.Context(), db, id); derr != nil {
+				writeAccessRoleError(w, derr)
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"deleted": id})
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+	})
+}
+
+type accessRoleBody struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Panels      []string `json:"panels"`
+}
+
+func writeAccessRoleError(w http.ResponseWriter, err error) {
+	if errors.Is(err, store.ErrAccessRoleNotFound) {
+		writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	writeStoreError(w, err)
+}

--- a/internal/server/api_access_roles_test.go
+++ b/internal/server/api_access_roles_test.go
@@ -72,9 +72,9 @@ func TestAccessRoleAPIAndEnforcement(t *testing.T) {
 		t.Fatalf("granting admin panel = %d, want 400", resp.Code)
 	}
 
-	// Before assignment bob is grandfathered to all grantable panels and can hit /api/workflows.
-	if resp := doJSONRequest(t, handler, http.MethodGet, "/api/workflows", nil, bobToken); resp.Code == http.StatusForbidden {
-		t.Fatalf("ungated bob should reach /api/workflows, got 403")
+	// Before assignment bob is grandfathered to all grantable panels and can hit /api/documents.
+	if resp := doJSONRequest(t, handler, http.MethodGet, "/api/documents", nil, bobToken); resp.Code == http.StatusForbidden {
+		t.Fatalf("ungated bob should reach /api/documents, got 403")
 	}
 
 	// Assign bob the restrictive role.
@@ -102,11 +102,11 @@ func TestAccessRoleAPIAndEnforcement(t *testing.T) {
 		t.Fatalf("bob panels = %v, want [tickets]", me.Panels)
 	}
 
-	// Enforcement: bob can no longer reach the workflows panel API; admin still can.
-	if resp := doJSONRequest(t, handler, http.MethodGet, "/api/workflows", nil, bobToken); resp.Code != http.StatusForbidden {
-		t.Fatalf("restricted bob GET /api/workflows = %d, want 403", resp.Code)
+	// Enforcement: bob can no longer reach the documents panel API; admin still can.
+	if resp := doJSONRequest(t, handler, http.MethodGet, "/api/documents", nil, bobToken); resp.Code != http.StatusForbidden {
+		t.Fatalf("restricted bob GET /api/documents = %d, want 403", resp.Code)
 	}
-	if resp := doJSONRequest(t, handler, http.MethodGet, "/api/workflows", nil, adminToken); resp.Code == http.StatusForbidden {
+	if resp := doJSONRequest(t, handler, http.MethodGet, "/api/documents", nil, adminToken); resp.Code == http.StatusForbidden {
 		t.Fatalf("admin must bypass panel enforcement, got 403")
 	}
 }

--- a/internal/server/api_access_roles_test.go
+++ b/internal/server/api_access_roles_test.go
@@ -1,0 +1,112 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/simonski/ticket/internal/store"
+)
+
+func loginToken(t *testing.T, handler http.Handler, username, password string) string {
+	t.Helper()
+	resp := doJSONRequest(t, handler, http.MethodPost, "/api/login", map[string]string{
+		"username": username,
+		"password": password,
+	}, "")
+	if resp.Code != http.StatusOK {
+		t.Fatalf("login %s status = %d, body = %s", username, resp.Code, resp.Body.String())
+	}
+	var payload struct {
+		Token string `json:"token"`
+	}
+	decodeResponse(t, resp, &payload)
+	if payload.Token == "" {
+		t.Fatalf("login %s returned empty token", username)
+	}
+	return payload.Token
+}
+
+func TestAccessRoleAPIAndEnforcement(t *testing.T) {
+	handler, db := testHandler(t)
+	defer db.Close()
+
+	if _, err := store.CreateUser(context.Background(), db, "bob", "password123", "user"); err != nil {
+		t.Fatalf("create bob: %v", err)
+	}
+	adminToken := loginToken(t, handler, "admin", "password")
+	bobToken := loginToken(t, handler, "bob", "password123")
+
+	// Non-admin cannot list access roles.
+	if resp := doJSONRequest(t, handler, http.MethodGet, "/api/access-roles", nil, bobToken); resp.Code != http.StatusForbidden {
+		t.Fatalf("bob GET /api/access-roles = %d, want 403", resp.Code)
+	}
+
+	// Admin lists roles (builtin Member is seeded).
+	listResp := doJSONRequest(t, handler, http.MethodGet, "/api/access-roles", nil, adminToken)
+	if listResp.Code != http.StatusOK {
+		t.Fatalf("admin list = %d", listResp.Code)
+	}
+	var roles []store.AccessRole
+	decodeResponse(t, listResp, &roles)
+	if len(roles) == 0 || roles[0].Name != "Member" {
+		t.Fatalf("expected builtin Member role, got %+v", roles)
+	}
+
+	// Admin creates a restrictive role (tickets only).
+	createResp := doJSONRequest(t, handler, http.MethodPost, "/api/access-roles", map[string]any{
+		"name":   "Limited",
+		"panels": []string{store.PanelTickets},
+	}, adminToken)
+	if createResp.Code != http.StatusCreated {
+		t.Fatalf("create role = %d, body = %s", createResp.Code, createResp.Body.String())
+	}
+	var limited store.AccessRole
+	decodeResponse(t, createResp, &limited)
+
+	// Granting an admin panel is rejected.
+	if resp := doJSONRequest(t, handler, http.MethodPost, "/api/access-roles", map[string]any{
+		"name":   "Sneaky",
+		"panels": []string{store.PanelUsers},
+	}, adminToken); resp.Code != http.StatusBadRequest {
+		t.Fatalf("granting admin panel = %d, want 400", resp.Code)
+	}
+
+	// Before assignment bob is grandfathered to all grantable panels and can hit /api/workflows.
+	if resp := doJSONRequest(t, handler, http.MethodGet, "/api/workflows", nil, bobToken); resp.Code == http.StatusForbidden {
+		t.Fatalf("ungated bob should reach /api/workflows, got 403")
+	}
+
+	// Assign bob the restrictive role.
+	bob, err := store.GetUserByUsername(context.Background(), db, "bob")
+	if err != nil {
+		t.Fatalf("get bob: %v", err)
+	}
+	if resp := doJSONRequest(t, handler, http.MethodPut, "/api/access-roles/memberships", map[string]any{
+		"user_id":  bob.ID,
+		"role_ids": []int64{limited.ID},
+	}, adminToken); resp.Code != http.StatusOK {
+		t.Fatalf("assign membership = %d, body = %s", resp.Code, resp.Body.String())
+	}
+
+	// bob's effective panels are now tickets only.
+	meResp := doJSONRequest(t, handler, http.MethodGet, "/api/me/panels", nil, bobToken)
+	if meResp.Code != http.StatusOK {
+		t.Fatalf("me/panels = %d", meResp.Code)
+	}
+	var me struct {
+		Panels []string `json:"panels"`
+	}
+	decodeResponse(t, meResp, &me)
+	if len(me.Panels) != 1 || me.Panels[0] != store.PanelTickets {
+		t.Fatalf("bob panels = %v, want [tickets]", me.Panels)
+	}
+
+	// Enforcement: bob can no longer reach the workflows panel API; admin still can.
+	if resp := doJSONRequest(t, handler, http.MethodGet, "/api/workflows", nil, bobToken); resp.Code != http.StatusForbidden {
+		t.Fatalf("restricted bob GET /api/workflows = %d, want 403", resp.Code)
+	}
+	if resp := doJSONRequest(t, handler, http.MethodGet, "/api/workflows", nil, adminToken); resp.Code == http.StatusForbidden {
+		t.Fatalf("admin must bypass panel enforcement, got 403")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -233,6 +233,7 @@ func handlerWithPasskeyFactory(db *sql.DB, version string, verbose bool, output 
 	mux.Handle("/", spaHandler(fileServer, staticFS, version))
 
 	var handler http.Handler = mux
+	handler = panelAccessMiddleware(handler, db)
 	handler = csrfMiddleware(handler)
 	handler = writeThrottleMiddleware(handler, db, newRateLimiter(writeRateLimitFromEnv(), time.Minute))
 	handler = requestTimeoutMiddleware(handler, requestTimeoutFromEnv())

--- a/internal/store/access_role.go
+++ b/internal/store/access_role.go
@@ -203,14 +203,14 @@ func DeleteAccessRole(ctx context.Context, db *sql.DB, id int64) error {
 	if role.Builtin {
 		return errors.New("the builtin access role cannot be deleted")
 	}
-	if _, err := db.ExecContext(ctx, `DELETE FROM access_role_panels WHERE access_role_id = ?`, id); err != nil {
-		return err
+	if _, derr := db.ExecContext(ctx, `DELETE FROM access_role_panels WHERE access_role_id = ?`, id); derr != nil {
+		return derr
 	}
-	if _, err := db.ExecContext(ctx, `DELETE FROM user_access_roles WHERE access_role_id = ?`, id); err != nil {
-		return err
+	if _, derr := db.ExecContext(ctx, `DELETE FROM user_access_roles WHERE access_role_id = ?`, id); derr != nil {
+		return derr
 	}
-	_, err = db.ExecContext(ctx, `DELETE FROM access_roles WHERE access_role_id = ?`, id)
-	return err
+	_, derr := db.ExecContext(ctx, `DELETE FROM access_roles WHERE access_role_id = ?`, id)
+	return derr
 }
 
 // GetAccessRole loads one access role with its panels.

--- a/internal/store/access_role.go
+++ b/internal/store/access_role.go
@@ -1,0 +1,380 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+// Access roles gate which UI panels a user can see/use (TK-135). They are
+// distinct from workflow roles (architect/engineer/QA) and from the admin/member
+// flag. A user is a member of zero or more access roles; their effective panel
+// set is the union of those roles' granted panels. Admins implicitly have every
+// panel. A user with no assigned access roles is grandfathered to the default
+// member panel set so upgrades never lock anyone out.
+
+// Panel keys mirror the web UI nav view identifiers.
+const (
+	PanelTickets       = "tickets"
+	PanelProjects      = "projects"
+	PanelChat          = "chat"
+	PanelInterventions = "interventions"
+	PanelWorkflows     = "workflows"
+	PanelRoles         = "roles"
+	PanelDocuments     = "documents"
+	PanelContext       = "context"
+	PanelTeams         = "teams"
+	PanelProgrammes    = "programmes"
+	PanelSettings      = "settings"
+	PanelAgents        = "agents"
+	PanelUsers         = "users"
+	PanelAdminSummary  = "admin-summary"
+
+	builtinMemberRoleName = "Member"
+)
+
+// adminPanels always require the admin flag and cannot be granted via an access
+// role. The remaining panels are grantable.
+var adminPanels = []string{PanelProgrammes, PanelSettings, PanelAgents, PanelUsers, PanelAdminSummary}
+
+// grantablePanels are the panels an access role may grant (everything that is
+// not admin-only). This is also the default member panel set, preserving the
+// pre-TK-135 behaviour where every signed-in user saw the general+process nav.
+var grantablePanels = []string{
+	PanelTickets, PanelProjects, PanelChat, PanelInterventions,
+	PanelWorkflows, PanelRoles, PanelDocuments, PanelContext, PanelTeams,
+}
+
+// AllPanels is the full ordered panel list (grantable first, then admin).
+func AllPanels() []string {
+	out := make([]string, 0, len(grantablePanels)+len(adminPanels))
+	out = append(out, grantablePanels...)
+	out = append(out, adminPanels...)
+	return out
+}
+
+// GrantablePanels returns the panels an access role may grant (a copy).
+func GrantablePanels() []string {
+	return append([]string(nil), grantablePanels...)
+}
+
+func isGrantablePanel(key string) bool {
+	return slices.Contains(grantablePanels, key)
+}
+
+func isAdminPanel(key string) bool {
+	return slices.Contains(adminPanels, key)
+}
+
+// AccessRole is a named set of panel grants.
+type AccessRole struct {
+	ID          int64    `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Builtin     bool     `json:"builtin"`
+	Panels      []string `json:"panels"`
+	CreatedAt   string   `json:"created_at,omitempty"`
+	UpdatedAt   string   `json:"updated_at,omitempty"`
+}
+
+// ErrAccessRoleNotFound is returned when an access role does not exist.
+var ErrAccessRoleNotFound = errors.New("access role not found")
+
+// normalizePanels validates, de-duplicates, and orders a panel set, rejecting
+// admin-only or unknown panel keys.
+func normalizePanels(panels []string) ([]string, error) {
+	seen := map[string]bool{}
+	for _, p := range panels {
+		key := strings.TrimSpace(p)
+		if key == "" {
+			continue
+		}
+		if isAdminPanel(key) {
+			return nil, fmt.Errorf("panel %q is admin-only and cannot be granted via an access role", key)
+		}
+		if !isGrantablePanel(key) {
+			return nil, fmt.Errorf("unknown panel %q", key)
+		}
+		seen[key] = true
+	}
+	out := make([]string, 0, len(seen))
+	for _, p := range grantablePanels {
+		if seen[p] {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+// EnsureDefaultAccessRoles creates the builtin "Member" role (granting every
+// non-admin panel) if it does not already exist. Idempotent.
+func EnsureDefaultAccessRoles(ctx context.Context, db *sql.DB) error {
+	var id int64
+	err := db.QueryRowContext(ctx, `SELECT access_role_id FROM access_roles WHERE name = ?`, builtinMemberRoleName).Scan(&id)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, sql.ErrNoRows) {
+		return err
+	}
+	_, cerr := createAccessRole(ctx, db, builtinMemberRoleName,
+		"Standard access to the general and process panels.", grantablePanels, true)
+	return cerr
+}
+
+func createAccessRole(ctx context.Context, db *sql.DB, name, description string, panels []string, builtin bool) (AccessRole, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return AccessRole{}, errors.New("access role name is required")
+	}
+	norm, err := normalizePanels(panels)
+	if err != nil {
+		return AccessRole{}, err
+	}
+	res, err := db.ExecContext(ctx, `INSERT INTO access_roles (name, description, builtin) VALUES (?, ?, ?)`,
+		name, strings.TrimSpace(description), boolToInt(builtin))
+	if err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "unique") {
+			return AccessRole{}, fmt.Errorf("an access role named %q already exists", name)
+		}
+		return AccessRole{}, err
+	}
+	id, _ := res.LastInsertId()
+	if perr := replaceAccessRolePanels(ctx, db, id, norm); perr != nil {
+		return AccessRole{}, perr
+	}
+	return GetAccessRole(ctx, db, id)
+}
+
+// CreateAccessRole creates a new (non-builtin) access role.
+func CreateAccessRole(ctx context.Context, db *sql.DB, name, description string, panels []string) (AccessRole, error) {
+	return createAccessRole(ctx, db, name, description, panels, false)
+}
+
+func replaceAccessRolePanels(ctx context.Context, db *sql.DB, roleID int64, panels []string) error {
+	if _, err := db.ExecContext(ctx, `DELETE FROM access_role_panels WHERE access_role_id = ?`, roleID); err != nil {
+		return err
+	}
+	for _, p := range panels {
+		if _, err := db.ExecContext(ctx, `INSERT INTO access_role_panels (access_role_id, panel_key) VALUES (?, ?)`, roleID, p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UpdateAccessRole updates an access role's name/description/panels.
+func UpdateAccessRole(ctx context.Context, db *sql.DB, id int64, name, description string, panels []string) (AccessRole, error) {
+	existing, err := GetAccessRole(ctx, db, id)
+	if err != nil {
+		return AccessRole{}, err
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		name = existing.Name
+	}
+	norm, err := normalizePanels(panels)
+	if err != nil {
+		return AccessRole{}, err
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE access_roles SET name = ?, description = ?, updated_at = CURRENT_TIMESTAMP WHERE access_role_id = ?`,
+		name, strings.TrimSpace(description), id); err != nil {
+		if strings.Contains(strings.ToLower(err.Error()), "unique") {
+			return AccessRole{}, fmt.Errorf("an access role named %q already exists", name)
+		}
+		return AccessRole{}, err
+	}
+	if perr := replaceAccessRolePanels(ctx, db, id, norm); perr != nil {
+		return AccessRole{}, perr
+	}
+	return GetAccessRole(ctx, db, id)
+}
+
+// DeleteAccessRole removes an access role and its memberships. Builtin roles
+// cannot be deleted.
+func DeleteAccessRole(ctx context.Context, db *sql.DB, id int64) error {
+	role, err := GetAccessRole(ctx, db, id)
+	if err != nil {
+		return err
+	}
+	if role.Builtin {
+		return errors.New("the builtin access role cannot be deleted")
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM access_role_panels WHERE access_role_id = ?`, id); err != nil {
+		return err
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM user_access_roles WHERE access_role_id = ?`, id); err != nil {
+		return err
+	}
+	_, err = db.ExecContext(ctx, `DELETE FROM access_roles WHERE access_role_id = ?`, id)
+	return err
+}
+
+// GetAccessRole loads one access role with its panels.
+func GetAccessRole(ctx context.Context, db *sql.DB, id int64) (AccessRole, error) {
+	var r AccessRole
+	var builtin int
+	err := db.QueryRowContext(ctx, `SELECT access_role_id, name, description, builtin, created_at, updated_at FROM access_roles WHERE access_role_id = ?`, id).
+		Scan(&r.ID, &r.Name, &r.Description, &builtin, &r.CreatedAt, &r.UpdatedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return AccessRole{}, ErrAccessRoleNotFound
+	}
+	if err != nil {
+		return AccessRole{}, err
+	}
+	r.Builtin = builtin != 0
+	panels, perr := accessRolePanels(ctx, db, id)
+	if perr != nil {
+		return AccessRole{}, perr
+	}
+	r.Panels = panels
+	return r, nil
+}
+
+func accessRolePanels(ctx context.Context, db *sql.DB, roleID int64) ([]string, error) {
+	rows, err := db.QueryContext(ctx, `SELECT panel_key FROM access_role_panels WHERE access_role_id = ?`, roleID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	set := map[string]bool{}
+	for rows.Next() {
+		var k string
+		if serr := rows.Scan(&k); serr != nil {
+			return nil, serr
+		}
+		set[k] = true
+	}
+	if rerr := rows.Err(); rerr != nil {
+		return nil, rerr
+	}
+	out := make([]string, 0, len(set))
+	for _, p := range grantablePanels {
+		if set[p] {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+// ListAccessRoles returns all access roles (with panels), seeding the builtin
+// role first so freshly-upgraded databases always expose the preset.
+func ListAccessRoles(ctx context.Context, db *sql.DB) ([]AccessRole, error) {
+	if err := EnsureDefaultAccessRoles(ctx, db); err != nil {
+		return nil, err
+	}
+	rows, err := db.QueryContext(ctx, `SELECT access_role_id FROM access_roles ORDER BY builtin DESC, name COLLATE NOCASE ASC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if serr := rows.Scan(&id); serr != nil {
+			return nil, serr
+		}
+		ids = append(ids, id)
+	}
+	if rerr := rows.Err(); rerr != nil {
+		return nil, rerr
+	}
+	out := make([]AccessRole, 0, len(ids))
+	for _, id := range ids {
+		r, gerr := GetAccessRole(ctx, db, id)
+		if gerr != nil {
+			return nil, gerr
+		}
+		out = append(out, r)
+	}
+	return out, nil
+}
+
+// SetUserAccessRoles replaces a user's access-role membership.
+func SetUserAccessRoles(ctx context.Context, db *sql.DB, userID string, roleIDs []int64) error {
+	userID = strings.TrimSpace(userID)
+	if userID == "" {
+		return errors.New("user id is required")
+	}
+	if _, err := db.ExecContext(ctx, `DELETE FROM user_access_roles WHERE user_id = ?`, userID); err != nil {
+		return err
+	}
+	for _, rid := range roleIDs {
+		if _, err := GetAccessRole(ctx, db, rid); err != nil {
+			return err
+		}
+		if _, err := db.ExecContext(ctx, `INSERT OR IGNORE INTO user_access_roles (user_id, access_role_id) VALUES (?, ?)`, userID, rid); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// UserAccessRoleIDs returns the access-role ids a user belongs to.
+func UserAccessRoleIDs(ctx context.Context, db *sql.DB, userID string) ([]int64, error) {
+	rows, err := db.QueryContext(ctx, `SELECT access_role_id FROM user_access_roles WHERE user_id = ? ORDER BY access_role_id`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if serr := rows.Scan(&id); serr != nil {
+			return nil, serr
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// EffectivePanels resolves the panel set a user can access. Admins get every
+// panel; otherwise the union of their access roles' panels, or the default
+// member set when the user has no assigned roles (grandfathered).
+func EffectivePanels(ctx context.Context, db *sql.DB, userID string, isAdmin bool) ([]string, error) {
+	if isAdmin {
+		return AllPanels(), nil
+	}
+	ids, err := UserAccessRoleIDs(ctx, db, userID)
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return GrantablePanels(), nil
+	}
+	set := map[string]bool{}
+	for _, id := range ids {
+		panels, perr := accessRolePanels(ctx, db, id)
+		if perr != nil {
+			return nil, perr
+		}
+		for _, p := range panels {
+			set[p] = true
+		}
+	}
+	out := make([]string, 0, len(set))
+	for _, p := range grantablePanels {
+		if set[p] {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+// UserCanAccessPanel reports whether a user may access a given panel.
+func UserCanAccessPanel(ctx context.Context, db *sql.DB, userID string, isAdmin bool, panel string) (bool, error) {
+	if isAdmin {
+		return true, nil
+	}
+	if isAdminPanel(panel) {
+		return false, nil
+	}
+	panels, err := EffectivePanels(ctx, db, userID, isAdmin)
+	if err != nil {
+		return false, err
+	}
+	return slices.Contains(panels, panel), nil
+}

--- a/internal/store/access_role_test.go
+++ b/internal/store/access_role_test.go
@@ -1,0 +1,144 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+func openAccessRoleTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := createSchema(context.Background(), db); err != nil {
+		t.Fatalf("createSchema: %v", err)
+	}
+	return db
+}
+
+func TestEnsureDefaultAccessRolesIdempotent(t *testing.T) {
+	ctx := context.Background()
+	db := openAccessRoleTestDB(t)
+	if err := EnsureDefaultAccessRoles(ctx, db); err != nil {
+		t.Fatalf("ensure 1: %v", err)
+	}
+	if err := EnsureDefaultAccessRoles(ctx, db); err != nil {
+		t.Fatalf("ensure 2: %v", err)
+	}
+	roles, err := ListAccessRoles(ctx, db)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(roles) != 1 || roles[0].Name != builtinMemberRoleName || !roles[0].Builtin {
+		t.Fatalf("want one builtin Member role, got %+v", roles)
+	}
+	if len(roles[0].Panels) != len(grantablePanels) {
+		t.Fatalf("Member role should grant all %d grantable panels, got %v", len(grantablePanels), roles[0].Panels)
+	}
+}
+
+func TestAccessRoleCRUDAndPanelValidation(t *testing.T) {
+	ctx := context.Background()
+	db := openAccessRoleTestDB(t)
+
+	r, err := CreateAccessRole(ctx, db, "Viewer", "read-only", []string{PanelTickets, PanelProjects})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if len(r.Panels) != 2 {
+		t.Fatalf("want 2 panels, got %v", r.Panels)
+	}
+
+	// Admin-only panels cannot be granted.
+	if _, err := CreateAccessRole(ctx, db, "Sneaky", "", []string{PanelUsers}); err == nil {
+		t.Fatal("granting an admin panel should fail")
+	}
+	// Unknown panels are rejected.
+	if _, err := CreateAccessRole(ctx, db, "Bogus", "", []string{"nope"}); err == nil {
+		t.Fatal("unknown panel should fail")
+	}
+	// Duplicate names are rejected.
+	if _, err := CreateAccessRole(ctx, db, "Viewer", "", []string{PanelTickets}); err == nil {
+		t.Fatal("duplicate name should fail")
+	}
+
+	updated, err := UpdateAccessRole(ctx, db, r.ID, "Viewer+", "", []string{PanelTickets, PanelChat, PanelDocuments})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if updated.Name != "Viewer+" || len(updated.Panels) != 3 {
+		t.Fatalf("update mismatch: %+v", updated)
+	}
+
+	if err := DeleteAccessRole(ctx, db, r.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := GetAccessRole(ctx, db, r.ID); err != ErrAccessRoleNotFound {
+		t.Fatalf("want ErrAccessRoleNotFound, got %v", err)
+	}
+}
+
+func TestDeleteBuiltinAccessRoleRejected(t *testing.T) {
+	ctx := context.Background()
+	db := openAccessRoleTestDB(t)
+	roles, _ := ListAccessRoles(ctx, db)
+	if err := DeleteAccessRole(ctx, db, roles[0].ID); err == nil {
+		t.Fatal("deleting the builtin role should fail")
+	}
+}
+
+func TestEffectivePanels(t *testing.T) {
+	ctx := context.Background()
+	db := openAccessRoleTestDB(t)
+
+	// Admin sees every panel including admin-only ones.
+	adminPanelsSet, err := EffectivePanels(ctx, db, "admin-user", true)
+	if err != nil {
+		t.Fatalf("admin panels: %v", err)
+	}
+	if len(adminPanelsSet) != len(AllPanels()) {
+		t.Fatalf("admin should see all %d panels, got %d", len(AllPanels()), len(adminPanelsSet))
+	}
+
+	// A user with no assigned roles is grandfathered to the default member set.
+	def, err := EffectivePanels(ctx, db, "u1", false)
+	if err != nil {
+		t.Fatalf("default panels: %v", err)
+	}
+	if len(def) != len(grantablePanels) {
+		t.Fatalf("ungated user should see default %d panels, got %v", len(grantablePanels), def)
+	}
+
+	// Assigning a restrictive role narrows the set.
+	role, err := CreateAccessRole(ctx, db, "TicketsOnly", "", []string{PanelTickets})
+	if err != nil {
+		t.Fatalf("create role: %v", err)
+	}
+	if err := SetUserAccessRoles(ctx, db, "u1", []int64{role.ID}); err != nil {
+		t.Fatalf("assign: %v", err)
+	}
+	got, err := EffectivePanels(ctx, db, "u1", false)
+	if err != nil {
+		t.Fatalf("effective: %v", err)
+	}
+	if len(got) != 1 || got[0] != PanelTickets {
+		t.Fatalf("want [tickets], got %v", got)
+	}
+
+	ok, err := UserCanAccessPanel(ctx, db, "u1", false, PanelProjects)
+	if err != nil || ok {
+		t.Fatalf("u1 should NOT access projects (ok=%v err=%v)", ok, err)
+	}
+	ok, _ = UserCanAccessPanel(ctx, db, "u1", false, PanelTickets)
+	if !ok {
+		t.Fatal("u1 should access tickets")
+	}
+	// Admin-only panel denied to non-admin even if somehow requested.
+	ok, _ = UserCanAccessPanel(ctx, db, "u1", false, PanelUsers)
+	if ok {
+		t.Fatal("non-admin must never access an admin panel")
+	}
+}

--- a/internal/store/schema_version.go
+++ b/internal/store/schema_version.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	LegacySchemaVersion  = 1
-	CurrentSchemaVersion = 13
+	CurrentSchemaVersion = 14
 	schemaMetaTable      = "schema_meta"
 	schemaVersionKey     = "schema_version"
 	// DefaultBackupRetention is the number of timestamped pre-upgrade backups

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -138,6 +138,9 @@ func Init(path, adminUsername, adminPassword string, seedFn ...SeedFunc) error {
 	if planErr := ensureDefaultPlans(ctx, db); planErr != nil {
 		return planErr
 	}
+	if arErr := EnsureDefaultAccessRoles(ctx, db); arErr != nil {
+		return arErr
+	}
 	adminUser, err := CreateUserWithParams(ctx, db, UserCreateParams{
 		Username:               adminUsername,
 		PlainPassword:          adminPassword,
@@ -828,6 +831,35 @@ CREATE INDEX IF NOT EXISTS idx_rooms_project_id ON rooms(project_id);
 CREATE INDEX IF NOT EXISTS idx_rooms_ticket_id ON rooms(ticket_id);
 CREATE INDEX IF NOT EXISTS idx_room_members_member_id ON room_members(member_id);
 CREATE INDEX IF NOT EXISTS idx_room_messages_room_id ON room_messages(room_id, message_id);
+
+-- Access roles: per-panel feature flags. Each access role grants a set of UI
+-- panels; users are members of zero or more access roles (TK-135).
+CREATE TABLE IF NOT EXISTS access_roles (
+	access_role_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	name TEXT NOT NULL,
+	description TEXT NOT NULL DEFAULT '',
+	builtin INTEGER NOT NULL DEFAULT 0,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS access_role_panels (
+	access_role_id INTEGER NOT NULL,
+	panel_key TEXT NOT NULL,
+	PRIMARY KEY (access_role_id, panel_key),
+	FOREIGN KEY(access_role_id) REFERENCES access_roles(access_role_id)
+);
+
+CREATE TABLE IF NOT EXISTS user_access_roles (
+	user_id TEXT NOT NULL,
+	access_role_id INTEGER NOT NULL,
+	PRIMARY KEY (user_id, access_role_id),
+	FOREIGN KEY(access_role_id) REFERENCES access_roles(access_role_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_access_roles_name ON access_roles(name);
+CREATE INDEX IF NOT EXISTS idx_access_role_panels_role ON access_role_panels(access_role_id);
+CREATE INDEX IF NOT EXISTS idx_user_access_roles_user ON user_access_roles(user_id);
 
 `
 

--- a/tests/playwright/site2.spec.js
+++ b/tests/playwright/site2.spec.js
@@ -2183,3 +2183,7 @@ test("account menu is a single 'Account settings' entry (TK-50)", async ({ page 
   await expect(page.locator("#account-modal")).toHaveClass(/open/);
   await expect(page.locator("#account-modal-title")).toHaveText("Account settings");
 });
+
+test("admin sees the Access (access-roles) nav entry (TK-135)", async ({ page }) => {
+  await expect(page.locator('#admin-nav button[data-view="access"]')).toBeVisible();
+});

--- a/web/default/index.html
+++ b/web/default/index.html
@@ -859,6 +859,42 @@
                     </div>
                 </section>
 
+                <!-- Access roles (TK-135): per-panel feature flags -->
+                <section id="view-access" class="view">
+                    <div class="card">
+                        <div class="card-header">
+                            <h2>Access roles</h2>
+                            <button id="new-access-role-button" class="btn btn-primary" type="button">New role</button>
+                        </div>
+                        <p class="meta">Each access role grants a set of panels. A user sees the union of their roles' panels; a user with no roles sees all standard panels. Admins always see everything.</p>
+                        <div id="access-role-list" class="item-list"></div>
+                    </div>
+                    <div class="card">
+                        <div class="card-header"><h2 id="access-role-editor-title">Role editor</h2></div>
+                        <form id="access-role-form" class="form-stack">
+                            <div class="field"><label for="access-role-name">Name</label><input id="access-role-name" required></div>
+                            <div class="field"><label for="access-role-description">Description</label><textarea id="access-role-description"></textarea></div>
+                            <div class="field">
+                                <label>Panels this role grants</label>
+                                <div id="access-role-panels" class="item-list"></div>
+                            </div>
+                            <div class="form-actions">
+                                <button id="save-access-role-button" class="btn btn-primary" type="submit">Save</button>
+                                <button id="delete-access-role-button" class="btn btn-danger" type="button">Delete</button>
+                                <button id="reset-access-role-button" class="btn btn-ghost" type="button">Clear</button>
+                            </div>
+                        </form>
+                    </div>
+                    <div class="card">
+                        <div class="card-header"><h2>Assign roles to a user</h2></div>
+                        <form id="access-assign-form" class="form-stack">
+                            <div class="field"><label for="access-assign-user">User</label><select id="access-assign-user"></select></div>
+                            <div class="field"><label>Roles</label><div id="access-assign-roles" class="item-list"></div></div>
+                            <div class="form-actions"><button id="save-access-assign-button" class="btn btn-primary" type="submit">Save assignment</button></div>
+                        </form>
+                    </div>
+                </section>
+
                 <!-- Roles -->
                 <section id="view-roles" class="view split">
                     <div class="card">

--- a/web/default/site.css
+++ b/web/default/site.css
@@ -2057,3 +2057,8 @@ select {
 
 /* Board keyboard navigation focus ring (TK-128). */
 .ticket-card.kbd-focus { outline: 2px solid var(--accent, #ff7a1a); outline-offset: 1px; }
+
+/* Access-roles admin panel (TK-135). */
+#view-access .access-role-item { display: block; width: 100%; text-align: left; padding: 8px 10px; margin-bottom: 6px; background: var(--surface, #fff); border: 1px solid var(--border, #ddd); border-radius: 6px; cursor: pointer; }
+#view-access .access-role-item.active { border-color: var(--accent, #ff7a1a); }
+#view-access .access-check-row { display: flex; align-items: center; gap: 8px; padding: 3px 0; }

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -13,6 +13,8 @@
             passkeyStatus: "",
             passkeyStatusError: false,
             accountModalOpen: false,
+            panels: null,
+            accessRoles: [],
             currentView: "tickets",
             viewScrollByPanel: {},
             scrollPersistenceReady: false,
@@ -126,6 +128,7 @@
             { view: "settings", label: "Settings", section: "admin", adminOnly: true, icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M12 3v4\"></path><path d=\"M12 17v4\"></path><path d=\"M4.9 6.3l2.8 2\"></path><path d=\"M16.3 15.7l2.8 2\"></path><path d=\"M3 12h4\"></path><path d=\"M17 12h4\"></path><path d=\"M4.9 17.7l2.8-2\"></path><path d=\"M16.3 8.3l2.8-2\"></path><circle cx=\"12\" cy=\"12\" r=\"3.5\"></circle></svg>" },
             { view: "agents", label: "Agents", section: "admin", adminOnly: true, icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M12 3v4\"></path><path d=\"M8 8a4 4 0 1 1 8 0\"></path><path d=\"M7 13h10v7H7z\"></path></svg>" },
             { view: "users", label: "Users", section: "admin", adminOnly: true, icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2\"></path><circle cx=\"9\" cy=\"7\" r=\"4\"></circle><path d=\"M22 21v-2a4 4 0 0 0-3-3.87\"></path><path d=\"M16 3.13a4 4 0 0 1 0 7.75\"></path></svg>" },
+            { view: "access", label: "Access", section: "admin", adminOnly: true, icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><rect x=\"5\" y=\"11\" width=\"14\" height=\"9\" rx=\"2\"></rect><path d=\"M8 11V8a4 4 0 0 1 8 0v3\"></path></svg>" },
             { view: "admin-summary", label: "Summary", section: "admin", adminOnly: true, icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><rect x=\"3\" y=\"3\" width=\"7\" height=\"7\"/><rect x=\"14\" y=\"3\" width=\"7\" height=\"7\"/><rect x=\"3\" y=\"14\" width=\"7\" height=\"7\"/><rect x=\"14\" y=\"14\" width=\"7\" height=\"7\"/></svg>" },
         ];
         let navDragView = "";
@@ -598,14 +601,31 @@
             return Boolean(state.status && state.status.user && state.status.user.role === "admin");
         }
 
+        // canAccessPanel gates a nav view by the user's effective panel set
+        // (TK-135). Admins see everything. Before the panel set loads
+        // (state.panels === null) we stay optimistic so the nav doesn't flash
+        // empty. Admin-only items are gated by isAdmin() separately.
+        function canAccessPanel(view) {
+            if (isAdmin()) {
+                return true;
+            }
+            if (!Array.isArray(state.panels)) {
+                return true;
+            }
+            return state.panels.includes(view);
+        }
+        function navItemVisible(item) {
+            return item.adminOnly ? isAdmin() : canAccessPanel(item.view);
+        }
+
         function visibleNavItems() {
-            return NAV_ITEMS.filter((item) => !item.adminOnly || isAdmin());
+            return NAV_ITEMS.filter(navItemVisible);
         }
         function visibleGeneralNavItems() {
-            return NAV_ITEMS.filter((item) => item.section === "general" && (!item.adminOnly || isAdmin()));
+            return NAV_ITEMS.filter((item) => item.section === "general" && navItemVisible(item));
         }
         function visibleProcessNavItems() {
-            return NAV_ITEMS.filter((item) => item.section === "process" && (!item.adminOnly || isAdmin()));
+            return NAV_ITEMS.filter((item) => item.section === "process" && navItemVisible(item));
         }
         function visibleAdminNavItems() {
             return NAV_ITEMS.filter((item) => item.section === "admin" && isAdmin());
@@ -1635,6 +1655,9 @@
             if (viewName === "chat") {
                 refreshChatView();
             }
+            if (viewName === "access") {
+                refreshAccessView();
+            }
             if (viewName === "settings") {
                 let tab = "organisation";
                 try { tab = localStorage.getItem("site2.settingsTab") || "organisation"; } catch (e) { /* ignore */ }
@@ -1946,6 +1969,11 @@
         }
 
         async function loadDocuments() {
+            if (!canAccessPanel("documents")) {
+                state.documents = [];
+                state.selectedDocumentID = null;
+                return;
+            }
             if (!state.selectedProjectID) {
                 state.documents = [];
                 state.selectedDocumentID = null;
@@ -2103,9 +2131,20 @@
             }
         }
 
+        async function loadMyPanels() {
+            try {
+                const res = await api("/api/me/panels");
+                state.panels = Array.isArray(res && res.panels) ? res.panels : [];
+            } catch (error) {
+                // If the panel set can't be loaded, stay optimistic (null) so the
+                // nav isn't hidden; server-side enforcement still applies.
+                state.panels = null;
+            }
+        }
+
         async function refreshAll() {
             await loadStatus();
-            await Promise.all([loadSystemAgentModelConfig(), loadWorkflows(), loadRoles(), loadProjects(), loadAgents(), loadTeams(), loadPlans(), loadPasskeys(), fetchUsers(), loadOrg(), loadProgrammes()]);
+            await Promise.all([loadMyPanels(), loadSystemAgentModelConfig(), loadWorkflows(), loadRoles(), loadProjects(), loadAgents(), loadTeams(), loadPlans(), loadPasskeys(), fetchUsers(), loadOrg(), loadProgrammes()]);
             await loadConfigSettings();
             try {
                 await loadOrchestratorConfig();
@@ -2471,6 +2510,193 @@
                     event.preventDefault();
                 }
             });
+        }
+
+        // ── Access roles admin panel (TK-135) ────────────────────────────
+        let selectedAccessRoleID = 0;
+        let accessGrantablePanels = [];
+
+        function panelLabel(view) {
+            const item = NAV_ITEMS.find((n) => n.view === view);
+            return item ? item.label : view;
+        }
+
+        async function refreshAccessView() {
+            if (!isAdmin()) { return; }
+            try {
+                const [rolesRes, panelsRes] = await Promise.all([api("/api/access-roles"), api("/api/panels")]);
+                state.accessRoles = Array.isArray(rolesRes) ? rolesRes : [];
+                accessGrantablePanels = (panelsRes && Array.isArray(panelsRes.grantable)) ? panelsRes.grantable : [];
+            } catch (error) {
+                state.accessRoles = [];
+                accessGrantablePanels = [];
+            }
+            if (!state.users || !state.users.length) {
+                try { await fetchUsers(); } catch (e) { /* ignore */ }
+            }
+            renderAccessView();
+        }
+
+        function renderAccessView() {
+            renderAccessRoleList();
+            renderAccessPanelCheckboxes();
+            renderAccessAssignUserOptions();
+            renderAccessAssignRoles();
+        }
+
+        function renderAccessRoleList() {
+            const list = document.getElementById("access-role-list");
+            if (!list) { return; }
+            if (!state.accessRoles.length) {
+                list.innerHTML = "<div class=\"meta\">No access roles yet.</div>";
+                return;
+            }
+            list.innerHTML = state.accessRoles.map((role) => {
+                const panels = (role.panels || []).map(panelLabel).join(", ") || "no panels";
+                const builtin = role.builtin ? " <span class=\"chip\">builtin</span>" : "";
+                const active = role.id === selectedAccessRoleID ? " active" : "";
+                return "<button type=\"button\" class=\"access-role-item" + active + "\" data-access-role-id=\"" + role.id + "\">"
+                    + "<strong>" + escapeHTML(role.name) + "</strong>" + builtin
+                    + "<div class=\"meta\">" + escapeHTML(panels) + "</div></button>";
+            }).join("");
+            list.querySelectorAll("[data-access-role-id]").forEach((el) => {
+                el.addEventListener("click", () => selectAccessRole(Number(el.dataset.accessRoleId)));
+            });
+        }
+
+        function renderAccessPanelCheckboxes() {
+            const box = document.getElementById("access-role-panels");
+            if (!box) { return; }
+            const role = state.accessRoles.find((r) => r.id === selectedAccessRoleID);
+            // A brand-new role defaults to all panels checked.
+            const granted = new Set(role ? (role.panels || []) : accessGrantablePanels);
+            box.innerHTML = accessGrantablePanels.map((p) =>
+                "<label class=\"access-check-row\"><input type=\"checkbox\" data-access-panel=\"" + p + "\""
+                + (granted.has(p) ? " checked" : "") + "> " + escapeHTML(panelLabel(p)) + "</label>"
+            ).join("");
+        }
+
+        function selectAccessRole(id) {
+            selectedAccessRoleID = id;
+            const role = state.accessRoles.find((r) => r.id === id);
+            document.getElementById("access-role-name").value = role ? role.name : "";
+            document.getElementById("access-role-description").value = role ? (role.description || "") : "";
+            const title = document.getElementById("access-role-editor-title");
+            if (title) { title.textContent = role ? ("Edit: " + role.name) : "Role editor"; }
+            const del = document.getElementById("delete-access-role-button");
+            if (del) { del.style.display = (role && !role.builtin) ? "" : "none"; }
+            renderAccessRoleList();
+            renderAccessPanelCheckboxes();
+        }
+
+        function clearAccessRoleForm() {
+            selectedAccessRoleID = 0;
+            const nameEl = document.getElementById("access-role-name");
+            const descEl = document.getElementById("access-role-description");
+            if (nameEl) { nameEl.value = ""; }
+            if (descEl) { descEl.value = ""; }
+            const title = document.getElementById("access-role-editor-title");
+            if (title) { title.textContent = "New role"; }
+            renderAccessRoleList();
+            renderAccessPanelCheckboxes();
+        }
+
+        function selectedAccessPanelKeys() {
+            return Array.from(document.querySelectorAll("#access-role-panels [data-access-panel]:checked"))
+                .map((el) => el.dataset.accessPanel);
+        }
+
+        async function saveAccessRole(event) {
+            event.preventDefault();
+            const body = {
+                name: document.getElementById("access-role-name").value.trim(),
+                description: document.getElementById("access-role-description").value.trim(),
+                panels: selectedAccessPanelKeys(),
+            };
+            if (!body.name) { setNotice("Role name is required", true); return; }
+            try {
+                if (selectedAccessRoleID) {
+                    await api("/api/access-roles/" + selectedAccessRoleID, { method: "PUT", body: JSON.stringify(body) });
+                } else {
+                    await api("/api/access-roles", { method: "POST", body: JSON.stringify(body) });
+                }
+                setNotice("Access role saved");
+                clearAccessRoleForm();
+                await refreshAccessView();
+            } catch (error) {
+                setNotice(error.message || "Failed to save role", true);
+            }
+        }
+
+        async function deleteAccessRoleAction() {
+            if (!selectedAccessRoleID) { return; }
+            try {
+                await api("/api/access-roles/" + selectedAccessRoleID, { method: "DELETE" });
+                setNotice("Access role deleted");
+                clearAccessRoleForm();
+                await refreshAccessView();
+            } catch (error) {
+                setNotice(error.message || "Failed to delete role", true);
+            }
+        }
+
+        function renderAccessAssignUserOptions() {
+            const sel = document.getElementById("access-assign-user");
+            if (!sel) { return; }
+            const users = (state.users || []).filter((u) => (u.user_type || "user") !== "agent");
+            const current = sel.value;
+            sel.innerHTML = "<option value=\"\">Select a user…</option>" + users.map((u) =>
+                "<option value=\"" + escapeHTML(u.user_id || u.id) + "\">" + escapeHTML(u.username || u.user_id) + "</option>"
+            ).join("");
+            if (current) { sel.value = current; }
+        }
+
+        async function renderAccessAssignRoles() {
+            const box = document.getElementById("access-assign-roles");
+            const sel = document.getElementById("access-assign-user");
+            if (!box || !sel) { return; }
+            const userID = sel.value;
+            const assigned = new Set();
+            if (userID) {
+                try {
+                    const res = await api("/api/access-roles/memberships?user_id=" + encodeURIComponent(userID));
+                    (res && res.role_ids ? res.role_ids : []).forEach((id) => assigned.add(id));
+                } catch (e) { /* ignore */ }
+            }
+            box.innerHTML = state.accessRoles.map((role) =>
+                "<label class=\"access-check-row\"><input type=\"checkbox\" data-assign-role=\"" + role.id + "\""
+                + (assigned.has(role.id) ? " checked" : "") + "> " + escapeHTML(role.name) + "</label>"
+            ).join("") || "<div class=\"meta\">No roles to assign.</div>";
+        }
+
+        async function saveAccessAssignment(event) {
+            event.preventDefault();
+            const sel = document.getElementById("access-assign-user");
+            const userID = sel ? sel.value : "";
+            if (!userID) { setNotice("Select a user first", true); return; }
+            const roleIDs = Array.from(document.querySelectorAll("#access-assign-roles [data-assign-role]:checked"))
+                .map((el) => Number(el.dataset.assignRole));
+            try {
+                await api("/api/access-roles/memberships", { method: "PUT", body: JSON.stringify({ user_id: userID, role_ids: roleIDs }) });
+                setNotice("Roles assigned");
+            } catch (error) {
+                setNotice(error.message || "Failed to assign roles", true);
+            }
+        }
+
+        function setupAccessView() {
+            const form = document.getElementById("access-role-form");
+            if (form) { form.addEventListener("submit", saveAccessRole); }
+            const newBtn = document.getElementById("new-access-role-button");
+            if (newBtn) { newBtn.addEventListener("click", clearAccessRoleForm); }
+            const resetBtn = document.getElementById("reset-access-role-button");
+            if (resetBtn) { resetBtn.addEventListener("click", clearAccessRoleForm); }
+            const delBtn = document.getElementById("delete-access-role-button");
+            if (delBtn) { delBtn.addEventListener("click", deleteAccessRoleAction); }
+            const assignForm = document.getElementById("access-assign-form");
+            if (assignForm) { assignForm.addEventListener("submit", saveAccessAssignment); }
+            const userSel = document.getElementById("access-assign-user");
+            if (userSel) { userSel.addEventListener("change", renderAccessAssignRoles); }
         }
 
         function connectLiveUpdates() {
@@ -9423,6 +9649,7 @@
         setupCommandPalette();
         setupChat();
         setupBoardKeyboardNav();
+        setupAccessView();
         state.viewScrollByPanel = loadStoredViewScrollByPanel();
         state.currentView = loadStoredSelectedView() || state.currentView;
         switchView(state.currentView, { restoreScroll: false });


### PR DESCRIPTION
Introduces access roles: per-panel feature flags gating which UI panels a user can see/use, with an admin management UI.

**Store** (schema v14): access_roles / access_role_panels / user_access_roles; CRUD with admin-panel/unknown-panel validation; EffectivePanels (admin=all; union of assigned roles; default member set when ungated so upgrades never lock anyone out); idempotent builtin Member role.

**Server**: admin REST API (/api/access-roles[/{id}|/memberships], /api/panels) + GET /api/me/panels; panelAccessMiddleware server-enforces the self-contained panels (chat/rooms, documents) with admin bypass. Workflows/roles/teams carry board-shared data so they stay reachable (UI-gated only); foundational endpoints (projects/tickets) never gated.

**Web**: nav hides inaccessible panels (optimistic until /api/me/panels loads); admin Access panel to CRUD roles, toggle panels, and assign roles to users.

Decisions (confirmed): new dedicated access roles; server-enforced + UI hide; one PR. Default migration preserves todays access.

Tests: store + server (API + enforcement) Go suites; site2 nav test; verified end-to-end against a real server (admin nav, Member listed, role create persists, restricted user 403 on /api/documents). OpenAPI + USER_GUIDE updated.

refs TK-135