### PR TITLE
TK-147: surface agent reply failures in-room

### DIFF
--- a/internal/server/room_agent.go
+++ b/internal/server/room_agent.go
@@ -66,6 +66,10 @@ func postAgentReply(ctx context.Context, db *sql.DB, room store.Room, agent stor
 	reply, rerr := roomAgentReply(ctx, agent.Username, trigger, history)
 	if rerr != nil {
 		log.Printf("server: room agent %s reply failed: %v", agent.Username, rerr)
+		// Surface the failure in the room so the user isn't left wondering why
+		// nothing happened; the detailed error stays in the server log.
+		postAgentNotice(ctx, db, room, agent,
+			"couldn't reply — the agent command failed. Check the server's chat command / model (TICKET_CHAT_CMD) and the server logs.", hub)
 		return false
 	}
 	reply = strings.TrimSpace(reply)
@@ -86,6 +90,24 @@ func postAgentReply(ctx context.Context, db *sql.DB, room store.Room, agent stor
 		hub.broadcastRoomMessage(room.ID, out)
 	}
 	return true
+}
+
+// postAgentNotice posts a muted agent_event line (e.g. a reply failure) into the
+// room from the agent, so failures are visible rather than silent.
+func postAgentNotice(ctx context.Context, db *sql.DB, room store.Room, agent store.User, text string, hub *liveHub) {
+	out, err := store.PostRoomMessage(ctx, db, store.RoomMessage{
+		RoomID:   room.ID,
+		SenderID: agent.ID,
+		Kind:     "agent_event",
+		Body:     "⚠️ " + text,
+		Attrs:    store.Attrs{"agent": true},
+	})
+	if err != nil {
+		return
+	}
+	if hub != nil {
+		hub.broadcastRoomMessage(room.ID, out)
+	}
 }
 
 // defaultRoomAgentReply runs the configured chat/agent command one-shot, feeding

--- a/internal/server/room_agent_test.go
+++ b/internal/server/room_agent_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -56,6 +57,44 @@ func TestReplyAsAgentsPostsAgentReply(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("agent reply not posted into the room; messages=%+v", msgs)
+	}
+}
+
+func TestReplyAsAgentsPostsNoticeOnFailure(t *testing.T) {
+	_, db := testHandler(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	agent, _, err := store.CreateAgent(ctx, db, "")
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	uname := "helper"
+	if _, uerr := store.UpdateAgent(ctx, db, agent.ID, store.AgentUpdateParams{Username: &uname}); uerr != nil {
+		t.Fatalf("rename agent: %v", uerr)
+	}
+	room, _ := store.CreateRoom(ctx, db, store.Room{Name: "Help", CreatedBy: "admin"})
+	_ = store.JoinRoom(ctx, db, room.ID, agent.ID, "member")
+
+	// The agent command fails.
+	orig := roomAgentReply
+	roomAgentReply = func(_ context.Context, _, _ string, _ []store.RoomMessage) (string, error) {
+		return "", errors.New("exit status 1: model not supported")
+	}
+	defer func() { roomAgentReply = orig }()
+
+	msg, _ := store.PostRoomMessage(ctx, db, store.RoomMessage{RoomID: room.ID, SenderID: "u1", Body: "hey @helper?"})
+	replyAsAgents(ctx, db, room, msg, nil)
+
+	msgs, _ := store.ListRoomMessages(ctx, db, room.ID, 50, 0)
+	notice := false
+	for _, m := range msgs {
+		if m.SenderID == agent.ID && m.Kind == "agent_event" && strings.Contains(m.Body, "couldn't reply") {
+			notice = true
+		}
+	}
+	if !notice {
+		t.Fatalf("a failed agent reply should post an in-room notice; messages=%+v", msgs)
 	}
 }
 


### PR DESCRIPTION
A failed chat/agent command (e.g. codex non-zero) was only logged to the server terminal, so the room showed nothing. Now post a muted agent_event notice in the room; detailed error stays in the log. Test added. refs TK-147