### PR TITLE
TK-149: layered agent-model resolution + direct provider API

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1789,6 +1789,30 @@ paths:
                       username: { type: string }
                       display_name: { type: string }
 
+  /api/me/agent-model:
+    get:
+      tags: [Rooms]
+      summary: The caller's per-user agent-model overrides
+      operationId: getMyAgentModel
+      responses:
+        '200': { description: Per-user overrides (empty fields inherit project/system) }
+    put:
+      tags: [Rooms]
+      summary: Set the caller's per-user agent-model overrides
+      operationId: setMyAgentModel
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                provider: { type: string }
+                model: { type: string }
+                url: { type: string }
+                api_key: { type: string }
+      responses:
+        '200': { description: Saved per-user overrides }
+
   # ── Email (SMTP) settings ────────────────────────────────────────────
   /api/email/settings:
     get:

--- a/internal/server/agent_model_api.go
+++ b/internal/server/agent_model_api.go
@@ -1,0 +1,134 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/simonski/ticket/internal/store"
+)
+
+// agentModelCanCallAPI reports whether the resolved config points at an HTTP API
+// (vs a CLI provider, which has no base URL). API providers carry a base_url and
+// an API key.
+func agentModelCanCallAPI(cfg store.AgentModelConfig) bool {
+	return strings.TrimSpace(cfg.URL) != "" && strings.TrimSpace(cfg.APIKey) != "" && strings.TrimSpace(cfg.Model) != ""
+}
+
+// callAgentModelAPI sends a single-prompt completion request to the configured
+// provider (Anthropic Messages API, or an OpenAI-compatible /chat/completions
+// endpoint) and returns the assistant's text (TK-149).
+func callAgentModelAPI(ctx context.Context, cfg store.AgentModelConfig, prompt string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 120*time.Second)
+	defer cancel()
+	if strings.EqualFold(cfg.Provider, "anthropic") || strings.Contains(strings.ToLower(cfg.URL), "anthropic") {
+		return callAnthropic(ctx, cfg, prompt)
+	}
+	return callOpenAICompatible(ctx, cfg, prompt)
+}
+
+func httpJSON(ctx context.Context, method, url string, headers map[string]string, body any) ([]byte, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode >= 400 {
+		return out, fmt.Errorf("%s %s -> %d: %s", method, url, resp.StatusCode, strings.TrimSpace(string(out)))
+	}
+	return out, nil
+}
+
+func callAnthropic(ctx context.Context, cfg store.AgentModelConfig, prompt string) (string, error) {
+	base := strings.TrimRight(strings.TrimSpace(cfg.URL), "/")
+	if base == "" {
+		base = "https://api.anthropic.com"
+	}
+	url := base
+	if !strings.HasSuffix(url, "/v1/messages") {
+		url += "/v1/messages"
+	}
+	body := map[string]any{
+		"model":      cfg.Model,
+		"max_tokens": 1024,
+		"messages":   []map[string]any{{"role": "user", "content": prompt}},
+	}
+	out, err := httpJSON(ctx, http.MethodPost, url, map[string]string{
+		"x-api-key":         cfg.APIKey,
+		"anthropic-version": "2023-06-01",
+	}, body)
+	if err != nil {
+		return "", err
+	}
+	var parsed struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if jerr := json.Unmarshal(out, &parsed); jerr != nil {
+		return "", jerr
+	}
+	var b strings.Builder
+	for _, c := range parsed.Content {
+		if c.Type == "text" {
+			b.WriteString(c.Text)
+		}
+	}
+	return strings.TrimSpace(b.String()), nil
+}
+
+func callOpenAICompatible(ctx context.Context, cfg store.AgentModelConfig, prompt string) (string, error) {
+	base := strings.TrimRight(strings.TrimSpace(cfg.URL), "/")
+	if base == "" {
+		base = "https://api.openai.com/v1"
+	}
+	url := base
+	if !strings.HasSuffix(url, "/chat/completions") {
+		url += "/chat/completions"
+	}
+	body := map[string]any{
+		"model":    cfg.Model,
+		"messages": []map[string]any{{"role": "user", "content": prompt}},
+	}
+	headers := map[string]string{}
+	if strings.TrimSpace(cfg.APIKey) != "" {
+		headers["Authorization"] = "Bearer " + cfg.APIKey
+	}
+	out, err := httpJSON(ctx, http.MethodPost, url, headers, body)
+	if err != nil {
+		return "", err
+	}
+	var parsed struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if jerr := json.Unmarshal(out, &parsed); jerr != nil {
+		return "", jerr
+	}
+	if len(parsed.Choices) == 0 {
+		return "", fmt.Errorf("model returned no choices")
+	}
+	return strings.TrimSpace(parsed.Choices[0].Message.Content), nil
+}

--- a/internal/server/api_personal_agent_test.go
+++ b/internal/server/api_personal_agent_test.go
@@ -43,7 +43,7 @@ func TestPersonalAgentEndpointAndDMReply(t *testing.T) {
 
 	// In the DM, the agent replies to a message with NO @mention (stubbed responder).
 	orig := roomAgentReply
-	roomAgentReply = func(_ context.Context, agentName, _ string, _ []store.RoomMessage) (string, error) {
+	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, agentName, _ string, _ []store.RoomMessage) (string, error) {
 		return "hello from " + agentName, nil
 	}
 	defer func() { roomAgentReply = orig }()
@@ -63,5 +63,21 @@ func TestPersonalAgentEndpointAndDMReply(t *testing.T) {
 	}
 	if !found {
 		t.Fatal("agent did not reply in the personal-agent DM")
+	}
+}
+
+func TestUserAgentModelEndpoint(t *testing.T) {
+	handler, db := testHandler(t)
+	defer db.Close()
+	tok := loginToken(t, handler, "admin", "password")
+
+	if r := doJSONRequest(t, handler, http.MethodPut, "/api/me/agent-model", map[string]any{"provider": "anthropic", "model": "claude-x"}, tok); r.Code != http.StatusOK {
+		t.Fatalf("PUT /api/me/agent-model = %d, body=%s", r.Code, r.Body.String())
+	}
+	g := doJSONRequest(t, handler, http.MethodGet, "/api/me/agent-model", nil, tok)
+	var cfg store.AgentModelConfig
+	decodeResponse(t, g, &cfg)
+	if cfg.Provider != "anthropic" || cfg.Model != "claude-x" {
+		t.Fatalf("per-user config not persisted: %+v", cfg)
 	}
 }

--- a/internal/server/api_system.go
+++ b/internal/server/api_system.go
@@ -351,6 +351,43 @@ func (r *router) registerSystemHandlers() {
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 		}
 	})
+	// Per-user agent-model overrides (TK-149): GET returns the caller's overrides,
+	// PUT replaces them. These override the project and system config at resolve time.
+	mux.HandleFunc("/api/me/agent-model", func(w http.ResponseWriter, r *http.Request) {
+		user, err := requireUser(db, r)
+		if err != nil {
+			writeAuthError(w, err)
+			return
+		}
+		switch r.Method {
+		case http.MethodGet:
+			cfg, gerr := store.UserAgentModelConfig(r.Context(), db, user.ID)
+			if gerr != nil {
+				writeStoreError(w, gerr)
+				return
+			}
+			writeJSON(w, http.StatusOK, cfg)
+		case http.MethodPut:
+			var payload agentModelConfigRequest
+			if derr := json.NewDecoder(r.Body).Decode(&payload); derr != nil {
+				writeError(w, http.StatusBadRequest, "invalid json body")
+				return
+			}
+			if serr := store.SetUserAgentModelConfig(r.Context(), db, user.ID, store.AgentModelConfig{
+				Provider: payload.Provider,
+				Model:    payload.Model,
+				URL:      payload.URL,
+				APIKey:   payload.APIKey,
+			}); serr != nil {
+				writeStoreError(w, serr)
+				return
+			}
+			cfg, _ := store.UserAgentModelConfig(r.Context(), db, user.ID)
+			writeJSON(w, http.StatusOK, cfg)
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+	})
 	mux.HandleFunc("/api/config/settings", func(w http.ResponseWriter, r *http.Request) {
 		if _, err := requireAdmin(db, r); err != nil {
 			writeAuthError(w, err)

--- a/internal/server/room_agent.go
+++ b/internal/server/room_agent.go
@@ -16,7 +16,7 @@ import (
 // roomAgentResponder generates an agent's reply to a room prompt. It is a
 // package var so tests can inject a deterministic stub; the default runs the
 // configured chat/agent command one-shot (TK-131).
-type roomAgentResponder func(ctx context.Context, agentName, prompt string, history []store.RoomMessage) (string, error)
+type roomAgentResponder func(ctx context.Context, cfg store.AgentModelConfig, agentName, prompt string, history []store.RoomMessage) (string, error)
 
 var roomAgentReply roomAgentResponder = defaultRoomAgentReply
 
@@ -34,7 +34,7 @@ func replyAsAgents(ctx context.Context, db *sql.DB, room store.Room, msg store.R
 		if merr != nil || !member {
 			continue
 		}
-		if postAgentReply(ctx, db, room, agent, msg.Body, hub) {
+		if postAgentReply(ctx, db, room, agent, msg.SenderID, msg.Body, hub) {
 			posted++
 		}
 	}
@@ -51,7 +51,7 @@ func replyAsAgents(ctx context.Context, db *sql.DB, room store.Room, msg store.R
 				if gerr != nil || agent.UserType != "agent" {
 					continue
 				}
-				if postAgentReply(ctx, db, room, agent, msg.Body, hub) {
+				if postAgentReply(ctx, db, room, agent, msg.SenderID, msg.Body, hub) {
 					posted++
 				}
 			}
@@ -60,10 +60,12 @@ func replyAsAgents(ctx context.Context, db *sql.DB, room store.Room, msg store.R
 	return posted
 }
 
-// postAgentReply generates and posts a single agent reply into the room.
-func postAgentReply(ctx context.Context, db *sql.DB, room store.Room, agent store.User, trigger string, hub *liveHub) bool {
+// postAgentReply generates and posts a single agent reply into the room. The
+// model is resolved for the requesting user in the room's project (TK-149).
+func postAgentReply(ctx context.Context, db *sql.DB, room store.Room, agent store.User, requesterID, trigger string, hub *liveHub) bool {
+	cfg, _ := store.ResolveAgentModelConfig(ctx, db, requesterID, room.ProjectID)
 	history, _ := store.ListRoomMessages(ctx, db, room.ID, 20, 0)
-	reply, rerr := roomAgentReply(ctx, agent.Username, trigger, history)
+	reply, rerr := roomAgentReply(ctx, cfg, agent.Username, trigger, history)
 	if rerr != nil {
 		log.Printf("server: room agent %s reply failed: %v", agent.Username, rerr)
 		// Surface the failure in the room so the user isn't left wondering why
@@ -114,15 +116,22 @@ func postAgentNotice(ctx context.Context, db *sql.DB, room store.Room, agent sto
 // it a prompt built from the room transcript, and returns its stdout. Requires
 // the agent runtime to be configured; otherwise it returns an error and no reply
 // is posted.
-func defaultRoomAgentReply(_ context.Context, agentName, prompt string, history []store.RoomMessage) (string, error) {
+func defaultRoomAgentReply(ctx context.Context, cfg store.AgentModelConfig, agentName, prompt string, history []store.RoomMessage) (string, error) {
+	full := buildRoomAgentPrompt(agentName, prompt, history)
+	// When a provider API is configured (resolved per user/project/system), call
+	// it directly; otherwise fall back to the configured CLI command (TK-149).
+	if agentModelCanCallAPI(cfg) {
+		log.Printf("server: agent %s replying via %s model %q (api)", agentName, cfg.Provider, cfg.Model)
+		return callAgentModelAPI(ctx, cfg, full)
+	}
 	commandArgs := resolveChatCommandArgs()
 	if len(commandArgs) == 0 {
 		return "", errors.New("chat agent command is empty")
 	}
-	full := buildRoomAgentPrompt(agentName, prompt, history)
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	log.Printf("server: agent %s replying via CLI %v", agentName, commandArgs)
+	cctx, cancel := context.WithTimeout(ctx, 120*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, commandArgs[0], commandArgs[1:]...) // #nosec G204 -- commandArgs resolved from trusted server configuration
+	cmd := exec.CommandContext(cctx, commandArgs[0], commandArgs[1:]...) // #nosec G204 -- commandArgs resolved from trusted server configuration
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/server/room_agent_test.go
+++ b/internal/server/room_agent_test.go
@@ -34,7 +34,7 @@ func TestReplyAsAgentsPostsAgentReply(t *testing.T) {
 
 	// Stub the responder so the test is deterministic and offline.
 	orig := roomAgentReply
-	roomAgentReply = func(_ context.Context, agentName, prompt string, _ []store.RoomMessage) (string, error) {
+	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, agentName, prompt string, _ []store.RoomMessage) (string, error) {
 		return "On it — " + agentName + " here", nil
 	}
 	defer func() { roomAgentReply = orig }()
@@ -78,7 +78,7 @@ func TestReplyAsAgentsPostsNoticeOnFailure(t *testing.T) {
 
 	// The agent command fails.
 	orig := roomAgentReply
-	roomAgentReply = func(_ context.Context, _, _ string, _ []store.RoomMessage) (string, error) {
+	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, _, _ string, _ []store.RoomMessage) (string, error) {
 		return "", errors.New("exit status 1: model not supported")
 	}
 	defer func() { roomAgentReply = orig }()
@@ -106,7 +106,7 @@ func TestReplyAsAgentsIgnoresNonAgentAndNonMember(t *testing.T) {
 
 	called := false
 	orig := roomAgentReply
-	roomAgentReply = func(_ context.Context, _, _ string, _ []store.RoomMessage) (string, error) {
+	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, _, _ string, _ []store.RoomMessage) (string, error) {
 		called = true
 		return "should not happen", nil
 	}

--- a/internal/store/agent_model_resolve.go
+++ b/internal/store/agent_model_resolve.go
@@ -1,0 +1,109 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"strconv"
+	"strings"
+)
+
+// Agent-model configuration resolves in layers (TK-149): per-user overrides
+// per-project overrides the system config, which itself carries the built-in
+// default. Empty fields at a layer fall through to the next.
+
+func userAgentModelKey(userID, field string) string {
+	return "agent_model_user_" + strings.TrimSpace(userID) + "_" + field
+}
+
+// UserAgentModelConfig returns a user's per-user overrides (empty = not set).
+func UserAgentModelConfig(ctx context.Context, db *sql.DB, userID string) (AgentModelConfig, error) {
+	var cfg AgentModelConfig
+	fields := []struct {
+		field string
+		dst   *string
+	}{
+		{"provider", &cfg.Provider}, {"name", &cfg.Model}, {"url", &cfg.URL}, {"api_key", &cfg.APIKey},
+	}
+	for _, f := range fields {
+		v, err := getAppSettingValue(ctx, db, userAgentModelKey(userID, f.field))
+		if err != nil {
+			return cfg, err
+		}
+		*f.dst = v
+	}
+	return cfg, nil
+}
+
+// SetUserAgentModelConfig stores a user's per-user overrides.
+func SetUserAgentModelConfig(ctx context.Context, db *sql.DB, userID string, cfg AgentModelConfig) error {
+	pairs := []struct{ field, val string }{
+		{"provider", cfg.Provider}, {"name", cfg.Model}, {"url", cfg.URL}, {"api_key", cfg.APIKey},
+	}
+	for _, p := range pairs {
+		if err := SetAppSetting(ctx, db, userAgentModelKey(userID, p.field), strings.TrimSpace(p.val)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func overlayAgentModel(base *AgentModelConfig, o AgentModelConfig) {
+	if strings.TrimSpace(o.Provider) != "" {
+		base.Provider = o.Provider
+	}
+	if strings.TrimSpace(o.Model) != "" {
+		base.Model = o.Model
+	}
+	if strings.TrimSpace(o.URL) != "" {
+		base.URL = o.URL
+	}
+	if strings.TrimSpace(o.APIKey) != "" {
+		base.APIKey = o.APIKey
+	}
+}
+
+// ResolveAgentModelConfig computes the effective agent-model config for a user
+// working in a project: system (with built-in default + provider list) overlaid
+// by the project, overlaid by the user. The API key falls back to the matching
+// provider entry's stored key when not set explicitly.
+func ResolveAgentModelConfig(ctx context.Context, db *sql.DB, userID string, projectID *int64) (AgentModelConfig, error) {
+	cfg, err := SystemAgentModelConfig(ctx, db)
+	if err != nil {
+		return cfg, err
+	}
+	if projectID != nil {
+		if proj, perr := GetProject(ctx, db, strconv.FormatInt(*projectID, 10)); perr == nil {
+			overlayAgentModel(&cfg, AgentModelConfig{
+				Provider: proj.AgentModelProvider,
+				Model:    proj.AgentModelName,
+				URL:      proj.AgentModelURL,
+				APIKey:   proj.AgentModelAPIKey,
+			})
+		}
+	}
+	if strings.TrimSpace(userID) != "" {
+		uc, uerr := UserAgentModelConfig(ctx, db, userID)
+		if uerr != nil {
+			return cfg, uerr
+		}
+		overlayAgentModel(&cfg, uc)
+	}
+	// Fall back to the configured provider's stored key/URL when not set inline.
+	if strings.TrimSpace(cfg.APIKey) == "" || strings.TrimSpace(cfg.URL) == "" {
+		for _, p := range cfg.Providers {
+			if p.ID == cfg.Provider {
+				if strings.TrimSpace(cfg.APIKey) == "" {
+					cfg.APIKey = p.APIKey
+				}
+				if strings.TrimSpace(cfg.URL) == "" {
+					cfg.URL = p.BaseURL
+				}
+				if strings.TrimSpace(cfg.Model) == "" {
+					cfg.Model = p.DefaultModel
+				}
+				break
+			}
+		}
+	}
+	return cfg, nil
+}

--- a/internal/store/agent_model_resolve_test.go
+++ b/internal/store/agent_model_resolve_test.go
@@ -1,0 +1,44 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+func TestResolveAgentModelConfigLayers(t *testing.T) {
+	ctx := context.Background()
+	db := openAccessRoleTestDB(t)
+
+	// Built-in system default.
+	cfg, err := ResolveAgentModelConfig(ctx, db, "u1", nil)
+	if err != nil {
+		t.Fatalf("resolve default: %v", err)
+	}
+	if cfg.Provider != DefaultAgentModelProvider || cfg.Model != DefaultAgentModelName {
+		t.Fatalf("default resolve = %+v, want %s/%s", cfg, DefaultAgentModelProvider, DefaultAgentModelName)
+	}
+
+	// System override.
+	if err := SetSystemAgentModelConfig(ctx, db, AgentModelConfig{Provider: "anthropic", Model: "claude-sys", URL: "https://api.anthropic.com", APIKey: "sys-key"}); err != nil {
+		t.Fatalf("set system: %v", err)
+	}
+	cfg, _ = ResolveAgentModelConfig(ctx, db, "u1", nil)
+	if cfg.Provider != "anthropic" || cfg.Model != "claude-sys" || cfg.APIKey != "sys-key" {
+		t.Fatalf("system override = %+v", cfg)
+	}
+
+	// Per-user override only changes the fields it sets (model), inheriting the rest.
+	if err := SetUserAgentModelConfig(ctx, db, "u1", AgentModelConfig{Model: "claude-user"}); err != nil {
+		t.Fatalf("set user: %v", err)
+	}
+	cfg, _ = ResolveAgentModelConfig(ctx, db, "u1", nil)
+	if cfg.Model != "claude-user" || cfg.Provider != "anthropic" || cfg.APIKey != "sys-key" {
+		t.Fatalf("user override = %+v, want model claude-user inheriting provider/key", cfg)
+	}
+
+	// A different user without overrides still sees the system config.
+	other, _ := ResolveAgentModelConfig(ctx, db, "u2", nil)
+	if other.Model != "claude-sys" {
+		t.Fatalf("u2 should inherit system model, got %q", other.Model)
+	}
+}


### PR DESCRIPTION
Chat/agent replies now use a configured model instead of always shelling to codex.

- Resolution: per-user > per-project > system > built-in default (per-user added; project/system existed).
- Direct API: Anthropic Messages + OpenAI-compatible /chat/completions; falls back to the CLI command when no provider URL+key is configured. Logs the path + provider/model (so server activity is visible).
- GET/PUT /api/me/agent-model for per-user overrides.

Tests + lint + server/store suites green; OpenAPI updated. UI for per-user selection is a follow-up.

refs TK-149