### PR TITLE
TK-142: personal agent per user (DM + query + /task ticket)

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -76,6 +76,14 @@ not viewing, a **red counter** appears next to that room in the list.
 Open any ticket and click **💬 Breakout** to open (or create) a chat room scoped
 to that ticket — handy for discussing an epic or story in context.
 
+## Your personal agent
+
+Every user gets their own agent, provisioned automatically the first time you open
+chat. It appears as a DM under **People & Agents** (e.g. `you's agent`). Talk to it
+there — each message is a **query** it answers in the thread (the DM is your
+ongoing session), and `/task <description>` delegates a tracked **ticket**. Only
+you see your personal-agent DM.
+
 ## Working with agents in chat
 
 Agents are first-class room members. There are two ways to involve them:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1768,6 +1768,27 @@ paths:
       responses:
         '200': { description: Deleted }
 
+  /api/me/agent:
+    get:
+      tags: [Rooms]
+      summary: The caller's personal agent + its DM room (provisioned on first use)
+      operationId: getMyAgent
+      responses:
+        '200':
+          description: Personal agent and DM room id
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  room_id: { type: integer }
+                  agent:
+                    type: object
+                    properties:
+                      user_id: { type: string }
+                      username: { type: string }
+                      display_name: { type: string }
+
   # ── Email (SMTP) settings ────────────────────────────────────────────
   /api/email/settings:
     get:

--- a/internal/server/api_personal_agent_test.go
+++ b/internal/server/api_personal_agent_test.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/simonski/ticket/internal/store"
+)
+
+func TestPersonalAgentEndpointAndDMReply(t *testing.T) {
+	handler, db := testHandler(t)
+	defer db.Close()
+	ctx := context.Background()
+	adminToken := loginToken(t, handler, "admin", "password")
+
+	// GET /api/me/agent provisions the personal agent + DM room.
+	resp := doJSONRequest(t, handler, http.MethodGet, "/api/me/agent", nil, adminToken)
+	if resp.Code != http.StatusOK {
+		t.Fatalf("GET /api/me/agent = %d, body=%s", resp.Code, resp.Body.String())
+	}
+	var payload struct {
+		RoomID int64 `json:"room_id"`
+		Agent  struct {
+			Username string `json:"username"`
+		} `json:"agent"`
+	}
+	decodeResponse(t, resp, &payload)
+	if payload.RoomID == 0 || !strings.Contains(payload.Agent.Username, "assistant") {
+		t.Fatalf("unexpected personal-agent payload: %+v", payload)
+	}
+
+	// Idempotent: a second call returns the same DM room.
+	resp2 := doJSONRequest(t, handler, http.MethodGet, "/api/me/agent", nil, adminToken)
+	var payload2 struct {
+		RoomID int64 `json:"room_id"`
+	}
+	decodeResponse(t, resp2, &payload2)
+	if payload2.RoomID != payload.RoomID {
+		t.Fatalf("second call returned a different DM room (%d != %d)", payload2.RoomID, payload.RoomID)
+	}
+
+	// In the DM, the agent replies to a message with NO @mention (stubbed responder).
+	orig := roomAgentReply
+	roomAgentReply = func(_ context.Context, agentName, _ string, _ []store.RoomMessage) (string, error) {
+		return "hello from " + agentName, nil
+	}
+	defer func() { roomAgentReply = orig }()
+
+	dm, _ := store.GetRoom(ctx, db, payload.RoomID)
+	admin, _ := store.GetUserByUsername(ctx, db, "admin")
+	msg, _ := store.PostRoomMessage(ctx, db, store.RoomMessage{RoomID: dm.ID, SenderID: admin.ID, Body: "are you there?"})
+	if n := replyAsAgents(ctx, db, dm, msg, nil); n != 1 {
+		t.Fatalf("DM auto-reply posted %d, want 1", n)
+	}
+	msgs, _ := store.ListRoomMessages(ctx, db, dm.ID, 50, 0)
+	found := false
+	for _, m := range msgs {
+		if strings.Contains(m.Body, "hello from") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("agent did not reply in the personal-agent DM")
+	}
+}

--- a/internal/server/api_rooms.go
+++ b/internal/server/api_rooms.go
@@ -18,6 +18,28 @@ func (r *router) registerRoomHandlers() {
 	db := r.db
 	mux := r.mux
 
+	// The caller's personal agent (provisioned on first use) + its DM room (TK-142).
+	mux.HandleFunc("/api/me/agent", func(w http.ResponseWriter, req *http.Request) {
+		if req.Method != http.MethodGet {
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+			return
+		}
+		user, err := requireUser(db, req)
+		if err != nil {
+			writeAuthError(w, err)
+			return
+		}
+		agent, dm, eerr := store.EnsurePersonalAgent(req.Context(), db, user)
+		if eerr != nil {
+			writeStoreError(w, eerr)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"room_id": dm.ID,
+			"agent":   map[string]any{"user_id": agent.ID, "username": agent.Username, "display_name": agent.DisplayName},
+		})
+	})
+
 	// Collection: list + create.
 	mux.HandleFunc("/api/rooms", func(w http.ResponseWriter, req *http.Request) {
 		user, err := requireUser(db, req)

--- a/internal/server/room_agent.go
+++ b/internal/server/room_agent.go
@@ -34,32 +34,58 @@ func replyAsAgents(ctx context.Context, db *sql.DB, room store.Room, msg store.R
 		if merr != nil || !member {
 			continue
 		}
-		history, _ := store.ListRoomMessages(ctx, db, room.ID, 20, 0)
-		reply, rerr := roomAgentReply(ctx, agent.Username, msg.Body, history)
-		if rerr != nil {
-			log.Printf("server: room agent %s reply failed: %v", agent.Username, rerr)
-			continue
+		if postAgentReply(ctx, db, room, agent, msg.Body, hub) {
+			posted++
 		}
-		reply = strings.TrimSpace(reply)
-		if reply == "" {
-			continue
-		}
-		out, perr := store.PostRoomMessage(ctx, db, store.RoomMessage{
-			RoomID:   room.ID,
-			SenderID: agent.ID,
-			Kind:     "text",
-			Body:     reply,
-			Attrs:    store.Attrs{"agent": true},
-		})
-		if perr != nil {
-			continue
-		}
-		posted++
-		if hub != nil {
-			hub.broadcastRoomMessage(room.ID, out)
+	}
+	// In a DM (e.g. a user's personal agent), the agent answers every message from
+	// a human — no @mention required (TK-142).
+	if posted == 0 && strings.HasPrefix(room.Slug, "dm-") {
+		if sender, serr := store.GetUserByID(ctx, db, msg.SenderID); serr == nil && sender.UserType != "agent" {
+			members, _ := store.ListRoomMembers(ctx, db, room.ID)
+			for _, m := range members {
+				if m.MemberID == msg.SenderID {
+					continue
+				}
+				agent, gerr := store.GetUserByID(ctx, db, m.MemberID)
+				if gerr != nil || agent.UserType != "agent" {
+					continue
+				}
+				if postAgentReply(ctx, db, room, agent, msg.Body, hub) {
+					posted++
+				}
+			}
 		}
 	}
 	return posted
+}
+
+// postAgentReply generates and posts a single agent reply into the room.
+func postAgentReply(ctx context.Context, db *sql.DB, room store.Room, agent store.User, trigger string, hub *liveHub) bool {
+	history, _ := store.ListRoomMessages(ctx, db, room.ID, 20, 0)
+	reply, rerr := roomAgentReply(ctx, agent.Username, trigger, history)
+	if rerr != nil {
+		log.Printf("server: room agent %s reply failed: %v", agent.Username, rerr)
+		return false
+	}
+	reply = strings.TrimSpace(reply)
+	if reply == "" {
+		return false
+	}
+	out, perr := store.PostRoomMessage(ctx, db, store.RoomMessage{
+		RoomID:   room.ID,
+		SenderID: agent.ID,
+		Kind:     "text",
+		Body:     reply,
+		Attrs:    store.Attrs{"agent": true},
+	})
+	if perr != nil {
+		return false
+	}
+	if hub != nil {
+		hub.broadcastRoomMessage(room.ID, out)
+	}
+	return true
 }
 
 // defaultRoomAgentReply runs the configured chat/agent command one-shot, feeding

--- a/internal/store/personal_agent.go
+++ b/internal/store/personal_agent.go
@@ -1,0 +1,65 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// EnsurePersonalAgent returns the caller's personal agent — creating one owned by
+// them on first use — and the DM room between the two (TK-142). The agent is an
+// ordinary agent user with owner_id set; the DM (slug dm-*) surfaces under the
+// "People & Agents" group. Humans get an agent; agents do not.
+func EnsurePersonalAgent(ctx context.Context, db *sql.DB, owner User) (Agent, Room, error) {
+	if owner.UserType == "agent" {
+		return Agent{}, Room{}, fmt.Errorf("agents do not have a personal agent")
+	}
+	agentID, err := personalAgentID(ctx, db, owner.ID)
+	if err != nil {
+		return Agent{}, Room{}, err
+	}
+	if agentID == "" {
+		created, _, cerr := CreateAgent(ctx, db, "")
+		if cerr != nil {
+			return Agent{}, Room{}, cerr
+		}
+		uname := personalAgentUsername(owner.Username)
+		role := "assistant"
+		if _, uerr := UpdateAgent(ctx, db, created.ID, AgentUpdateParams{Username: &uname, AgentRole: &role}); uerr != nil {
+			return Agent{}, Room{}, uerr
+		}
+		display := owner.Username + "'s agent"
+		if _, derr := db.ExecContext(ctx, `UPDATE users SET owner_id = ?, display_name = ? WHERE user_id = ?`, owner.ID, display, created.ID); derr != nil {
+			return Agent{}, Room{}, derr
+		}
+		agentID = created.ID
+	}
+	agentUser, gerr := GetUserByID(ctx, db, agentID)
+	if gerr != nil {
+		return Agent{}, Room{}, gerr
+	}
+	dm, derr := FindOrCreateDMRoom(ctx, db, owner, agentUser)
+	if derr != nil {
+		return Agent{}, Room{}, derr
+	}
+	return agentUser, dm, nil
+}
+
+func personalAgentID(ctx context.Context, db *sql.DB, ownerID string) (string, error) {
+	var id string
+	err := db.QueryRowContext(ctx, `SELECT user_id FROM users WHERE user_type = 'agent' AND owner_id = ? AND enabled = 1 ORDER BY created_at LIMIT 1`, strings.TrimSpace(ownerID)).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	return id, err
+}
+
+func personalAgentUsername(owner string) string {
+	base := strings.ToLower(strings.TrimSpace(owner))
+	if base == "" {
+		base = "user"
+	}
+	return base + "-assistant"
+}

--- a/internal/store/personal_agent_test.go
+++ b/internal/store/personal_agent_test.go
@@ -1,0 +1,53 @@
+package store
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestEnsurePersonalAgent(t *testing.T) {
+	ctx := context.Background()
+	db := openAccessRoleTestDB(t)
+
+	owner, err := CreateUser(ctx, db, "alice", "password123", "user")
+	if err != nil {
+		t.Fatalf("create owner: %v", err)
+	}
+
+	agent, dm, err := EnsurePersonalAgent(ctx, db, owner)
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	if agent.UserType != "agent" {
+		t.Fatalf("personal agent should be an agent, got %q", agent.UserType)
+	}
+	if agent.Username != "alice-assistant" {
+		t.Fatalf("agent username = %q, want alice-assistant", agent.Username)
+	}
+	if !strings.HasPrefix(dm.Slug, "dm-") {
+		t.Fatalf("DM slug = %q, want a dm- room", dm.Slug)
+	}
+
+	// Idempotent: a second call returns the same agent + DM.
+	agent2, dm2, err := EnsurePersonalAgent(ctx, db, owner)
+	if err != nil {
+		t.Fatalf("ensure 2: %v", err)
+	}
+	if agent2.ID != agent.ID {
+		t.Fatalf("second ensure made a new agent (%s != %s)", agent2.ID, agent.ID)
+	}
+	if dm2.ID != dm.ID {
+		t.Fatalf("second ensure made a new DM (%d != %d)", dm2.ID, dm.ID)
+	}
+
+	// A different user gets their own distinct agent.
+	bob, _ := CreateUser(ctx, db, "bob", "password123", "user")
+	bobAgent, _, err := EnsurePersonalAgent(ctx, db, bob)
+	if err != nil {
+		t.Fatalf("ensure bob: %v", err)
+	}
+	if bobAgent.ID == agent.ID {
+		t.Fatal("bob should get his own agent, not alice's")
+	}
+}

--- a/internal/store/schema_version.go
+++ b/internal/store/schema_version.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	LegacySchemaVersion  = 1
-	CurrentSchemaVersion = 14
+	CurrentSchemaVersion = 15
 	schemaMetaTable      = "schema_meta"
 	schemaVersionKey     = "schema_version"
 	// DefaultBackupRetention is the number of timestamped pre-upgrade backups

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -218,6 +218,7 @@ CREATE TABLE IF NOT EXISTS users (
 	description TEXT NOT NULL DEFAULT '',
 	status TEXT NOT NULL DEFAULT '',
 	last_seen TEXT NOT NULL DEFAULT '',
+	owner_id TEXT NOT NULL DEFAULT '',
 	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -1691,6 +1692,12 @@ CREATE TABLE user_notifications (
 		}
 	}
 
+	// Add owner_id to users — set on personal agents to link them to their owner (TK-142).
+	if !columnExists(ctx, db, "users", "owner_id") {
+		if _, err := db.ExecContext(ctx, `ALTER TABLE users ADD COLUMN owner_id TEXT NOT NULL DEFAULT ''`); err != nil {
+			return err
+		}
+	}
 	// Add agent_role to users (refiner, developer, tester etc.).
 	if !columnExists(ctx, db, "users", "agent_role") {
 		if _, err := db.ExecContext(ctx, `ALTER TABLE users ADD COLUMN agent_role TEXT NOT NULL DEFAULT ''`); err != nil {

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -2257,9 +2257,15 @@
             if (!room.project_id) { return "global"; }
             return room.ticket_id ? "breakout" : "project";
         }
-        // Display label for a room (DMs show the conversation, not the raw name).
+        // Display label for a room. DMs show the other participant(s), not "DM: me, them".
         function roomLabel(room) {
-            return String(room.name || "room");
+            const name = String(room.name || "room");
+            if (room.slug && room.slug.indexOf("dm-") === 0 && name.indexOf("DM: ") === 0) {
+                const me = (state.status && state.status.user && state.status.user.username) || "";
+                const others = name.slice(4).split(", ").filter((n) => n && n.toLowerCase() !== me.toLowerCase());
+                if (others.length) { return others.join(", "); }
+            }
+            return name;
         }
         // @name and #label become highlighted entities in the message feed (S6).
         function highlightRoomText(body) {
@@ -2297,6 +2303,10 @@
                 const proj = (state.projects || []).find((p) => p.id === state.selectedProjectID);
                 const pname = proj ? String(proj.prefix || proj.title || "project").toLowerCase() : "project";
                 tasks.push(apiClient.post("/api/rooms", { name: pname, visibility: "public", project_id: state.selectedProjectID }).catch(() => {}));
+            }
+            // Provision the user's personal agent + its DM (appears under People & Agents).
+            if (!state.rooms.some((r) => roomScope(r) === "people")) {
+                tasks.push(api("/api/me/agent").catch(() => {}));
             }
             if (!tasks.length) { return Promise.resolve(); }
             return Promise.all(tasks).then(() => loadRooms());


### PR DESCRIPTION
Each user gets an auto-provisioned personal agent (owned via users.owner_id, schema v15), surfaced as a DM under People & Agents. Talk to it (queries answered in-thread via the DM auto-reply seam — no @mention needed) and /task to delegate a ticket. Session = the persistent DM thread (richer sessions deferred).

Store (EnsurePersonalAgent) + server (GET /api/me/agent, DM auto-reply) + web (provision on chat open, friendly DM labels) + docs. Tests + real-server smoke + site2 chat green.

refs TK-142