### PR TITLE
TK-137: chat — one unified full-height panel

### DIFF
--- a/web/default/index.html
+++ b/web/default/index.html
@@ -515,33 +515,35 @@
                 </section>
 
                 <!-- Chat / multiplayer rooms -->
-                <section id="view-chat" class="view split">
-                    <div class="card">
-                        <div class="card-header">
-                            <div>
-                                <h2>Rooms</h2>
-                                <p class="meta">Chat with your team and agents.</p>
+                <section id="view-chat" class="view">
+                    <div class="chat-shell">
+                        <div class="chat-pane chat-sidebar">
+                            <div class="card-header">
+                                <div>
+                                    <h2>Rooms</h2>
+                                    <p class="meta">Chat with your team and agents.</p>
+                                </div>
+                                <button id="new-room-button" class="btn btn-primary" type="button">New room</button>
                             </div>
-                            <button id="new-room-button" class="btn btn-primary" type="button">New room</button>
+                            <div id="chat-rooms-list" class="item-list"></div>
                         </div>
-                        <div id="chat-rooms-list" class="item-list"></div>
-                    </div>
-                    <div class="card" id="chat-room-view">
-                        <div class="card-header">
-                            <div>
-                                <h2 id="chat-room-title">Select a room</h2>
-                                <p class="meta" id="chat-room-topic"></p>
+                        <div class="chat-pane chat-main" id="chat-room-view">
+                            <div class="card-header">
+                                <div>
+                                    <h2 id="chat-room-title">Select a room</h2>
+                                    <p class="meta" id="chat-room-topic"></p>
+                                </div>
+                                <div class="view-actions">
+                                    <button id="chat-join-button" class="btn" type="button" hidden>Join</button>
+                                    <button id="chat-leave-button" class="btn btn-ghost" type="button" hidden>Leave</button>
+                                </div>
                             </div>
-                            <div class="view-actions">
-                                <button id="chat-join-button" class="btn" type="button" hidden>Join</button>
-                                <button id="chat-leave-button" class="btn btn-ghost" type="button" hidden>Leave</button>
-                            </div>
+                            <div id="chat-messages" class="chat-messages"></div>
+                            <form id="chat-composer" class="chat-composer">
+                                <input id="chat-composer-input" type="text" autocomplete="off" placeholder="Message — @name, #label, or /task /new /invite /kick /join /leave /list /msg" disabled>
+                                <button id="chat-send-button" class="btn btn-primary" type="submit" disabled>Send</button>
+                            </form>
                         </div>
-                        <div id="chat-messages" class="chat-messages"></div>
-                        <form id="chat-composer" class="chat-composer">
-                            <input id="chat-composer-input" type="text" autocomplete="off" placeholder="Message — @name, #label, or /task /new /invite /kick /join /leave /list /msg" disabled>
-                            <button id="chat-send-button" class="btn btn-primary" type="submit" disabled>Send</button>
-                        </form>
                     </div>
                 </section>
 

--- a/web/default/site.css
+++ b/web/default/site.css
@@ -2040,13 +2040,35 @@ select {
 #view-chat .chat-room-item { display: block; width: 100%; text-align: left; padding: 7px 12px; border: none; background: transparent; color: inherit; cursor: pointer; border-radius: 6px; }
 #view-chat .chat-room-item:hover { background: var(--accent-soft, rgba(255,122,26,.12)); }
 #view-chat .chat-room-item.active { background: var(--accent-soft, rgba(255,122,26,.2)); font-weight: 600; }
-#chat-room-view { display: flex; flex-direction: column; }
-.chat-messages { flex: 1; min-height: 220px; max-height: 52vh; overflow-y: auto; padding: 10px 4px; display: flex; flex-direction: column; gap: 6px; }
+/* Unified full-height chat shell: rooms sidebar + message pane as one panel. */
+#view-chat { padding: 16px; }
+.chat-shell {
+    flex: 1; display: flex; min-height: 0;
+    border: 1px solid var(--border, #333); border-radius: 10px; overflow: hidden;
+    background: var(--surface, #fff);
+}
+.dark .chat-shell { background: hsl(22 10% 14%); }
+.chat-pane { display: flex; flex-direction: column; min-height: 0; }
+.chat-sidebar {
+    width: 280px; flex-shrink: 0;
+    border-right: 1px solid var(--border, #333);
+    background: hsl(38 24% 96%);
+}
+.dark .chat-sidebar { background: hsl(22 10% 18%); }
+.chat-sidebar .card-header { padding: 12px 14px; }
+#chat-rooms-list { flex: 1; overflow-y: auto; padding: 4px 6px; }
+.chat-main { flex: 1; min-width: 0; }
+.chat-main .card-header { padding: 12px 16px; border-bottom: 1px solid var(--border, #333); }
+.chat-messages { flex: 1; min-height: 0; overflow-y: auto; padding: 12px 16px; display: flex; flex-direction: column; gap: 6px; }
+@media (max-width: 760px) {
+    .chat-shell { flex-direction: column; }
+    .chat-sidebar { width: 100%; border-right: none; border-bottom: 1px solid var(--border, #333); max-height: 30vh; }
+}
 .chat-msg { padding: 5px 8px; border-radius: 6px; }
 .chat-msg-sender { font-weight: 600; margin-right: 6px; opacity: .85; }
 .chat-msg-system, .chat-msg-agent_event { opacity: .7; font-style: italic; }
 .chat-msg-task { background: var(--accent-soft, rgba(255,122,26,.12)); }
-.chat-composer { display: flex; gap: 8px; padding: 8px 4px; border-top: 1px solid var(--border, #333); }
+.chat-composer { display: flex; gap: 8px; padding: 12px 16px; border-top: 1px solid var(--border, #333); }
 .chat-composer-input, #chat-composer-input { flex: 1; padding: 9px 12px; border-radius: 7px; border: 1px solid var(--border, #444); background: transparent; color: inherit; }
 .chat-member { padding: 4px 8px; }
 .chat-mention { color: var(--accent, #ff7a1a); font-weight: 600; }


### PR DESCRIPTION
Merged the rooms list and message pane into a single full-height chat shell (was two cards with a gap + a 52vh message cap). Sidebar left, messages fill height and scroll, composer pinned bottom. IDs preserved; chat tests green; headless-verified full height. refs TK-137