### PR TITLE
TK-139: chat rooms — join-by-name, new/leave switching, permanent rooms, unread counters

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -55,13 +55,18 @@ Type these in the composer:
 
 | Command | Does |
 |---------|------|
-| `/new <name>` | Create a room |
-| `/join` · `/leave` | Join or leave the current room |
+| `/new <name>` | Create a room and switch into it |
+| `/join <name>` | Join a room by name and switch into it (just switches if you're already a member) |
+| `/leave` | Leave the current room and return to the previous room |
 | `/invite <username>` | Add a user to the room (and its project) |
 | `/kick <username>` | Remove a user from the room |
 | `/list` | List rooms alphabetically with member counts |
 | `/msg @username <message>` | Send a direct message |
 | `/task [@agent] <description>` | Create a tracked ticket (see below) |
+
+The **public room** and a **project's room** are permanent — you can't leave them
+(no Leave button, and `/leave` is rejected). When messages arrive in rooms you're
+not viewing, a **red counter** appears next to that room in the list.
 
 ### Breakout rooms from a ticket
 

--- a/internal/server/api_rooms.go
+++ b/internal/server/api_rooms.go
@@ -50,9 +50,14 @@ func (r *router) registerRoomHandlers() {
 			}
 			counts, _ := store.RoomMemberCounts(req.Context(), db)
 			unread, _ := store.UnreadRoomIDs(req.Context(), db, user.ID)
+			unreadCounts, _ := store.RoomUnreadCounts(req.Context(), db, user.ID)
 			for i := range rooms {
 				rooms[i].MemberCount = counts[rooms[i].ID]
 				rooms[i].Unread = unread[rooms[i].ID]
+				rooms[i].UnreadCount = unreadCounts[rooms[i].ID]
+				if perm, perr := store.RoomIsPermanent(req.Context(), db, rooms[i]); perr == nil {
+					rooms[i].Permanent = perm
+				}
 			}
 			writeJSON(w, http.StatusOK, rooms)
 		case http.MethodPost:
@@ -406,6 +411,20 @@ func handleRoomCommand(w http.ResponseWriter, req *http.Request, db *sql.DB, roo
 		writeJSON(w, http.StatusCreated, msg)
 		return true
 	}
+	// postTo posts a system line into a DIFFERENT room and returns that message,
+	// so the web client follows the message and switches into the target room.
+	postTo := func(targetRoomID int64, text, kind string, extra store.Attrs) bool {
+		msg, err := store.PostRoomMessage(ctx, db, store.RoomMessage{RoomID: targetRoomID, SenderID: user.ID, Kind: kind, Body: text, Attrs: extra})
+		if err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
+			return true
+		}
+		if hub != nil {
+			hub.broadcastRoomMessage(targetRoomID, msg)
+		}
+		writeJSON(w, http.StatusCreated, msg)
+		return true
+	}
 
 	switch cmd {
 	case "task":
@@ -430,7 +449,9 @@ func handleRoomCommand(w http.ResponseWriter, req *http.Request, db *sql.DB, roo
 			writeError(w, http.StatusBadRequest, cerr.Error())
 			return true
 		}
-		return post("created room #"+created.Name, "system", store.Attrs{"new_room_id": created.ID})
+		_ = store.JoinRoom(ctx, db, created.ID, user.ID, "owner")
+		// Post the confirmation into the new room so the client switches into it.
+		return postTo(created.ID, "created room #"+created.Name, "system", store.Attrs{"new_room_id": created.ID})
 	case "invite":
 		target, err := store.GetUserByUsername(ctx, db, strings.TrimPrefix(arg, "@"))
 		if err != nil {
@@ -457,11 +478,23 @@ func handleRoomCommand(w http.ResponseWriter, req *http.Request, db *sql.DB, roo
 		}
 		return post("removed @"+target.Username, "system", nil)
 	case "join":
-		if jerr := store.JoinRoom(ctx, db, room.ID, user.ID, "member"); jerr != nil {
+		// "/join <name>" joins (or just switches to) a room by name; "/join" with
+		// no argument joins the current room.
+		target := room
+		if arg != "" {
+			found, ferr := store.FindRoomByName(ctx, db, strings.TrimPrefix(arg, "#"), user.ID, room.ProjectID)
+			if ferr != nil {
+				writeError(w, http.StatusBadRequest, ferr.Error())
+				return true
+			}
+			target = found
+		}
+		if jerr := store.JoinRoom(ctx, db, target.ID, user.ID, "member"); jerr != nil {
 			writeStoreError(w, jerr)
 			return true
 		}
-		return post("@"+user.Username+" joined", "system", nil)
+		// Post into the target room so the client follows and switches into it.
+		return postTo(target.ID, "@"+user.Username+" joined", "system", nil)
 	case "leave":
 		if lerr := store.LeaveRoom(ctx, db, room.ID, user.ID); lerr != nil {
 			writeStoreError(w, lerr)

--- a/internal/server/api_rooms.go
+++ b/internal/server/api_rooms.go
@@ -472,7 +472,7 @@ func handleRoomCommand(w http.ResponseWriter, req *http.Request, db *sql.DB, roo
 			writeError(w, http.StatusBadRequest, "unknown user: "+arg)
 			return true
 		}
-		if lerr := store.LeaveRoom(ctx, db, room.ID, target.ID); lerr != nil {
+		if lerr := store.RemoveRoomMember(ctx, db, room.ID, target.ID); lerr != nil {
 			writeStoreError(w, lerr)
 			return true
 		}

--- a/internal/server/api_rooms_test.go
+++ b/internal/server/api_rooms_test.go
@@ -110,6 +110,9 @@ func TestRoomAPIJoinLeaveAndPrivateVisibility(t *testing.T) {
 	registerUser(t, handler, "bob", "password123")
 	bob := roomLoginToken(t, handler, "bob", "password123")
 
+	// The first public room in a scope is permanent (non-leavable); seed it so the
+	// "Public" room below is an ordinary, leavable room.
+	doJSONRequest(t, handler, http.MethodPost, "/api/rooms", map[string]any{"name": "general"}, admin)
 	// Public room: bob can see and join.
 	pubResp := doJSONRequest(t, handler, http.MethodPost, "/api/rooms", map[string]any{"name": "Public"}, admin)
 	var pub store.Room

--- a/internal/store/room.go
+++ b/internal/store/room.go
@@ -258,6 +258,14 @@ func LeaveRoom(ctx context.Context, db *sql.DB, roomID int64, memberID string) e
 	return derr
 }
 
+// RemoveRoomMember removes a member without the permanence guard. Used for
+// administrative removal (kick), which is allowed even on permanent rooms —
+// unlike voluntarily leaving via LeaveRoom.
+func RemoveRoomMember(ctx context.Context, db *sql.DB, roomID int64, memberID string) error {
+	_, err := db.ExecContext(ctx, `DELETE FROM room_members WHERE room_id = ? AND member_id = ?`, roomID, strings.TrimSpace(memberID))
+	return err
+}
+
 // RoomIsPermanent reports whether a room is the primary (non-leavable) room for
 // its scope: the lowest-id public global room, or a project's lowest-id public
 // room. Breakout (ticket) and private rooms are always leavable.

--- a/internal/store/room.go
+++ b/internal/store/room.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"regexp"
 	"sort"
@@ -28,6 +29,8 @@ type Room struct {
 	// Transient, populated per-request by the API layer.
 	MemberCount int  `json:"member_count"`
 	Unread      bool `json:"unread"`
+	UnreadCount int  `json:"unread_count"`
+	Permanent   bool `json:"permanent"` // global + project primary rooms cannot be left
 }
 
 // Scope returns "global", "project", or "breakout".
@@ -235,9 +238,111 @@ func JoinRoom(ctx context.Context, db *sql.DB, roomID int64, memberID, role stri
 }
 
 // LeaveRoom removes a member from a room.
+// ErrRoomPermanent is returned when a member tries to leave a non-leavable room
+// (the global public room or a project's primary room).
+var ErrRoomPermanent = errors.New("this room cannot be left")
+
 func LeaveRoom(ctx context.Context, db *sql.DB, roomID int64, memberID string) error {
-	_, err := db.ExecContext(ctx, `DELETE FROM room_members WHERE room_id = ? AND member_id = ?`, roomID, strings.TrimSpace(memberID))
-	return err
+	room, err := GetRoom(ctx, db, roomID)
+	if err != nil {
+		return err
+	}
+	permanent, perr := RoomIsPermanent(ctx, db, room)
+	if perr != nil {
+		return perr
+	}
+	if permanent {
+		return ErrRoomPermanent
+	}
+	_, derr := db.ExecContext(ctx, `DELETE FROM room_members WHERE room_id = ? AND member_id = ?`, roomID, strings.TrimSpace(memberID))
+	return derr
+}
+
+// RoomIsPermanent reports whether a room is the primary (non-leavable) room for
+// its scope: the lowest-id public global room, or a project's lowest-id public
+// room. Breakout (ticket) and private rooms are always leavable.
+func RoomIsPermanent(ctx context.Context, db *sql.DB, room Room) (bool, error) {
+	if room.Archived || room.Visibility != "public" || strings.TrimSpace(room.TicketID) != "" {
+		return false, nil
+	}
+	var primaryID int64
+	var err error
+	if room.ProjectID == nil {
+		err = db.QueryRowContext(ctx, `SELECT room_id FROM rooms WHERE project_id IS NULL AND visibility = 'public' AND archived = 0 ORDER BY room_id LIMIT 1`).Scan(&primaryID)
+	} else {
+		err = db.QueryRowContext(ctx, `SELECT room_id FROM rooms WHERE project_id = ? AND ticket_id = '' AND visibility = 'public' AND archived = 0 ORDER BY room_id LIMIT 1`, *room.ProjectID).Scan(&primaryID)
+	}
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return primaryID == room.ID, nil
+}
+
+// RoomUnreadCounts returns, per room the member belongs to, how many messages
+// arrived after their last read (for the unread badge).
+func RoomUnreadCounts(ctx context.Context, db *sql.DB, memberID string) (map[int64]int, error) {
+	rows, err := db.QueryContext(ctx, `
+		SELECT rm.room_id, COUNT(msg.message_id)
+		FROM room_members rm
+		JOIN room_messages msg ON msg.room_id = rm.room_id
+		WHERE rm.member_id = ? AND (rm.last_read_at = '' OR msg.created_at > rm.last_read_at)
+		GROUP BY rm.room_id`, strings.TrimSpace(memberID))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := map[int64]int{}
+	for rows.Next() {
+		var id int64
+		var n int
+		if serr := rows.Scan(&id, &n); serr != nil {
+			return nil, serr
+		}
+		out[id] = n
+	}
+	return out, rows.Err()
+}
+
+// FindRoomByName resolves a visible room by name or slug (case-insensitive),
+// preferring the current project scope, then global, that the member can see.
+func FindRoomByName(ctx context.Context, db *sql.DB, name, memberID string, projectID *int64) (Room, error) {
+	needle := strings.ToLower(strings.TrimSpace(name))
+	if needle == "" {
+		return Room{}, errors.New("room name is required")
+	}
+	rows, err := db.QueryContext(ctx, `SELECT `+roomColumns+` FROM rooms
+		WHERE archived = 0 AND (LOWER(name) = ? OR LOWER(slug) = ?)
+		  AND (visibility = 'public' OR room_id IN (SELECT room_id FROM room_members WHERE member_id = ?))
+		ORDER BY (project_id IS NOT NULL) DESC, room_id ASC`, needle, needle, strings.TrimSpace(memberID))
+	if err != nil {
+		return Room{}, err
+	}
+	defer rows.Close()
+	var match *Room
+	for rows.Next() {
+		r, serr := scanRoom(rows)
+		if serr != nil {
+			return Room{}, serr
+		}
+		// Prefer a room in the active project; otherwise take the first.
+		if projectID != nil && r.ProjectID != nil && *r.ProjectID == *projectID {
+			return r, nil
+		}
+		if match == nil {
+			rc := r
+			match = &rc
+		}
+	}
+	if rerr := rows.Err(); rerr != nil {
+		return Room{}, rerr
+	}
+	if match == nil {
+		return Room{}, fmt.Errorf("no room named %q", name)
+	}
+	return *match, nil
 }
 
 // IsRoomMember reports whether a member belongs to a room.

--- a/internal/store/room_test.go
+++ b/internal/store/room_test.go
@@ -50,6 +50,11 @@ func TestRoomScopeAndCreate(t *testing.T) {
 func TestRoomJoinLeaveAndMembership(t *testing.T) {
 	db := testDB(t)
 	ctx := context.Background()
+	// The first public room in a scope is the permanent (non-leavable) room, so
+	// seed a primary "general" first; "team" is then an ordinary leavable room.
+	if _, err := CreateRoom(ctx, db, Room{Name: "general", CreatedBy: "alice"}); err != nil {
+		t.Fatalf("seed general: %v", err)
+	}
 	room, err := CreateRoom(ctx, db, Room{Name: "team", CreatedBy: "alice"})
 	if err != nil {
 		t.Fatalf("create: %v", err)
@@ -73,6 +78,59 @@ func TestRoomJoinLeaveAndMembership(t *testing.T) {
 	}
 	if ok, _ := IsRoomMember(ctx, db, room.ID, "bob"); ok {
 		t.Fatalf("bob should have left")
+	}
+}
+
+func TestRoomPermanenceAndUnreadCounts(t *testing.T) {
+	db := testDB(t)
+	ctx := context.Background()
+
+	// First public global room is permanent; a second public room is leavable.
+	general, _ := CreateRoom(ctx, db, Room{Name: "general", CreatedBy: "admin"})
+	team, _ := CreateRoom(ctx, db, Room{Name: "team", CreatedBy: "admin"})
+	priv, _ := CreateRoom(ctx, db, Room{Name: "secret", Visibility: "private", CreatedBy: "admin"})
+
+	if p, _ := RoomIsPermanent(ctx, db, general); !p {
+		t.Fatal("the primary public room should be permanent")
+	}
+	if p, _ := RoomIsPermanent(ctx, db, team); p {
+		t.Fatal("a secondary public room should be leavable")
+	}
+	if p, _ := RoomIsPermanent(ctx, db, priv); p {
+		t.Fatal("a private room should be leavable")
+	}
+
+	// Leaving the permanent room is rejected.
+	_ = JoinRoom(ctx, db, general.ID, "bob", "member")
+	if err := LeaveRoom(ctx, db, general.ID, "bob"); err != ErrRoomPermanent {
+		t.Fatalf("leave permanent = %v, want ErrRoomPermanent", err)
+	}
+
+	// Unread counts: bob is a member of team; two messages arrive unread.
+	_ = JoinRoom(ctx, db, team.ID, "bob", "member")
+	_, _ = PostRoomMessage(ctx, db, RoomMessage{RoomID: team.ID, SenderID: "admin", Body: "hi"})
+	_, _ = PostRoomMessage(ctx, db, RoomMessage{RoomID: team.ID, SenderID: "admin", Body: "again"})
+	counts, err := RoomUnreadCounts(ctx, db, "bob")
+	if err != nil {
+		t.Fatalf("unread counts: %v", err)
+	}
+	if counts[team.ID] != 2 {
+		t.Fatalf("team unread = %d, want 2", counts[team.ID])
+	}
+	// After marking read, the count clears.
+	_ = MarkRoomRead(ctx, db, team.ID, "bob")
+	counts, _ = RoomUnreadCounts(ctx, db, "bob")
+	if counts[team.ID] != 0 {
+		t.Fatalf("team unread after read = %d, want 0", counts[team.ID])
+	}
+
+	// FindRoomByName resolves case-insensitively.
+	found, err := FindRoomByName(ctx, db, "TEAM", "bob", nil)
+	if err != nil || found.ID != team.ID {
+		t.Fatalf("find team: %v (id=%d)", err, found.ID)
+	}
+	if _, err := FindRoomByName(ctx, db, "nope", "bob", nil); err == nil {
+		t.Fatal("unknown room should error")
 	}
 }
 

--- a/web/default/site.css
+++ b/web/default/site.css
@@ -2084,3 +2084,6 @@ select {
 #view-access .access-role-item { display: block; width: 100%; text-align: left; padding: 8px 10px; margin-bottom: 6px; background: var(--surface, #fff); border: 1px solid var(--border, #ddd); border-radius: 6px; cursor: pointer; }
 #view-access .access-role-item.active { border-color: var(--accent, #ff7a1a); }
 #view-access .access-check-row { display: flex; align-items: center; gap: 8px; padding: 3px 0; }
+
+/* Red unread counter near a room in the chat list (TK-139). */
+.chat-unread-badge { display: inline-block; min-width: 18px; padding: 0 5px; margin-left: 6px; border-radius: 9px; background: #e5484d; color: #fff; font-size: 11px; font-weight: 700; line-height: 18px; text-align: center; vertical-align: middle; }

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -80,6 +80,7 @@
             drag: null,
             liveSocket: null,
             activeRoomID: 0,
+            lastRoomID: 0,
             rooms: [],
             liveRefreshTimer: null,
             refinementSocket: null,
@@ -2308,15 +2309,22 @@
                 const scoped = state.rooms.filter((r) => roomScope(r) === g[0]);
                 if (!scoped.length) { return; }
                 html += "<div class=\"chat-room-group\">" + escapeHTML(g[1]) + "</div>";
-                html += scoped.map((r) =>
-                    "<button type=\"button\" class=\"chat-room-item" + (r.room_id === state.activeRoomID ? " active" : "") + (r.unread ? " unread" : "") + "\" data-room-id=\"" + r.room_id + "\">" +
-                    (r.unread ? "<span class=\"chat-unread-dot\">*</span> " : "") +
-                    (r.visibility === "private" ? "🔒 " : "# ") + escapeHTML(r.name) +
-                    "<span class=\"chat-room-count\">" + (r.member_count || 0) + "</span></button>").join("");
+                html += scoped.map((r) => {
+                    const active = r.room_id === state.activeRoomID;
+                    const n = active ? 0 : (r.unread_count || 0);
+                    const badge = n > 0 ? "<span class=\"chat-unread-badge\">" + (n > 99 ? "99+" : n) + "</span>" : "";
+                    return "<button type=\"button\" class=\"chat-room-item" + (active ? " active" : "") + (n > 0 ? " unread" : "") + "\" data-room-id=\"" + r.room_id + "\">" +
+                        (r.visibility === "private" ? "🔒 " : "# ") + escapeHTML(r.name) + badge +
+                        "<span class=\"chat-room-count\">" + (r.member_count || 0) + "</span></button>";
+                }).join("");
             });
             list.innerHTML = html;
         }
         function selectRoom(roomID) {
+            // Remember where we came from so /leave can return there.
+            if (state.activeRoomID && state.activeRoomID !== roomID) {
+                state.lastRoomID = state.activeRoomID;
+            }
             state.activeRoomID = roomID;
             const room = state.rooms.find((r) => r.room_id === roomID);
             const titleEl = document.getElementById("chat-room-title");
@@ -2335,7 +2343,8 @@
             const joinBtn = document.getElementById("chat-join-button");
             const leaveBtn = document.getElementById("chat-leave-button");
             if (joinBtn) { joinBtn.hidden = false; }
-            if (leaveBtn) { leaveBtn.hidden = false; }
+            // The public global room and a project's room cannot be left.
+            if (leaveBtn) { leaveBtn.hidden = Boolean(room && room.permanent); }
             subscribeRoom(roomID);
             // Loading messages marks the room read server-side; refresh the list
             // afterwards so the unread marker clears.
@@ -2359,16 +2368,30 @@
             const body = String(input.value || "").trim();
             if (!body) { return; }
             const roomID = state.activeRoomID;
+            const isLeave = body.toLowerCase() === "/leave";
             input.value = "";
             apiClient.post("/api/rooms/" + roomID + "/messages", { body: body })
                 .then((msg) => loadRooms().then(() => {
                     renderRoomsList();
-                    // /msg routes to a DM room and /new creates a room — follow the
-                    // message if the server placed it somewhere other than here.
+                    if (isLeave) {
+                        // After leaving, return to the previous room (or a default).
+                        selectRoom(roomReturnTarget(roomID));
+                        return;
+                    }
+                    // /msg routes to a DM room and /new + /join switch rooms — follow
+                    // the message if the server placed it somewhere other than here.
                     const target = (msg && msg.room_id && msg.room_id !== roomID) ? msg.room_id : roomID;
                     if (target !== roomID) { selectRoom(target); } else { loadRoomMessages(roomID); }
                 }))
                 .catch((err) => setNotice("Send failed: " + err.message, true));
+        }
+        // roomReturnTarget picks where to land after leaving `leftRoomID`: the last
+        // room if it still exists, else a sensible default.
+        function roomReturnTarget(leftRoomID) {
+            if (state.lastRoomID && state.lastRoomID !== leftRoomID && state.rooms.some((r) => r.room_id === state.lastRoomID)) {
+                return state.lastRoomID;
+            }
+            return pickDefaultRoomID();
         }
         function createRoomFromPrompt() {
             Promise.resolve(uiPrompt("New room name", "", "Create")).then((name) => {
@@ -2432,7 +2455,11 @@
             if (leaveBtn) {
                 leaveBtn.addEventListener("click", () => {
                     if (!state.activeRoomID) { return; }
-                    apiClient.post("/api/rooms/" + state.activeRoomID + "/leave").then(() => loadRooms()).then(renderRoomsList).catch(() => {});
+                    const left = state.activeRoomID;
+                    apiClient.post("/api/rooms/" + left + "/leave")
+                        .then(() => loadRooms())
+                        .then(() => { renderRoomsList(); selectRoom(roomReturnTarget(left)); })
+                        .catch((err) => setNotice(err.message || "Cannot leave this room", true));
                 });
             }
         }


### PR DESCRIPTION
- /new <name> creates + switches into the room; /join <name> joins by name + switches (just switches if already a member); /leave leaves and returns to the previous room.
- The public global room and a project's primary room are permanent: LeaveRoom rejects them, the Leave button is hidden, and /leave errors. Kick uses RemoveRoomMember so admins can still remove members.
- Red numeric unread counter per room (RoomUnreadCounts + chat-unread-badge).

Store + server room/chat Go tests, plus a real-server headless smoke (new/leave/join switching, permanent leave hidden) and green site2 chat tests. USER_GUIDE updated.

refs TK-139