### PR TITLE
TK-136: chat auto-selects a room + focuses the composer on open

### DIFF
--- a/tests/playwright/site2.spec.js
+++ b/tests/playwright/site2.spec.js
@@ -2187,3 +2187,11 @@ test("account menu is a single 'Account settings' entry (TK-50)", async ({ page 
 test("admin sees the Access (access-roles) nav entry (TK-135)", async ({ page }) => {
   await expect(page.locator('#admin-nav button[data-view="access"]')).toBeVisible();
 });
+
+test("chat: opening the panel auto-selects a room and focuses the composer", async ({ page }) => {
+  await page.locator('#main-nav button[data-view="chat"]').click();
+  // A room is selected automatically — the user can chat without clicking one.
+  await expect(page.locator("#chat-room-title")).toHaveText("General");
+  await expect(page.locator("#chat-composer-input")).toBeEnabled();
+  await expect(page.locator("#chat-composer-input")).toBeFocused();
+});

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -2258,10 +2258,21 @@
         function refreshChatView() {
             loadRooms().then(() => ensureDefaultRooms()).then(() => {
                 renderRoomsList();
-                if (state.activeRoomID && state.rooms.some((r) => r.room_id === state.activeRoomID)) {
-                    selectRoom(state.activeRoomID);
+                // Always land the user in a room so they can start chatting. Keep
+                // the current room if it's still present; otherwise pick a sensible
+                // default (the public global room, else the first available).
+                const roomID = (state.activeRoomID && state.rooms.some((r) => r.room_id === state.activeRoomID))
+                    ? state.activeRoomID
+                    : pickDefaultRoomID();
+                if (roomID) {
+                    selectRoom(roomID);
                 }
             });
+        }
+        function pickDefaultRoomID() {
+            if (!state.rooms.length) { return 0; }
+            const general = state.rooms.find((r) => roomScope(r) === "global" && r.visibility === "public");
+            return (general || state.rooms[0]).room_id;
         }
         // Automatically create a public global room and a project room the first
         // time chat is opened without them.
@@ -2314,7 +2325,11 @@
             renderRoomsList();
             const input = document.getElementById("chat-composer-input");
             const sendBtn = document.getElementById("chat-send-button");
-            if (input) { input.disabled = false; }
+            if (input) {
+                input.disabled = false;
+                // Focus the composer so the user can type immediately on entering a room.
+                input.focus();
+            }
             if (sendBtn) { sendBtn.disabled = false; }
             const joinBtn = document.getElementById("chat-join-button");
             const leaveBtn = document.getElementById("chat-leave-button");


### PR DESCRIPTION
Opening the chat panel sometimes left no room selected, so the composer was disabled and you could not start chatting. refreshChatView now keeps the current room if still present, else picks a default (public global room, else first available); selectRoom focuses the composer input. site2 regression test added.

refs TK-136