### PR TITLE
TK-132: SMTP email-sender config (CRUD + CLI + API + Settings panel)

### DIFF
--- a/cmd/tk/cmd_email.go
+++ b/cmd/tk/cmd_email.go
@@ -1,0 +1,156 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/simonski/ticket/internal/config"
+	"github.com/simonski/ticket/internal/store"
+	"github.com/simonski/ticket/libticket"
+)
+
+const emailUsage = "usage: tk email <show|set|enable|disable>\n" +
+	"  set [-host H] [-port N] [-username U] [-password P] [-from ADDR] [-from-name NAME] [-security none|starttls|tls]"
+
+// runEmail manages the SMTP email-sender configuration (TK-132). It configures
+// and enables/disables the sender; actually sending mail is separate (TK-138).
+func runEmail(args []string) error {
+	sub := "show"
+	if len(args) > 0 {
+		sub = args[0]
+	}
+	if sub == "help" || sub == "-h" || sub == "--help" {
+		fmt.Println(emailUsage)
+		return nil
+	}
+	cfg, err := config.Load()
+	if err != nil {
+		return err
+	}
+	svc, err := resolveService(cfg)
+	if err != nil {
+		return err
+	}
+	ctx := context.Background()
+	switch sub {
+	case "show", "get", "status":
+		ec, gerr := svc.GetEmailConfig(ctx)
+		if gerr != nil {
+			return gerr
+		}
+		return printEmailConfig(ec)
+	case "enable":
+		if eerr := svc.SetEmailEnabled(ctx, true); eerr != nil {
+			return eerr
+		}
+		fmt.Println("email sending enabled")
+		return nil
+	case "disable":
+		if eerr := svc.SetEmailEnabled(ctx, false); eerr != nil {
+			return eerr
+		}
+		fmt.Println("email sending disabled")
+		return nil
+	case "set", "config":
+		return runEmailSet(svc, args[1:])
+	default:
+		return errors.New(emailUsage)
+	}
+}
+
+func runEmailSet(svc libticket.Service, args []string) error {
+	fs := flag.NewFlagSet("email set", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	host := fs.String("host", "", "SMTP host")
+	port := fs.Int("port", 0, "SMTP port")
+	username := fs.String("username", "", "SMTP username")
+	password := fs.String("password", "", "SMTP password")
+	from := fs.String("from", "", "from address")
+	fromName := fs.String("from-name", "", "from display name")
+	security := fs.String("security", "", "none|starttls|tls")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	ctx := context.Background()
+	cur, err := svc.GetEmailConfig(ctx)
+	if err != nil {
+		return err
+	}
+	// A masked sentinel password must never be written back.
+	if cur.Password == "********" {
+		cur.Password = ""
+	}
+	updatePassword := false
+	fs.Visit(func(f *flag.Flag) {
+		switch f.Name {
+		case "host":
+			cur.Host = *host
+		case "port":
+			cur.Port = *port
+		case "username":
+			cur.Username = *username
+		case "password":
+			cur.Password = *password
+			updatePassword = true
+		case "from":
+			cur.FromAddress = *from
+		case "from-name":
+			cur.FromName = *fromName
+		case "security":
+			cur.Security = *security
+		}
+	})
+	if serr := svc.SetEmailConfig(ctx, cur, updatePassword); serr != nil {
+		return serr
+	}
+	saved, err := svc.GetEmailConfig(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Println("email configuration saved")
+	return printEmailConfig(saved)
+}
+
+func printEmailConfig(ec store.EmailConfig) error {
+	passwordState := "not set"
+	if strings.TrimSpace(ec.Password) != "" {
+		passwordState = "set"
+	}
+	if outputJSON {
+		return printJSON(map[string]any{
+			"enabled":      ec.Enabled,
+			"host":         ec.Host,
+			"port":         ec.Port,
+			"username":     ec.Username,
+			"from_address": ec.FromAddress,
+			"from_name":    ec.FromName,
+			"security":     ec.Security,
+			"has_password": strings.TrimSpace(ec.Password) != "",
+		})
+	}
+	enabled := "disabled"
+	if ec.Enabled {
+		enabled = "enabled"
+	}
+	fmt.Printf("email sending : %s\n", enabled)
+	fmt.Printf("smtp host     : %s\n", emptyDash(ec.Host))
+	fmt.Printf("smtp port     : %d\n", ec.Port)
+	fmt.Printf("username      : %s\n", emptyDash(ec.Username))
+	fmt.Printf("password      : %s\n", passwordState)
+	fmt.Printf("from address  : %s\n", emptyDash(ec.FromAddress))
+	fmt.Printf("from name     : %s\n", emptyDash(ec.FromName))
+	fmt.Printf("security      : %s\n", ec.Security)
+	return nil
+}
+
+func emptyDash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}

--- a/cmd/tk/help.go
+++ b/cmd/tk/help.go
@@ -74,6 +74,11 @@ var helpIndex = map[string]commandHelp{
 		details: []string{"Adds a user — resolved by email or username — to a project, joining them to that project's set of users.", "The project comes from -project/-project_id (or the configured project); -role defaults to member.", "A friendly front door over `tk project add-user`, which requires an exact user id."},
 		example: "tk invite alice@example.com -project WEB -role member",
 	},
+	"email": {
+		usage:   "tk email <show|set|enable|disable>",
+		details: []string{"Configures the SMTP email sender (admin). `set` updates host/port/username/password/from/from-name/security; `show` displays the config with the password masked; `enable`/`disable` toggle whether email is sent.", "A `set` without -password keeps the stored password. Actually sending mail is a separate capability."},
+		example: "tk email set -host smtp.example.com -port 587 -username mailer -password secret -from noreply@acme.com",
+	},
 	"login": {
 		usage:   "tk login [-username <name>] [-password <password> | -token <token> | --passkey] [-url <server-url>]",
 		details: []string{"Logs into the configured server and stores the session token in `~/.config/ticket/credentials.json`.", "Login resolution order: stored credentials, then username in credentials, then `-username` / `-password`, `-token`, or `--passkey`, then prompts.", "`--passkey` starts a browser-assisted passkey flow for the resolved username. Enroll a passkey first with `tk user passkey enroll`."},

--- a/cmd/tk/main.go
+++ b/cmd/tk/main.go
@@ -265,6 +265,8 @@ func run(args []string) error {
 		return runPullRequest(trimmedArgs[1:])
 	case "invite":
 		return runInvite(trimmedArgs[1:])
+	case "email":
+		return runEmail(trimmedArgs[1:])
 	case "clone", "cp":
 		return runClone(trimmedArgs[1:])
 	case "merge":

--- a/cmd/tk/main_test.go
+++ b/cmd/tk/main_test.go
@@ -837,6 +837,45 @@ func TestRunInviteAddsUserToProject(t *testing.T) {
 	}
 }
 
+func TestRunEmailConfig(t *testing.T) {
+	setupLocalCLI(t)
+
+	if err := run([]string{"email", "set", "-host", "smtp.example.com", "-port", "465", "-username", "mailer", "-password", "secret", "-from", "noreply@example.com", "-security", "tls"}); err != nil {
+		t.Fatalf("email set error = %v", err)
+	}
+	out := captureStdout(t, func() {
+		if err := run([]string{"email", "show"}); err != nil {
+			t.Fatalf("email show error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "smtp.example.com") || !strings.Contains(out, "password      : set") {
+		t.Fatalf("email show missing config:\n%s", out)
+	}
+	if strings.Contains(out, "secret") {
+		t.Fatalf("password value must never be printed:\n%s", out)
+	}
+
+	if err := run([]string{"email", "enable"}); err != nil {
+		t.Fatalf("email enable error = %v", err)
+	}
+	// Partial update keeps the stored password and toggles state.
+	if err := run([]string{"email", "set", "-port", "587"}); err != nil {
+		t.Fatalf("email set port error = %v", err)
+	}
+	out = captureStdout(t, func() { _ = run([]string{"email", "show"}) })
+	if !strings.Contains(out, "email sending : enabled") || !strings.Contains(out, "smtp port     : 587") || !strings.Contains(out, "password      : set") {
+		t.Fatalf("email state after partial update wrong:\n%s", out)
+	}
+
+	if err := run([]string{"email", "disable"}); err != nil {
+		t.Fatalf("email disable error = %v", err)
+	}
+	out = captureStdout(t, func() { _ = run([]string{"email", "show"}) })
+	if !strings.Contains(out, "email sending : disabled") {
+		t.Fatalf("email should be disabled:\n%s", out)
+	}
+}
+
 func TestRunProjectRequestAccessRemote(t *testing.T) {
 	tempDir := t.TempDir()
 	t.Setenv("TICKET_HOME", tempDir)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -87,6 +87,19 @@ Agents are first-class room members. There are two ways to involve them:
   /task investigate the flaky deploy
   ```
 
+## Email / SMTP (admin)
+
+Configure the outbound email sender under **Settings → Email** (or via the CLI):
+
+- Set the SMTP **host, port, security** (none/STARTTLS/TLS), **username/password**,
+  and **from address/name**, then toggle **Enable email sending**.
+- The password is **never shown back** — the form/`tk email show` only indicate
+  whether one is stored; saving without re-entering it keeps the stored secret.
+- CLI: `tk email show`, `tk email set -host … -port … -password …`,
+  `tk email enable`, `tk email disable`.
+- This only *configures* the sender; actually sending mail is a separate
+  capability.
+
 ## Access roles (admin)
 
 Admins can gate which panels each user sees from the **Access** panel (admin

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -78,6 +78,29 @@ components:
         description: { type: string }
         builtin: { type: boolean }
         panels: { type: array, items: { type: string } }
+    EmailConfig:
+      type: object
+      description: SMTP sender config. The password is never returned; has_password indicates whether one is stored.
+      properties:
+        enabled: { type: boolean }
+        host: { type: string }
+        port: { type: integer }
+        username: { type: string }
+        from_address: { type: string }
+        from_name: { type: string }
+        security: { type: string, enum: [none, starttls, tls] }
+        has_password: { type: boolean }
+    EmailConfigInput:
+      type: object
+      properties:
+        enabled: { type: boolean }
+        host: { type: string }
+        port: { type: integer }
+        username: { type: string }
+        password: { type: string, description: "Omit or leave empty to keep the stored password." }
+        from_address: { type: string }
+        from_name: { type: string }
+        security: { type: string, enum: [none, starttls, tls] }
     AccessRoleInput:
       type: object
       required: [name]
@@ -1744,6 +1767,48 @@ paths:
       operationId: deleteAccessRole
       responses:
         '200': { description: Deleted }
+
+  # ── Email (SMTP) settings ────────────────────────────────────────────
+  /api/email/settings:
+    get:
+      tags: [Email]
+      summary: Get the SMTP email-sender config (admin); password is masked
+      operationId: getEmailSettings
+      responses:
+        '200':
+          description: Email config (password never returned; has_password only)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/EmailConfig' }
+    put:
+      tags: [Email]
+      summary: Update the SMTP email-sender config (admin)
+      operationId: updateEmailSettings
+      requestBody:
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/EmailConfigInput' }
+      responses:
+        '200':
+          description: Saved config (masked)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/EmailConfig' }
+  /api/email/enabled:
+    put:
+      tags: [Email]
+      summary: Enable or disable email sending (admin)
+      operationId: setEmailEnabled
+      requestBody:
+        content:
+          application/json:
+            schema: { type: object, properties: { enabled: { type: boolean } } }
+      responses:
+        '200':
+          description: Saved config (masked)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/EmailConfig' }
 
   # ── Chat rooms ───────────────────────────────────────────────────────
   /api/rooms:

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -239,6 +239,67 @@ func (c *Client) SetRegistrationAutoApprove(ctx context.Context, enabled bool) e
 	}, nil)
 }
 
+func (c *Client) GetEmailConfig(ctx context.Context) (store.EmailConfig, error) {
+	if c.mode == config.ModeLocal {
+		db, err := c.openLocalDB()
+		if err != nil {
+			return store.EmailConfig{}, err
+		}
+		return store.GetEmailConfig(ctx, db)
+	}
+	// The server masks the password (returns only has_password). Surface a
+	// non-empty sentinel so callers can tell a password is configured without
+	// ever receiving the secret; it is display-only and never sent back.
+	var resp struct {
+		store.EmailConfig
+		HasPassword bool `json:"has_password"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, "/api/email/settings", nil, &resp); err != nil {
+		return store.EmailConfig{}, err
+	}
+	cfg := resp.EmailConfig
+	if resp.HasPassword {
+		cfg.Password = "********"
+	}
+	return cfg, nil
+}
+
+func (c *Client) SetEmailConfig(ctx context.Context, cfg store.EmailConfig, updatePassword bool) error {
+	if c.mode == config.ModeLocal {
+		db, err := c.openLocalDB()
+		if err != nil {
+			return err
+		}
+		return store.SetEmailConfig(ctx, db, cfg, updatePassword)
+	}
+	body := map[string]any{
+		"enabled":      cfg.Enabled,
+		"host":         cfg.Host,
+		"port":         cfg.Port,
+		"username":     cfg.Username,
+		"from_address": cfg.FromAddress,
+		"from_name":    cfg.FromName,
+		"security":     cfg.Security,
+	}
+	// Only send the password when it should change; an empty password preserves
+	// the stored secret server-side.
+	if updatePassword {
+		body["password"] = cfg.Password
+	}
+	return c.doJSON(ctx, http.MethodPut, "/api/email/settings", body, nil)
+}
+
+func (c *Client) SetEmailEnabled(ctx context.Context, enabled bool) error {
+	if c.mode == config.ModeLocal {
+		db, err := c.openLocalDB()
+		if err != nil {
+			return err
+		}
+		return store.SetEmailEnabled(ctx, db, enabled)
+	}
+	return c.doJSON(ctx, http.MethodPut, "/api/email/enabled", map[string]any{"enabled": enabled}, nil)
+}
+
 func (c *Client) ListPlans(ctx context.Context) ([]store.Plan, error) {
 	if c.mode == config.ModeLocal {
 		db, err := c.openLocalDB()

--- a/internal/server/api.go
+++ b/internal/server/api.go
@@ -74,6 +74,7 @@ func registerAPI(mux *http.ServeMux, db *sql.DB, version string, live *liveHub, 
 	r.registerDocumentHandlers()
 	r.registerRoomHandlers()
 	r.registerAccessRoleHandlers()
+	r.registerEmailHandlers()
 	r.registerTicketHandlers()
 	r.registerReleaseHandlers()
 	r.registerOrgHandlers()

--- a/internal/server/api_email.go
+++ b/internal/server/api_email.go
@@ -1,0 +1,105 @@
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/simonski/ticket/internal/store"
+)
+
+// registerEmailHandlers wires the SMTP email-sender configuration API (TK-132).
+// All endpoints are admin-only. The password is never returned to clients —
+// only a has_password flag — and a save that omits the password preserves the
+// stored secret.
+func (r *router) registerEmailHandlers() {
+	db := r.db
+	mux := r.mux
+
+	mux.HandleFunc("/api/email/settings", func(w http.ResponseWriter, req *http.Request) {
+		if _, err := requireAdmin(db, req); err != nil {
+			writeAuthError(w, err)
+			return
+		}
+		switch req.Method {
+		case http.MethodGet:
+			cfg, gerr := store.GetEmailConfig(req.Context(), db)
+			if gerr != nil {
+				writeStoreError(w, gerr)
+				return
+			}
+			writeJSON(w, http.StatusOK, emailConfigPayload(cfg))
+		case http.MethodPut:
+			var body struct {
+				Enabled     bool   `json:"enabled"`
+				Host        string `json:"host"`
+				Port        int    `json:"port"`
+				Username    string `json:"username"`
+				Password    string `json:"password"`
+				FromAddress string `json:"from_address"`
+				FromName    string `json:"from_name"`
+				Security    string `json:"security"`
+			}
+			if derr := decodeJSONBody(req, &body); derr != nil {
+				writeError(w, http.StatusBadRequest, "invalid request body")
+				return
+			}
+			cfg := store.EmailConfig{
+				Enabled:     body.Enabled,
+				Host:        body.Host,
+				Port:        body.Port,
+				Username:    body.Username,
+				Password:    body.Password,
+				FromAddress: body.FromAddress,
+				FromName:    body.FromName,
+				Security:    body.Security,
+			}
+			updatePassword := strings.TrimSpace(body.Password) != ""
+			if serr := store.SetEmailConfig(req.Context(), db, cfg, updatePassword); serr != nil {
+				writeStoreError(w, serr)
+				return
+			}
+			saved, _ := store.GetEmailConfig(req.Context(), db)
+			writeJSON(w, http.StatusOK, emailConfigPayload(saved))
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+	})
+
+	mux.HandleFunc("/api/email/enabled", func(w http.ResponseWriter, req *http.Request) {
+		if _, err := requireAdmin(db, req); err != nil {
+			writeAuthError(w, err)
+			return
+		}
+		if req.Method != http.MethodPut {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		var body struct {
+			Enabled bool `json:"enabled"`
+		}
+		if derr := decodeJSONBody(req, &body); derr != nil {
+			writeError(w, http.StatusBadRequest, "invalid request body")
+			return
+		}
+		if serr := store.SetEmailEnabled(req.Context(), db, body.Enabled); serr != nil {
+			writeStoreError(w, serr)
+			return
+		}
+		saved, _ := store.GetEmailConfig(req.Context(), db)
+		writeJSON(w, http.StatusOK, emailConfigPayload(saved))
+	})
+}
+
+// emailConfigPayload renders the config for clients with the password masked.
+func emailConfigPayload(cfg store.EmailConfig) map[string]any {
+	return map[string]any{
+		"enabled":      cfg.Enabled,
+		"host":         cfg.Host,
+		"port":         cfg.Port,
+		"username":     cfg.Username,
+		"from_address": cfg.FromAddress,
+		"from_name":    cfg.FromName,
+		"security":     cfg.Security,
+		"has_password": cfg.HasPassword(),
+	}
+}

--- a/internal/server/api_email_test.go
+++ b/internal/server/api_email_test.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/simonski/ticket/internal/store"
+)
+
+func TestEmailSettingsAPI(t *testing.T) {
+	handler, db := testHandler(t)
+	defer db.Close()
+
+	if _, err := store.CreateUser(context.Background(), db, "bob", "password123", "user"); err != nil {
+		t.Fatalf("create bob: %v", err)
+	}
+	adminToken := loginToken(t, handler, "admin", "password")
+	bobToken := loginToken(t, handler, "bob", "password123")
+
+	// Non-admin is denied.
+	if resp := doJSONRequest(t, handler, http.MethodGet, "/api/email/settings", nil, bobToken); resp.Code != http.StatusForbidden {
+		t.Fatalf("bob GET email settings = %d, want 403", resp.Code)
+	}
+
+	// Admin sees defaults; no password configured.
+	getResp := doJSONRequest(t, handler, http.MethodGet, "/api/email/settings", nil, adminToken)
+	if getResp.Code != http.StatusOK {
+		t.Fatalf("admin GET = %d", getResp.Code)
+	}
+	var cfg map[string]any
+	decodeResponse(t, getResp, &cfg)
+	if cfg["has_password"] != false || cfg["enabled"] != false {
+		t.Fatalf("unexpected defaults: %+v", cfg)
+	}
+
+	// Save a full config.
+	putResp := doJSONRequest(t, handler, http.MethodPut, "/api/email/settings", map[string]any{
+		"enabled": true, "host": "smtp.example.com", "port": 465, "username": "mailer",
+		"password": "secret", "from_address": "noreply@example.com", "security": "tls",
+	}, adminToken)
+	if putResp.Code != http.StatusOK {
+		t.Fatalf("PUT settings = %d, body = %s", putResp.Code, putResp.Body.String())
+	}
+	decodeResponse(t, putResp, &cfg)
+	if cfg["has_password"] != true {
+		t.Fatalf("has_password should be true after save: %+v", cfg)
+	}
+	if _, leaked := cfg["password"]; leaked {
+		t.Fatalf("password must never be returned to clients: %+v", cfg)
+	}
+
+	// Saving again without a password preserves the stored secret.
+	if resp := doJSONRequest(t, handler, http.MethodPut, "/api/email/settings", map[string]any{
+		"enabled": true, "host": "smtp.example.com", "port": 587, "username": "mailer",
+		"from_address": "noreply@example.com", "security": "starttls",
+	}, adminToken); resp.Code != http.StatusOK {
+		t.Fatalf("PUT no-password = %d", resp.Code)
+	}
+	saved, _ := store.GetEmailConfig(context.Background(), db)
+	if saved.Password != "secret" || saved.Port != 587 {
+		t.Fatalf("expected preserved password + updated port, got %+v", saved)
+	}
+
+	// Toggle enabled off.
+	if resp := doJSONRequest(t, handler, http.MethodPut, "/api/email/enabled", map[string]any{"enabled": false}, adminToken); resp.Code != http.StatusOK {
+		t.Fatalf("PUT enabled = %d", resp.Code)
+	}
+	saved, _ = store.GetEmailConfig(context.Background(), db)
+	if saved.Enabled {
+		t.Fatal("email should be disabled after toggle")
+	}
+}

--- a/internal/store/email_settings.go
+++ b/internal/store/email_settings.go
@@ -1,0 +1,157 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Email (SMTP sender) configuration is persisted in the app_settings KV store
+// under the keys below (TK-132). This layer only stores and validates the
+// configuration; actually sending mail is a separate concern (TK-138).
+const (
+	emailKeyEnabled     = "email.enabled"
+	emailKeyHost        = "email.smtp_host"
+	emailKeyPort        = "email.smtp_port"
+	emailKeyUsername    = "email.smtp_username"
+	emailKeyPassword    = "email.smtp_password"
+	emailKeyFromAddress = "email.from_address"
+	emailKeyFromName    = "email.from_name"
+	emailKeySecurity    = "email.security"
+
+	EmailSecurityNone     = "none"
+	EmailSecuritySTARTTLS = "starttls"
+	EmailSecurityTLS      = "tls"
+)
+
+// EmailConfig describes the SMTP sender. Password is write-through; callers that
+// expose it (the API) are responsible for masking it.
+type EmailConfig struct {
+	Enabled     bool   `json:"enabled"`
+	Host        string `json:"host"`
+	Port        int    `json:"port"`
+	Username    string `json:"username"`
+	Password    string `json:"password,omitempty"`
+	FromAddress string `json:"from_address"`
+	FromName    string `json:"from_name"`
+	Security    string `json:"security"`
+}
+
+// HasPassword reports whether a password is configured (used for masked display).
+func (c EmailConfig) HasPassword() bool { return strings.TrimSpace(c.Password) != "" }
+
+func getAppSettingValue(ctx context.Context, db *sql.DB, key string) (string, error) {
+	var v string
+	err := db.QueryRowContext(ctx, `SELECT value FROM app_settings WHERE key = ?`, key).Scan(&v)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	return v, err
+}
+
+// GetEmailConfig loads the SMTP configuration, applying sensible defaults.
+func GetEmailConfig(ctx context.Context, db *sql.DB) (EmailConfig, error) {
+	cfg := EmailConfig{Port: 587, Security: EmailSecuritySTARTTLS}
+	pairs := []struct {
+		key string
+		set func(string)
+	}{
+		{emailKeyEnabled, func(v string) { cfg.Enabled = v == "1" || strings.EqualFold(v, "true") }},
+		{emailKeyHost, func(v string) { cfg.Host = v }},
+		{emailKeyPort, func(v string) {
+			if n, err := strconv.Atoi(strings.TrimSpace(v)); err == nil && n > 0 {
+				cfg.Port = n
+			}
+		}},
+		{emailKeyUsername, func(v string) { cfg.Username = v }},
+		{emailKeyPassword, func(v string) { cfg.Password = v }},
+		{emailKeyFromAddress, func(v string) { cfg.FromAddress = v }},
+		{emailKeyFromName, func(v string) { cfg.FromName = v }},
+		{emailKeySecurity, func(v string) {
+			if s := normalizeEmailSecurity(v); s != "" {
+				cfg.Security = s
+			}
+		}},
+	}
+	for _, p := range pairs {
+		v, err := getAppSettingValue(ctx, db, p.key)
+		if err != nil {
+			return EmailConfig{}, err
+		}
+		if v != "" {
+			p.set(v)
+		}
+	}
+	return cfg, nil
+}
+
+func normalizeEmailSecurity(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case EmailSecurityNone:
+		return EmailSecurityNone
+	case EmailSecuritySTARTTLS, "tls/starttls":
+		return EmailSecuritySTARTTLS
+	case EmailSecurityTLS, "ssl":
+		return EmailSecurityTLS
+	default:
+		return ""
+	}
+}
+
+// SetEmailConfig validates and persists the SMTP configuration. When
+// updatePassword is false the stored password is left untouched (so callers can
+// save the form without re-entering the secret).
+func SetEmailConfig(ctx context.Context, db *sql.DB, cfg EmailConfig, updatePassword bool) error {
+	if cfg.Port <= 0 || cfg.Port > 65535 {
+		return fmt.Errorf("smtp port must be between 1 and 65535")
+	}
+	sec := normalizeEmailSecurity(cfg.Security)
+	if sec == "" {
+		return fmt.Errorf("security must be one of none, starttls, tls")
+	}
+	if cfg.Enabled && strings.TrimSpace(cfg.Host) == "" {
+		return fmt.Errorf("smtp host is required when email is enabled")
+	}
+	writes := map[string]string{
+		emailKeyEnabled:     boolToSetting(cfg.Enabled),
+		emailKeyHost:        strings.TrimSpace(cfg.Host),
+		emailKeyPort:        strconv.Itoa(cfg.Port),
+		emailKeyUsername:    cfg.Username,
+		emailKeyFromAddress: strings.TrimSpace(cfg.FromAddress),
+		emailKeyFromName:    strings.TrimSpace(cfg.FromName),
+		emailKeySecurity:    sec,
+	}
+	if updatePassword {
+		writes[emailKeyPassword] = cfg.Password
+	}
+	for k, v := range writes {
+		if err := SetAppSetting(ctx, db, k, v); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetEmailEnabled flips just the enable flag.
+func SetEmailEnabled(ctx context.Context, db *sql.DB, enabled bool) error {
+	if enabled {
+		cfg, err := GetEmailConfig(ctx, db)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(cfg.Host) == "" {
+			return fmt.Errorf("configure an SMTP host before enabling email")
+		}
+	}
+	return SetAppSetting(ctx, db, emailKeyEnabled, boolToSetting(enabled))
+}
+
+func boolToSetting(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}

--- a/internal/store/email_settings_test.go
+++ b/internal/store/email_settings_test.go
@@ -1,0 +1,93 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+func openEmailTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := Open(":memory:")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := createSchema(context.Background(), db); err != nil {
+		t.Fatalf("createSchema: %v", err)
+	}
+	return db
+}
+
+func TestEmailConfigDefaultsAndRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	db := openEmailTestDB(t)
+
+	// Defaults on an unconfigured database.
+	cfg, err := GetEmailConfig(ctx, db)
+	if err != nil {
+		t.Fatalf("get defaults: %v", err)
+	}
+	if cfg.Enabled || cfg.Port != 587 || cfg.Security != EmailSecuritySTARTTLS {
+		t.Fatalf("unexpected defaults: %+v", cfg)
+	}
+
+	in := EmailConfig{
+		Enabled: true, Host: "smtp.example.com", Port: 465, Username: "mailer",
+		Password: "secret", FromAddress: "noreply@example.com", FromName: "Ticket", Security: EmailSecurityTLS,
+	}
+	if err := SetEmailConfig(ctx, db, in, true); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got, err := GetEmailConfig(ctx, db)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !got.Enabled || got.Host != "smtp.example.com" || got.Port != 465 || got.Username != "mailer" ||
+		got.Password != "secret" || got.FromAddress != "noreply@example.com" || got.Security != EmailSecurityTLS {
+		t.Fatalf("round-trip mismatch: %+v", got)
+	}
+
+	// Saving without updatePassword preserves the stored secret.
+	in.Password = ""
+	in.FromName = "Ticket Bot"
+	if err := SetEmailConfig(ctx, db, in, false); err != nil {
+		t.Fatalf("set no-pw: %v", err)
+	}
+	got, _ = GetEmailConfig(ctx, db)
+	if got.Password != "secret" {
+		t.Fatalf("password should be preserved, got %q", got.Password)
+	}
+	if got.FromName != "Ticket Bot" {
+		t.Fatalf("from name not updated: %q", got.FromName)
+	}
+}
+
+func TestEmailConfigValidation(t *testing.T) {
+	ctx := context.Background()
+	db := openEmailTestDB(t)
+
+	if err := SetEmailConfig(ctx, db, EmailConfig{Port: 0, Security: EmailSecuritySTARTTLS}, true); err == nil {
+		t.Fatal("port 0 should fail")
+	}
+	if err := SetEmailConfig(ctx, db, EmailConfig{Port: 25, Security: "bogus"}, true); err == nil {
+		t.Fatal("bad security should fail")
+	}
+	if err := SetEmailConfig(ctx, db, EmailConfig{Enabled: true, Host: "", Port: 25, Security: EmailSecurityNone}, true); err == nil {
+		t.Fatal("enabling without a host should fail")
+	}
+	// Enabling via SetEmailEnabled requires a configured host.
+	if err := SetEmailEnabled(ctx, db, true); err == nil {
+		t.Fatal("enable without host should fail")
+	}
+	if err := SetEmailConfig(ctx, db, EmailConfig{Host: "smtp.example.com", Port: 587, Security: EmailSecuritySTARTTLS}, true); err != nil {
+		t.Fatalf("valid config: %v", err)
+	}
+	if err := SetEmailEnabled(ctx, db, true); err != nil {
+		t.Fatalf("enable with host: %v", err)
+	}
+	got, _ := GetEmailConfig(ctx, db)
+	if !got.Enabled {
+		t.Fatal("email should be enabled")
+	}
+}

--- a/libticket/http.go
+++ b/libticket/http.go
@@ -38,6 +38,18 @@ func (s *HTTPService) SetRegistrationAutoApprove(ctx context.Context, enabled bo
 	return s.client.SetRegistrationAutoApprove(ctx, enabled)
 }
 
+func (s *HTTPService) GetEmailConfig(ctx context.Context) (store.EmailConfig, error) {
+	return s.client.GetEmailConfig(ctx)
+}
+
+func (s *HTTPService) SetEmailConfig(ctx context.Context, cfg store.EmailConfig, updatePassword bool) error {
+	return s.client.SetEmailConfig(ctx, cfg, updatePassword)
+}
+
+func (s *HTTPService) SetEmailEnabled(ctx context.Context, enabled bool) error {
+	return s.client.SetEmailEnabled(ctx, enabled)
+}
+
 func (s *HTTPService) ListPlans(ctx context.Context) ([]store.Plan, error) {
 	return s.client.ListPlans(ctx)
 }

--- a/libticket/local.go
+++ b/libticket/local.go
@@ -114,6 +114,30 @@ func (s *LocalService) SetRegistrationEnabled(ctx context.Context, enabled bool)
 	return store.SetRegistrationEnabled(ctx, db, enabled)
 }
 
+func (s *LocalService) GetEmailConfig(ctx context.Context) (store.EmailConfig, error) {
+	db, err := s.openDB()
+	if err != nil {
+		return store.EmailConfig{}, err
+	}
+	return store.GetEmailConfig(ctx, db)
+}
+
+func (s *LocalService) SetEmailConfig(ctx context.Context, cfg store.EmailConfig, updatePassword bool) error {
+	db, err := s.openDB()
+	if err != nil {
+		return err
+	}
+	return store.SetEmailConfig(ctx, db, cfg, updatePassword)
+}
+
+func (s *LocalService) SetEmailEnabled(ctx context.Context, enabled bool) error {
+	db, err := s.openDB()
+	if err != nil {
+		return err
+	}
+	return store.SetEmailEnabled(ctx, db, enabled)
+}
+
 func (s *LocalService) SetRegistrationAutoApprove(ctx context.Context, enabled bool) error {
 	db, err := s.openDB()
 	if err != nil {

--- a/libticket/service.go
+++ b/libticket/service.go
@@ -29,6 +29,9 @@ type AuthService interface {
 	Status(ctx context.Context) (StatusResponse, error)
 	SetRegistrationEnabled(ctx context.Context, enabled bool) error
 	SetRegistrationAutoApprove(ctx context.Context, enabled bool) error
+	GetEmailConfig(ctx context.Context) (store.EmailConfig, error)
+	SetEmailConfig(ctx context.Context, cfg store.EmailConfig, updatePassword bool) error
+	SetEmailEnabled(ctx context.Context, enabled bool) error
 	ListPlans(ctx context.Context) ([]store.Plan, error)
 	DefaultPlan(ctx context.Context) (store.Plan, error)
 	SetDefaultPlan(ctx context.Context, slug string) error

--- a/web/default/index.html
+++ b/web/default/index.html
@@ -168,6 +168,7 @@
                                 <button type="button" class="seg-btn active" data-settings-tab="organisation">Organisation</button>
                                 <button type="button" class="seg-btn" data-settings-tab="providers">AI Providers</button>
                                 <button type="button" class="seg-btn" data-settings-tab="plans">Plans</button>
+                                <button type="button" class="seg-btn" data-settings-tab="email">Email</button>
                                 <button type="button" class="seg-btn" data-settings-tab="settings">Settings</button>
                             </div>
                         </div>
@@ -384,6 +385,37 @@
                                     </div>
                                 </form>
                             </div>
+                        </div>
+                    </div>
+
+                    <div class="settings-panel" data-settings-panel="email">
+                        <div class="card" style="max-width:600px">
+                            <div class="card-header">
+                                <div>
+                                    <h2>Email (SMTP)</h2>
+                                    <p class="meta">Configure the outbound email sender. Sending is governed by the enable toggle.</p>
+                                </div>
+                            </div>
+                            <form id="email-form" class="form-stack">
+                                <label class="check-row"><input type="checkbox" id="email-enabled"> Enable email sending</label>
+                                <div class="field"><label for="email-host">SMTP host</label><input id="email-host" placeholder="smtp.example.com"></div>
+                                <div class="field"><label for="email-port">Port</label><input id="email-port" type="number" value="587"></div>
+                                <div class="field"><label for="email-security">Security</label>
+                                    <select id="email-security">
+                                        <option value="starttls">STARTTLS</option>
+                                        <option value="tls">TLS/SSL</option>
+                                        <option value="none">None</option>
+                                    </select>
+                                </div>
+                                <div class="field"><label for="email-username">Username</label><input id="email-username" autocomplete="off"></div>
+                                <div class="field"><label for="email-password">Password</label><input id="email-password" type="password" autocomplete="new-password" placeholder="leave blank to keep current"></div>
+                                <div class="field"><label for="email-from-address">From address</label><input id="email-from-address" placeholder="noreply@example.com"></div>
+                                <div class="field"><label for="email-from-name">From name</label><input id="email-from-name" placeholder="Ticket"></div>
+                                <div class="form-actions">
+                                    <button id="email-save-button" class="btn btn-primary" type="submit">Save</button>
+                                    <span id="email-password-state" class="meta"></span>
+                                </div>
+                            </form>
                         </div>
                     </div>
 

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -1673,6 +1673,7 @@
             document.querySelectorAll("#view-settings .settings-panel").forEach((panel) => {
                 panel.classList.toggle("active", panel.dataset.settingsPanel === name);
             });
+            if (name === "email") { loadEmailSettings(); }
             try { localStorage.setItem("site2.settingsTab", name); } catch (e) { /* ignore */ }
         }
 
@@ -2697,6 +2698,56 @@
             } catch (error) {
                 setNotice(error.message || "Failed to assign roles", true);
             }
+        }
+
+        // ── Email (SMTP) settings (TK-132) ───────────────────────────────
+        async function loadEmailSettings() {
+            try {
+                const cfg = await api("/api/email/settings");
+                renderEmailForm(cfg || {});
+            } catch (error) {
+                /* non-admins never see this tab; ignore */
+            }
+        }
+        function renderEmailForm(cfg) {
+            const set = (id, val) => { const el = document.getElementById(id); if (el) { el.value = val == null ? "" : val; } };
+            const enabled = document.getElementById("email-enabled");
+            if (enabled) { enabled.checked = Boolean(cfg.enabled); }
+            set("email-host", cfg.host);
+            set("email-port", cfg.port || 587);
+            set("email-security", cfg.security || "starttls");
+            set("email-username", cfg.username);
+            set("email-from-address", cfg.from_address);
+            set("email-from-name", cfg.from_name);
+            const pw = document.getElementById("email-password");
+            if (pw) { pw.value = ""; }
+            const state = document.getElementById("email-password-state");
+            if (state) { state.textContent = cfg.has_password ? "A password is set — leave blank to keep it." : "No password set."; }
+        }
+        async function saveEmailSettings(event) {
+            event.preventDefault();
+            const val = (id) => { const el = document.getElementById(id); return el ? el.value.trim() : ""; };
+            const body = {
+                enabled: Boolean((document.getElementById("email-enabled") || {}).checked),
+                host: val("email-host"),
+                port: parseInt(val("email-port"), 10) || 587,
+                security: val("email-security") || "starttls",
+                username: val("email-username"),
+                from_address: val("email-from-address"),
+                from_name: val("email-from-name"),
+                password: val("email-password"),
+            };
+            try {
+                await api("/api/email/settings", { method: "PUT", body: JSON.stringify(body) });
+                setNotice("Email settings saved");
+                await loadEmailSettings();
+            } catch (error) {
+                setNotice(error.message || "Failed to save email settings", true);
+            }
+        }
+        function setupEmailSettings() {
+            const form = document.getElementById("email-form");
+            if (form) { form.addEventListener("submit", saveEmailSettings); }
         }
 
         function setupAccessView() {
@@ -9665,6 +9716,7 @@
         setupChat();
         setupBoardKeyboardNav();
         setupAccessView();
+        setupEmailSettings();
         state.viewScrollByPanel = loadStoredViewScrollByPanel();
         state.currentView = loadStoredSelectedView() || state.currentView;
         switchView(state.currentView, { restoreScroll: false });


### PR DESCRIPTION
Configures an SMTP email sender (config only — sending is TK-138). Stored in app_settings (no migration).

- **Store**: GetEmailConfig/SetEmailConfig/SetEmailEnabled with validation; password preserved on save-without-password.
- **Server**: admin GET/PUT /api/email/settings + PUT /api/email/enabled; password never returned (has_password only).
- **CLI**: tk email show/set/enable/disable (local + remote via libticket.Service; masked password sentinel).
- **Web**: Settings -> Email tab (SMTP form + enable toggle).

Store/server/CLI/contract Go suites + site2 green; verified end-to-end on a real server (web save persists, password masked). OpenAPI + USER_GUIDE updated.

refs TK-132