### PR TITLE
TK-141: theme-aware panel backgrounds (fix bright-white bar)

### DIFF
--- a/web/default/site.css
+++ b/web/default/site.css
@@ -2044,8 +2044,8 @@ select {
 #view-chat { padding: 16px; }
 .chat-shell {
     flex: 1; display: flex; min-height: 0;
-    border: 1px solid var(--border, #333); border-radius: 10px; overflow: hidden;
-    background: var(--surface, #fff);
+    border: 1px solid var(--card-border); border-radius: 10px; overflow: hidden;
+    background: var(--card);
 }
 .dark .chat-shell { background: hsl(22 10% 14%); }
 .chat-pane { display: flex; flex-direction: column; min-height: 0; }
@@ -2081,8 +2081,9 @@ select {
 .ticket-card.kbd-focus { outline: 2px solid var(--accent, #ff7a1a); outline-offset: 1px; }
 
 /* Access-roles admin panel (TK-135). */
-#view-access .access-role-item { display: block; width: 100%; text-align: left; padding: 8px 10px; margin-bottom: 6px; background: var(--surface, #fff); border: 1px solid var(--border, #ddd); border-radius: 6px; cursor: pointer; }
-#view-access .access-role-item.active { border-color: var(--accent, #ff7a1a); }
+#view-access .access-role-item { display: block; width: 100%; text-align: left; padding: 8px 10px; margin-bottom: 6px; background: var(--card); border: 1px solid var(--card-border); border-radius: 6px; cursor: pointer; color: inherit; }
+#view-access .access-role-item:hover { border-color: var(--accent, #ff7a1a); }
+#view-access .access-role-item.active { border-color: var(--accent, #ff7a1a); background: var(--accent-soft, rgba(255,122,26,0.12)); }
 #view-access .access-check-row { display: flex; align-items: center; gap: 8px; padding: 3px 0; }
 
 /* Red unread counter near a room in the chat list (TK-139). */


### PR DESCRIPTION
var(--surface,#fff) had no --surface var so access-role items + chat shell fell back to bright white (harsh in dark mode). Now use --card/--card-border; active role uses --accent-soft. refs TK-141