### PR TITLE
TK-148: single-project view + flatten detail panels

### DIFF
--- a/tests/playwright/site2.spec.js
+++ b/tests/playwright/site2.spec.js
@@ -1457,7 +1457,7 @@ test("remembers active panel and scroll position after refresh", async ({ page }
   await page.getByRole("button", { name: "Sign in" }).click();
   await expect(page.getByRole("heading", { name: "Board" })).toBeVisible();
 
-  await page.getByRole("button", { name: "Projects" }).click();
+  await page.locator('#main-nav button[data-view="projects"]').click();
   await page.evaluate(() => {
     document.body.style.minHeight = "3000px";
     window.scrollTo(0, 420);
@@ -1492,7 +1492,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("creates a project and persists default draft settings through the existing API", async ({ page }) => {
-  await page.getByRole("button", { name: "Projects" }).click();
+  await page.locator('#main-nav button[data-view="projects"]').click();
   await page.getByRole("button", { name: "New project" }).click();
   await expect(page.locator("#project-prefix")).toHaveAttribute("maxlength", "5");
   await page.locator("#project-prefix").fill("WEB");
@@ -1500,7 +1500,7 @@ test("creates a project and persists default draft settings through the existing
   await page.locator("#project-default-draft").selectOption("true");
   await page.getByRole("button", { name: "Save project" }).click();
 
-  await expect(page.locator("#project-list")).toContainText("Website");
+  await expect(page.locator("#project-title")).toHaveValue("Website");
 
   const requests = await page.evaluate(() => window.__site2Requests);
   expect(requests).toEqual(
@@ -1512,7 +1512,7 @@ test("creates a project and persists default draft settings through the existing
 });
 
 test("submits a project access request from the Projects view", async ({ page }) => {
-  await page.getByRole("button", { name: "Projects" }).click();
+  await page.locator('#main-nav button[data-view="projects"]').click();
   await page.locator("#project-request-access-ref").fill("GATE");
   await page.locator("#project-request-access-message").fill("please add me");
   await page.getByRole("button", { name: "Request access" }).click();
@@ -1583,7 +1583,7 @@ test("shows recent project history in the Projects view", async ({ page }) => {
   await page.locator("#login-password").fill("secret");
   await page.getByRole("button", { name: "Sign in" }).click();
   await expect(page.getByRole("heading", { name: "Board" })).toBeVisible();
-  await page.getByRole("button", { name: "Projects" }).click();
+  await page.locator('#main-nav button[data-view="projects"]').click();
 
   await expect(page.locator("#project-history-list")).toContainText("alice requested access to OPS");
   await expect(page.locator("#project-history-list")).toContainText("approved access request #7 for alice on OPS");
@@ -1623,7 +1623,7 @@ test("marks notifications as read from the Projects view", async ({ page }) => {
   await page.locator("#login-password").fill("secret");
   await page.getByRole("button", { name: "Sign in" }).click();
   await expect(page.getByRole("heading", { name: "Board" })).toBeVisible();
-  await page.getByRole("button", { name: "Projects" }).click();
+  await page.locator('#main-nav button[data-view="projects"]').click();
 
   await expect(page.locator("#project-notifications-list")).toContainText("Project access approved");
   await page.getByRole("button", { name: "Mark read" }).click();

--- a/web/default/index.html
+++ b/web/default/index.html
@@ -640,14 +640,10 @@
                 <!-- Projects -->
                 <section id="view-projects" class="view">
                     <div class="view-header">
-                        <div><h1>Projects</h1><p class="meta">Manage projects and their settings.</p></div>
+                        <div><h1>Project</h1><p class="meta">The current project — switch projects from the dropdown above.</p></div>
                         <div class="view-actions">
                             <button id="new-project-button" class="btn btn-primary" type="button">New project</button>
                         </div>
-                    </div>
-                    <div class="view-split">
-                    <div class="card">
-                        <div id="project-list" class="item-list"></div>
                     </div>
                     <div class="card">
                         <div class="card-header">
@@ -765,7 +761,6 @@
                             <div id="project-notifications-list" class="item-list"></div>
                         </div>
                     </div>
-                    </div><!-- /view-split -->
                 </section>
 
                 <!-- Workflows -->

--- a/web/default/site.css
+++ b/web/default/site.css
@@ -2094,3 +2094,21 @@ select {
 #view-chat button.chat-room-group:hover { opacity: 0.85; }
 #view-chat .chat-group-caret { font-size: 10px; opacity: 0.7; width: 12px; display: inline-block; }
 #view-chat .chat-room-group .chat-unread-badge { margin-left: auto; }
+
+/* Detail panels fill the panel space without a floating-card border (TK). */
+.view > .card,
+.view-split > .card,
+.view.split > .card:last-child,
+.settings-panel > .card {
+    border: none;
+    box-shadow: none;
+    border-radius: 0;
+    background: transparent;
+}
+/* Single-detail views and split detail panes fill the available height. */
+#view-projects > .card,
+.view.split > .card:last-child,
+.view-split > .card:last-child {
+    flex: 1;
+    min-height: 0;
+}

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -119,7 +119,7 @@
         const NAV_ORDER_STORAGE_KEY = "site2.navOrder";
         const NAV_ITEMS = [
             { view: "tickets", label: "Board", section: "general", icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M4 7h16\"></path><path d=\"M4 12h16\"></path><path d=\"M4 17h10\"></path></svg>" },
-            { view: "projects", label: "Projects", section: "general", icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M3 7h18\"></path><path d=\"M6 7v10\"></path><path d=\"M12 7v10\"></path><path d=\"M18 7v10\"></path><path d=\"M3 17h18\"></path></svg>" },
+            { view: "projects", label: "Project", section: "general", icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M3 7h18\"></path><path d=\"M6 7v10\"></path><path d=\"M12 7v10\"></path><path d=\"M18 7v10\"></path><path d=\"M3 17h18\"></path></svg>" },
             { view: "chat", label: "Chat", section: "general", icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M4 5h16v11H7l-3 3z\"></path><path d=\"M8 9h8\"></path><path d=\"M8 12h5\"></path></svg>" },
             { view: "interventions", label: "Mailbox", section: "general", icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M12 4v8\"></path><path d=\"M12 16h.01\"></path><circle cx=\"12\" cy=\"12\" r=\"9\"></circle></svg>" },
             { view: "workflows", label: "Workflows", section: "process", icon: "<svg viewBox=\"0 0 24 24\" aria-hidden=\"true\"><path d=\"M5 6h14\"></path><path d=\"M5 12h9\"></path><path d=\"M5 18h14\"></path><path d=\"M17 10l2 2-2 2\"></path></svg>" },
@@ -3016,27 +3016,15 @@
         }
 
         function renderProjects() {
-            if (!state.projects.length) {
-                els.projectList.innerHTML = "<div class=\"empty\">No projects yet.</div>";
-                return;
+            // Single-project view (no list): the editor reflects the project chosen
+            // in the top-bar dropdown. Switching projects there re-syncs it.
+            const cur = getCurrentProject();
+            if (cur && (!state.selectedProjectDraft || state.selectedProjectDraft.id !== cur.id)) {
+                state.selectedProjectDraft = structuredClone(cur);
+            } else if (!state.selectedProjectDraft) {
+                state.selectedProjectDraft = emptyProject();
             }
-            const defaultProjectID = currentDefaultProjectID();
-            els.projectList.innerHTML = state.projects.map((project) => {
-                const active = project.id === state.selectedProjectID ? " active" : "";
-                const isDefault = project.id === defaultProjectID;
-                const defaultChip = isDefault ? "<span class=\"chip\">default</span>" : "";
-                const defaultButton = "<button type=\"button\" class=\"btn-ghost\" data-project-default-id=\"" + project.id + "\">" + (isDefault ? "Clear default" : "Set default") + "</button>";
-                return "<div class=\"entity-card" + active + "\" data-project-id=\"" + project.id + "\">" +
-                    "<h4>" + escapeHTML(project.title) + " <small>(" + escapeHTML(project.prefix) + ")</small></h4>" +
-                    "<p>" + escapeHTML(project.description || "No description") + "</p>" +
-                    "<div class=\"tag-row tag-row-spaced\">" +
-                    "<span class=\"chip\">" + escapeHTML(project.visibility || "public") + "</span>" +
-                    "<span class=\"chip\">requests " + (project.accepts_new_members ? "open" : "closed") + "</span>" +
-                    "<span class=\"chip\">draft " + String(Boolean(project.default_draft)) + "</span>" +
-                    defaultChip +
-                    defaultButton +
-                    "</div></div>";
-            }).join("");
+            renderProjectEditor();
         }
 
         function renderPlans() {
@@ -5625,6 +5613,7 @@
         }
 
         function bindProjectHandlers() {
+            if (els.projectList) {
             els.projectList.addEventListener("click", (event) => {
                 const defaultButton = event.target.closest("[data-project-default-id]");
                 if (defaultButton) {
@@ -5659,6 +5648,7 @@
                 populateTicketTypeAndStageSelects();
                 Promise.all([loadProjectAgentModelConfig(), loadTickets(), loadReleases(), loadDocuments(), loadProjectAccessRequests(), loadProjectHistory(), loadMyProjectAccessRequests(), loadMyNotifications(), loadProjectAgents()]).then(renderAll).catch((error) => setNotice(error.message, true));
             });
+            }
 
             document.getElementById("new-project-button").addEventListener("click", () => {
                 state.selectedProjectID = null;


### PR DESCRIPTION
Projects tab -> Project, showing only the dropdown-selected project (no list). Detail panels flattened to fill their space (no floating-card border). Guarded the dead project-list handler that was aborting event wiring. site2 tests updated; full suite green. refs TK-148