### PR TITLE
fix(rooms): resolve 3 pre-existing gosec findings (make lint green)

### DIFF
--- a/internal/server/api_rooms.go
+++ b/internal/server/api_rooms.go
@@ -278,7 +278,9 @@ func handleRoomMessages(w http.ResponseWriter, req *http.Request, db *sql.DB, us
 			hub.broadcastRoomMessage(roomID, msg)
 		}
 		// If an agent member was @mentioned, let it reply asynchronously (TK-131).
-		go replyAsAgents(context.Background(), db, room, msg, hub)
+		// Detach from the request's cancellation (the reply must outlive the HTTP
+		// response) while still propagating its context values.
+		go replyAsAgents(context.WithoutCancel(req.Context()), db, room, msg, hub)
 		writeJSON(w, http.StatusCreated, msg)
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")

--- a/internal/store/room.go
+++ b/internal/store/room.go
@@ -184,6 +184,7 @@ func ListRooms(ctx context.Context, db *sql.DB, filter RoomFilter) ([]Room, erro
 	} else {
 		clauses = append(clauses, "visibility = 'public'")
 	}
+	// #nosec G202 -- roomColumns is a fixed column list; clauses are constant predicate strings and all values are bound via ? placeholders.
 	query := `SELECT ` + roomColumns + ` FROM rooms WHERE ` + strings.Join(clauses, " AND ") + ` ORDER BY updated_at DESC, room_id DESC`
 	rows, err := db.QueryContext(ctx, query, args...)
 	if err != nil {
@@ -329,6 +330,7 @@ func ListRoomMessages(ctx context.Context, db *sql.DB, roomID int64, limit int, 
 	}
 	args = append(args, limit)
 	// Fetch newest-first with the limit, then reverse to chronological order.
+	// #nosec G202 -- the SELECT column list is static; `where` is built from constant predicates and all values are bound via ? placeholders.
 	rows, err := db.QueryContext(ctx, `SELECT m.message_id, m.room_id, m.sender_id, COALESCE(u.username, m.sender_id), m.kind, m.body, m.attrs, m.created_at FROM room_messages m LEFT JOIN users u ON u.user_id = m.sender_id WHERE `+strings.ReplaceAll(where, "room_id", "m.room_id")+` ORDER BY m.message_id DESC LIMIT ?`, args...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
make lint was red on 3 pre-existing gosec findings in the rooms code (not from the access-roles work):

- api_rooms.go G118: async agent-reply goroutine used context.Background -> now context.WithoutCancel(req.Context()) (detached from request cancellation but request-derived).
- room.go x2 G202: ListRooms / ListRoomMessages build dynamic SQL from a fixed column list + constant predicates with all values bound via placeholders -> annotated // #nosec G202 per the existing store convention.

make lint (golangci + gosec) now reports 0 issues; rooms tests green.