### PR TITLE
Chat commands: /rename, /status, /ping, /msg (no-switch)

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -61,7 +61,10 @@ Type these in the composer:
 | `/invite <username>` | Add a user to the room (and its project) |
 | `/kick <username>` | Remove a user from the room |
 | `/list` | List rooms alphabetically with member counts |
-| `/msg @username <message>` | Send a direct message |
+| `/rename <name>` | Rename the current room (owner/admin; no-op if already named that) |
+| `/status [words]` | Set your status, or print it with no argument |
+| `/ping <username>` | Send a ping notification to a user |
+| `/msg <username> <message>` | DM a user **without** switching to that chat |
 | `/task [@agent] <description>` | Create a tracked ticket (see below) |
 
 The **public room** and a **project's room** are permanent — you can't leave them

--- a/internal/server/api_rooms.go
+++ b/internal/server/api_rooms.go
@@ -503,6 +503,50 @@ func handleRoomCommand(w http.ResponseWriter, req *http.Request, db *sql.DB, roo
 		return post("@"+user.Username+" left", "system", nil)
 	case "list":
 		return post(roomListText(ctx, db, user), "system", nil)
+	case "rename":
+		if arg == "" {
+			writeError(w, http.StatusBadRequest, "usage: /rename <new name>")
+			return true
+		}
+		if room.CreatedBy != user.ID && user.Role != "admin" {
+			writeError(w, http.StatusForbidden, "only the room owner can rename this room")
+			return true
+		}
+		if strings.EqualFold(strings.TrimSpace(room.Name), strings.TrimSpace(arg)) {
+			return post("room is already named #"+room.Name, "system", nil)
+		}
+		updated, uerr := store.UpdateRoom(ctx, db, room.ID, arg, room.Topic, room.Visibility)
+		if uerr != nil {
+			writeError(w, http.StatusBadRequest, uerr.Error())
+			return true
+		}
+		return post("renamed room to #"+updated.Name, "system", nil)
+	case "status":
+		if arg == "" {
+			current := strings.TrimSpace(user.Status)
+			if current == "" {
+				current = "(no status set)"
+			}
+			return post("your status: "+current, "system", nil)
+		}
+		if serr := store.SetUserStatus(ctx, db, user.ID, arg); serr != nil {
+			writeStoreError(w, serr)
+			return true
+		}
+		return post("@"+user.Username+" set status: "+arg, "system", nil)
+	case "ping":
+		target, perr := store.GetUserByUsername(ctx, db, strings.TrimPrefix(arg, "@"))
+		if perr != nil {
+			writeError(w, http.StatusBadRequest, "unknown user: "+arg)
+			return true
+		}
+		_, _ = store.CreateUserNotification(ctx, db, store.UserNotificationCreateParams{
+			UserID:  target.ID,
+			Kind:    "ping",
+			Title:   "Ping from @" + user.Username,
+			Message: "@" + user.Username + " pinged you in #" + room.Name,
+		})
+		return post("pinged @"+target.Username, "system", nil)
 	case "msg":
 		fields := strings.SplitN(strings.TrimSpace(arg), " ", 2)
 		if len(fields) < 2 || strings.TrimSpace(fields[1]) == "" {

--- a/internal/server/api_rooms_test.go
+++ b/internal/server/api_rooms_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -271,6 +272,63 @@ func TestRoomMessageStoresMentions(t *testing.T) {
 	mentions, ok := msg.Attrs["mentions"].([]any)
 	if !ok || len(mentions) != 1 || mentions[0] != "agent-1" {
 		t.Fatalf("message mentions = %v (ok=%v)", msg.Attrs["mentions"], ok)
+	}
+}
+
+func TestRoomChatCommandsRenameStatusPing(t *testing.T) {
+	t.Parallel()
+	handler, db := testHandler(t)
+	defer db.Close()
+	ctx := context.Background()
+	admin := roomLoginToken(t, handler, "admin", "password")
+	registerUser(t, handler, "bob", "password123")
+	bob := roomLoginToken(t, handler, "bob", "password123")
+
+	var room store.Room
+	decodeResponse(t, doJSONRequest(t, handler, http.MethodPost, "/api/rooms", map[string]any{"name": "Ops"}, admin), &room)
+	msgPath := "/api/rooms/" + itoa(room.ID) + "/messages"
+	send := func(body, tok string) *httptest.ResponseRecorder {
+		return doJSONRequest(t, handler, http.MethodPost, msgPath, map[string]string{"body": body}, tok)
+	}
+
+	// /rename (owner) renames the room.
+	if r := send("/rename Operations", admin); r.Code != http.StatusCreated {
+		t.Fatalf("/rename status=%d body=%s", r.Code, r.Body.String())
+	}
+	if fresh, _ := store.GetRoom(ctx, db, room.ID); fresh.Name != "Operations" {
+		t.Fatalf("room name=%q, want Operations", fresh.Name)
+	}
+	// No-op when already named (case-insensitive).
+	send("/rename operations", admin)
+	if fresh, _ := store.GetRoom(ctx, db, room.ID); fresh.Name != "Operations" {
+		t.Fatalf("case-insensitive no-op changed name to %q", fresh.Name)
+	}
+	// Non-owner cannot rename.
+	if r := send("/rename Hijack", bob); r.Code != http.StatusForbidden {
+		t.Fatalf("non-owner /rename = %d, want 403", r.Code)
+	}
+
+	// /status sets and reads back the user's status.
+	if r := send("/status heads down", admin); r.Code != http.StatusCreated {
+		t.Fatalf("/status set = %d", r.Code)
+	}
+	if u, _ := store.GetUserByUsername(ctx, db, "admin"); u.Status != "heads down" {
+		t.Fatalf("status=%q, want 'heads down'", u.Status)
+	}
+	var statusMsg store.RoomMessage
+	decodeResponse(t, send("/status", admin), &statusMsg)
+	if !strings.Contains(statusMsg.Body, "heads down") {
+		t.Fatalf("/status read = %q, want it to include the status", statusMsg.Body)
+	}
+
+	// /ping notifies the target user.
+	if r := send("/ping bob", admin); r.Code != http.StatusCreated {
+		t.Fatalf("/ping = %d body=%s", r.Code, r.Body.String())
+	}
+	bobUser, _ := store.GetUserByUsername(ctx, db, "bob")
+	notifs, _ := store.ListUserNotifications(ctx, db, bobUser.ID, "", 10)
+	if len(notifs) == 0 {
+		t.Fatal("/ping should create a notification for bob")
 	}
 }
 

--- a/internal/store/auth.go
+++ b/internal/store/auth.go
@@ -391,6 +391,13 @@ func GetUserDefaultProject(ctx context.Context, db *sql.DB, userID string) (Proj
 	return GetProjectByID(ctx, db, projectID.Int64)
 }
 
+// SetUserStatus sets a user's free-text status line.
+func SetUserStatus(ctx context.Context, db *sql.DB, userID, status string) error {
+	_, err := db.ExecContext(ctx, `UPDATE users SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE user_id = ?`,
+		strings.TrimSpace(status), strings.TrimSpace(userID))
+	return err
+}
+
 func SetUserDefaultProject(ctx context.Context, db *sql.DB, userID string, projectID int64) error {
 	result, err := db.ExecContext(ctx, `UPDATE users SET default_project_id = ?, updated_at = CURRENT_TIMESTAMP WHERE user_id = ?`, projectID, strings.TrimSpace(userID))
 	if err != nil {

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -2404,6 +2404,8 @@
             if (!body) { return; }
             const roomID = state.activeRoomID;
             const isLeave = body.toLowerCase() === "/leave";
+            // /msg sends to a private chat WITHOUT moving the sender to it.
+            const isMsg = body.toLowerCase().indexOf("/msg ") === 0;
             input.value = "";
             apiClient.post("/api/rooms/" + roomID + "/messages", { body: body })
                 .then((msg) => loadRooms().then(() => {
@@ -2411,6 +2413,12 @@
                     if (isLeave) {
                         // After leaving, return to the previous room (or a default).
                         selectRoom(roomReturnTarget(roomID));
+                        return;
+                    }
+                    if (isMsg) {
+                        // Stay put; the DM was delivered to the other room.
+                        loadRoomMessages(roomID);
+                        setNotice("Message sent");
                         return;
                     }
                     // /msg routes to a DM room and /new + /join switch rooms — follow


### PR DESCRIPTION
/rename <name> (owner-only, no-op if already named, case-insensitive); /status [words] (set/print user status); /ping <username> (notification); /msg <username> now keeps the sender in their current room. Server command tests + site2 chat green; USER_GUIDE updated.

refs TK-143 TK-144 TK-145 TK-146