### PR TITLE
TK-129: tk invite — add a user to a project by email/username

### DIFF
--- a/cmd/tk/cmd_invite.go
+++ b/cmd/tk/cmd_invite.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/simonski/ticket/internal/config"
+	"github.com/simonski/ticket/libticket"
+)
+
+const inviteUsage = "usage: tk invite <email|username> -project <id|title|prefix|alias>\n" +
+	"  [-role <observer|commenter|member|admin>]"
+
+// runInvite adds a user — resolved by email or username — to a project in a
+// role, joining them to that project's set of users (TK-129). It is a friendly
+// front door over `tk project add-user`, which requires an exact user id.
+func runInvite(args []string) error {
+	if len(args) == 1 && (args[0] == "help" || args[0] == "-h" || args[0] == "--help") {
+		fmt.Println(inviteUsage)
+		return nil
+	}
+	fs := flag.NewFlagSet("invite", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	role := fs.String("role", "member", "project role [observer,commenter,member,admin]")
+
+	// The user identifier is positional and conventionally leads (tk invite
+	// <user> -project P). Go's flag parser stops at the first positional, so peel
+	// a leading non-flag arg off before parsing; otherwise fall back to a
+	// trailing positional. -project / -project_id are global flags, extracted
+	// before dispatch into the run's configured project reference.
+	positional := ""
+	flagArgs := args
+	leading := false
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		positional = args[0]
+		flagArgs = args[1:]
+		leading = true
+	}
+	if err := fs.Parse(flagArgs); err != nil {
+		return err
+	}
+	// Count positionals seen so exactly one (the user) is accepted.
+	extra := fs.NArg()
+	if !leading {
+		positional = fs.Arg(0)
+		extra = fs.NArg() - 1
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+
+	target := strings.TrimSpace(positional)
+	ref := strings.TrimSpace(resolveConfiguredProjectReference(cfg))
+	if target == "" || ref == "" || extra > 0 {
+		return errors.New(inviteUsage)
+	}
+	svc, err := resolveService(cfg)
+	if err != nil {
+		return err
+	}
+
+	project, err := svc.GetProject(context.Background(), ref)
+	if err != nil {
+		return err
+	}
+
+	users, err := svc.ListUsers(context.Background())
+	if err != nil {
+		return err
+	}
+	needle := strings.ToLower(target)
+	matchedID := ""
+	matchedName := ""
+	for _, u := range users {
+		if strings.ToLower(u.Username) == needle || (u.Email != "" && strings.ToLower(u.Email) == needle) {
+			matchedID = u.ID
+			matchedName = u.Username
+			break
+		}
+	}
+	if matchedID == "" {
+		return fmt.Errorf("no user found matching %q (by username or email)", target)
+	}
+
+	member, err := svc.AddProjectMember(context.Background(), project.ID, libticket.ProjectMemberRequest{
+		UserID: matchedID,
+		Role:   strings.TrimSpace(*role),
+	})
+	if err != nil {
+		return err
+	}
+	if outputJSON {
+		return printJSON(member)
+	}
+	fmt.Printf("invited %s to project %s as %s\n", matchedName, project.Prefix, member.Role)
+	return nil
+}

--- a/cmd/tk/help.go
+++ b/cmd/tk/help.go
@@ -69,6 +69,11 @@ var helpIndex = map[string]commandHelp{
 		details: []string{"Manages pull requests, which live inside ticket and are linked to a ticket and project (VCS-host-agnostic).", "`create` opens a PR, inferring the repository (from the project's repos or the cwd git origin), source branch (current git branch), target branch (main), and provider (github when the repo host is github.com, otherwise none). Add `-gh` to open a real GitHub PR via the gh CLI and store its url (github repos only).", "`ls [[-id] <ticket-id>] [-open|-closed|-all]` lists PRs (project-wide when no ticket); `get <pr-id>` shows one. `tk get <ticket>` also shows linked PRs.", "`merge`/`close`/`reopen <pr-id>` transition status. Non-GitHub repositories get a native PR record inside ticket."},
 		example: "tk pr create TK-42 -url https://github.com/acme/widget/pull/7",
 	},
+	"invite": {
+		usage:   "tk invite <email|username> -project <id|title|prefix|alias> [-role <observer|commenter|member|admin>]",
+		details: []string{"Adds a user — resolved by email or username — to a project, joining them to that project's set of users.", "The project comes from -project/-project_id (or the configured project); -role defaults to member.", "A friendly front door over `tk project add-user`, which requires an exact user id."},
+		example: "tk invite alice@example.com -project WEB -role member",
+	},
 	"login": {
 		usage:   "tk login [-username <name>] [-password <password> | -token <token> | --passkey] [-url <server-url>]",
 		details: []string{"Logs into the configured server and stores the session token in `~/.config/ticket/credentials.json`.", "Login resolution order: stored credentials, then username in credentials, then `-username` / `-password`, `-token`, or `--passkey`, then prompts.", "`--passkey` starts a browser-assisted passkey flow for the resolved username. Enroll a passkey first with `tk user passkey enroll`."},
@@ -517,6 +522,7 @@ func renderRootUsage() string {
 		{"project", "Manage projects (ls, new, get, use, rm, repo)"},
 		{"dep", "Manage dependency links (add, remove)"},
 		{"pr", "Manage pull requests (create, ls, get, merge, close)"},
+		{"invite", "Invite a user (by email/username) to a project in a role"},
 		{"label", "Manage labels (ls, new, rm, add, remove, show)"},
 		{"time", "Log and view time entries (log, ls, total, rm)"},
 		{"story", "Manage stories (ls, new, get, update, rm)"},

--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -263,6 +263,8 @@ func run(args []string) error {
 		return runComment(trimmedArgs[1:])
 	case "pr", "pull-request":
 		return runPullRequest(trimmedArgs[1:])
+	case "invite":
+		return runInvite(trimmedArgs[1:])
 	case "clone", "cp":
 		return runClone(trimmedArgs[1:])
 	case "merge":

--- a/cmd/tk/main_test.go
+++ b/cmd/tk/main_test.go
@@ -769,6 +769,74 @@ func TestRunAdminHelpUsesFormattedNamespaceUsage(t *testing.T) {
 	}
 }
 
+func TestRunInviteAddsUserToProject(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("TICKET_HOME", tempDir)
+
+	dbPath := filepath.Join(tempDir, "ticket.db")
+	testutil.CloneSeededDB(t, dbPath, "adminpass")
+	db, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	defer db.Close()
+
+	handler, err := server.Handler(db, "test", false, nil, "", "")
+	if err != nil {
+		t.Fatalf("server.Handler() error = %v", err)
+	}
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+	setTestLocation(t, ts.URL)
+
+	alice, err := store.CreateUser(context.Background(), db, "alice", "password123", "user")
+	if err != nil {
+		t.Fatalf("CreateUser(alice) error = %v", err)
+	}
+
+	captureStdout(t, func() {
+		if err := run([]string{"login", "-username", "admin", "-password", "adminpass"}); err != nil {
+			t.Fatalf("admin login error = %v", err)
+		}
+	})
+
+	projectIDText := strings.TrimSpace(captureStdout(t, func() {
+		if err := run([]string{"project", "create", "-prefix", "INV", "-title", "Invite Project", "-printid"}); err != nil {
+			t.Fatalf("project create error = %v", err)
+		}
+	}))
+	projectID, err := strconv.ParseInt(projectIDText, 10, 64)
+	if err != nil {
+		t.Fatalf("ParseInt(project id) error = %v", err)
+	}
+
+	// Invite by username adds the user to the project in the given role.
+	out := captureStdout(t, func() {
+		if err := run([]string{"invite", "alice", "-project", "INV", "-role", "member"}); err != nil {
+			t.Fatalf("invite error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "invited alice") {
+		t.Fatalf("invite output = %q, want it to confirm alice", out)
+	}
+	member, err := store.GetProjectMember(context.Background(), db, projectID, alice.ID)
+	if err != nil {
+		t.Fatalf("GetProjectMember() error = %v (alice was not added)", err)
+	}
+	if member.Role != "member" {
+		t.Fatalf("alice role = %q, want member", member.Role)
+	}
+
+	// Inviting an unknown user fails clearly.
+	if err := run([]string{"invite", "nobody-here", "-project", "INV"}); err == nil {
+		t.Fatal("invite of unknown user should fail")
+	}
+	// Missing project ref shows usage (error).
+	if err := run([]string{"invite", "alice"}); err == nil {
+		t.Fatal("invite without -project should fail")
+	}
+}
+
 func TestRunProjectRequestAccessRemote(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("TICKET_HOME", tempDir)


### PR DESCRIPTION
New top-level tk invite <email|username> -project P -role R: resolves the user by email or username and adds them to the project in a role (default member) — joining the projects set of users. Friendly front door over tk project add-user (which needs an exact user id). Project comes from the global -project override; reuses ListUsers + AddProjectMember so it works local + remote.

Dispatch + root help + help entry; integration test (add-by-username, unknown-user fails, missing-project usage). cmd/tk suite + lint green.

refs TK-129