### PR TITLE
TK-4: canonical multiline format for the remaining long usage strings

### DIFF
--- a/cmd/tk/cmd_document.go
+++ b/cmd/tk/cmd_document.go
@@ -44,7 +44,8 @@ func runDocument(args []string) error {
 			return err
 		}
 		if strings.TrimSpace(*title) == "" {
-			return errors.New("usage: tk document create -title <title> [-d <description>] [-notes <notes>] [-content <text>]")
+			return errors.New("usage: tk document create -title <title>\n" +
+				"  [-d <description>] [-notes <notes>] [-content <text>]")
 		}
 		document, err := svc.CreateDocument(context.Background(), project.ID, libticket.DocumentRequest{
 			Title:       *title,
@@ -104,7 +105,8 @@ func runDocument(args []string) error {
 		return nil
 	case "update":
 		if len(args) < 2 {
-			return errors.New("usage: tk document update <id> [-title <title>] [-d <description>] [-notes <notes>] [-content <text>]")
+			return errors.New("usage: tk document update <id>\n" +
+				"  [-title <title>] [-d <description>] [-notes <notes>] [-content <text>]")
 		}
 		documentID, err := parseDocumentID(args[1])
 		if err != nil {

--- a/cmd/tk/cmd_project.go
+++ b/cmd/tk/cmd_project.go
@@ -49,7 +49,8 @@ func runProject(args []string) error {
 			joined := strings.TrimSpace(strings.Join(fs.Args(), " "))
 			if joined != "" {
 				if strings.TrimSpace(*message) != "" {
-					return errors.New("usage: tk project request-access [-project_id <id|title|prefix|alias>] [-message <text>] [message words]")
+					return errors.New("usage: tk project request-access [-project_id <id|title|prefix|alias>]\n" +
+						"  [-message <text>] [message words]")
 				}
 				*message = joined
 			}
@@ -75,7 +76,8 @@ func runProject(args []string) error {
 			return parseErr
 		}
 		if fs.NArg() != 0 {
-			return errors.New("usage: tk project access-requests [-project_id <id|title|prefix|alias>] [-status <pending|approved|rejected>]")
+			return errors.New("usage: tk project access-requests [-project_id <id|title|prefix|alias>]\n" +
+				"  [-status <pending|approved|rejected>]")
 		}
 		if strings.TrimSpace(*projectRef) == "" {
 			return errors.New("project_id is required (set an active project or pass -project_id)")
@@ -122,7 +124,8 @@ func runProject(args []string) error {
 			joined := strings.TrimSpace(strings.Join(fs.Args(), " "))
 			if joined != "" {
 				if strings.TrimSpace(*message) != "" {
-					return fmt.Errorf("usage: tk project %s [-project_id <id|title|prefix|alias>] -request_id <id> [-message <text>] [message words]", action)
+					return fmt.Errorf("usage: tk project %s [-project_id <id|title|prefix|alias>] -request_id <id>\n"+
+						"  [-message <text>] [message words]", action)
 				}
 				*message = joined
 			}

--- a/cmd/tk/cmd_pull_request.go
+++ b/cmd/tk/cmd_pull_request.go
@@ -98,7 +98,9 @@ func runPullRequestCreate(args []string) error {
 	}
 	ticketArg, rest, err := resolveIDFlag(*idFlag, positional)
 	if err != nil || len(rest) != 0 {
-		return errors.New("usage: tk pr create [-id] <ticket-id> [-repo R] [-from B] [-to B] [-title T] [-url U] [-provider none|github] [-m desc] [-gh]")
+		return errors.New("usage: tk pr create [-id] <ticket-id>\n" +
+			"  [-repo R] [-from B] [-to B] [-title T] [-url U]\n" +
+			"  [-provider none|github] [-m desc] [-gh]")
 	}
 
 	cfg, err := config.Load()

--- a/cmd/tk/cmd_sdlc.go
+++ b/cmd/tk/cmd_sdlc.go
@@ -373,7 +373,8 @@ func runWorkflow(args []string) error {
 			return err
 		}
 		if *workflowID == 0 || strings.TrimSpace(*title) == "" || fs.NArg() != 0 {
-			return errors.New("usage: tk workflow role-add -workflow_id <id> -title <title> [-description <text>] [-ac <text>]")
+			return errors.New("usage: tk workflow role-add -workflow_id <id> -title <title>\n" +
+				"  [-description <text>] [-ac <text>]")
 		}
 		role, err := svc.CreateRole(context.Background(), libticket.RoleRequest{
 			WorkflowID:         workflowID,

--- a/cmd/tk/cmd_team.go
+++ b/cmd/tk/cmd_team.go
@@ -131,7 +131,8 @@ func runTeam(args []string) error {
 			return err
 		}
 		if *teamID == 0 || *userID == "" || strings.TrimSpace(*role) == "" || fs.NArg() != 0 {
-			return errors.New("usage: tk team add-user -team_id <id> -user_id <id> -role <member|owner> [-job_title <title>]")
+			return errors.New("usage: tk team add-user -team_id <id> -user_id <id> -role <member|owner>\n" +
+				"  [-job_title <title>]")
 		}
 		member, err := svc.AddTeamMember(context.Background(), *teamID, libticket.TeamMemberRequest{
 			UserID:   *userID,

--- a/cmd/tk/cmd_work_item.go
+++ b/cmd/tk/cmd_work_item.go
@@ -15,7 +15,9 @@ import (
 
 func runWorkItem(args []string) error {
 	if len(args) == 0 || args[0] == "help" || args[0] == "-h" || args[0] == "--help" {
-		fmt.Println("usage: tk work-item <list|queue|start|create|reassign|cancel|retry|feedback|state-get|state-set> [flags]")
+		fmt.Println("usage: tk work-item <subcommand> [flags]\n" +
+			"  subcommands: list, queue, start, create, reassign,\n" +
+			"               cancel, retry, feedback, state-get, state-set")
 		return nil
 	}
 	cfg, err := config.Load()
@@ -69,7 +71,8 @@ func runWorkItem(args []string) error {
 		}
 		ticketID, rest, err := resolveIDFlag(*id, fs.Args())
 		if err != nil || len(rest) != 0 || strings.TrimSpace(ticketID) == "" || strings.TrimSpace(*workItemID) == "" {
-			return fmt.Errorf("usage: tk work-item %s [-id] <ticket-id> -work-item <work-item-id> [-assignee <username>] [-m message] [-commit_ref sha]", args[0])
+			return fmt.Errorf("usage: tk work-item %s [-id] <ticket-id> -work-item <work-item-id>\n"+
+				"  [-assignee <username>] [-m message] [-commit_ref sha]", args[0])
 		}
 		item, err := api.ActWorkItem(ctx, ticketID, strings.TrimSpace(*workItemID), args[0], client.WorkItemActionRequest{
 			Assignee:  strings.TrimSpace(*assignee),
@@ -114,7 +117,8 @@ func runWorkItem(args []string) error {
 		}
 		ticketID, rest, err := resolveIDFlag(*id, fs.Args())
 		if err != nil || len(rest) != 0 || strings.TrimSpace(ticketID) == "" || strings.TrimSpace(*stateValue) == "" {
-			return errors.New("usage: tk work-item state-set [-id] <ticket-id> -state <open|triaged|in_progress|resolved|wont_fix>")
+			return errors.New("usage: tk work-item state-set [-id] <ticket-id>\n" +
+				"  -state <open|triaged|in_progress|resolved|wont_fix>")
 		}
 		state, err := api.SetInterventionState(ctx, ticketID, strings.TrimSpace(*stateValue))
 		if err != nil {


### PR DESCRIPTION
Standardizes usage strings on the multiline canonical format (command + positional on line 1, grouped flags on indented continuation lines), matching the reference tk update / tk new.

Scope: the worst walls of text (tk new etc.) were already multilined. Of the ~172 usage strings, 165 are short single-line (already canonical) and were left as-is; the 11 remaining long ones (document create/update, project request-access/access-requests/approve-reject, pr create, team add-user, workflow role-add, work-item list/assign/state-set) are reformatted here.

cmd/tk suite + lint green.

refs TK-4