### PR TITLE
TK-151: AI provider/model default selectors (system + project) + label fix

### DIFF
--- a/web/default/index.html
+++ b/web/default/index.html
@@ -251,6 +251,28 @@
                                 </div>
                             </form>
                         </div>
+                        <div class="card">
+                            <div class="card-header">
+                                <div>
+                                    <h2>Default model</h2>
+                                    <p class="meta">The system-wide default AI provider and model. Projects and users can override it.</p>
+                                </div>
+                            </div>
+                            <div class="field-row">
+                                <div class="field">
+                                    <label for="system-agent-provider">AI provider</label>
+                                    <select id="system-agent-provider"></select>
+                                </div>
+                                <div class="field">
+                                    <label for="system-agent-model">Default model</label>
+                                    <select id="system-agent-model"></select>
+                                </div>
+                            </div>
+                            <p class="meta">Resolved: <span id="resolved-agent-provider"></span> / <span id="resolved-agent-model"></span></p>
+                            <div class="form-actions">
+                                <button id="save-system-agent-model" class="btn btn-primary" type="button">Save default model</button>
+                            </div>
+                        </div>
                     </div>
 
                     <div class="settings-panel" data-settings-panel="plans">
@@ -671,7 +693,7 @@
                                     </select>
                                 </div>
                                 <div class="field">
-                                    <label for="project-default-draft">Default draft</label>
+                                    <label for="project-default-draft">New tickets start in draft</label>
                                     <select id="project-default-draft">
                                         <option value="false">false</option>
                                         <option value="true">true</option>
@@ -680,6 +702,20 @@
                                 <div class="field">
                                     <label for="project-workflow">Default workflow</label>
                                     <select id="project-workflow"></select>
+                                </div>
+                                <div class="field-row">
+                                    <div class="field">
+                                        <label for="project-agent-provider">AI provider (default model)</label>
+                                        <select id="project-agent-provider"></select>
+                                    </div>
+                                    <div class="field">
+                                        <label for="project-agent-model">Default model</label>
+                                        <select id="project-agent-model"></select>
+                                    </div>
+                                </div>
+                                <div class="form-actions">
+                                    <button id="save-project-agent-model" class="btn" type="button">Save model</button>
+                                    <button id="clear-project-agent-model" class="btn btn-ghost" type="button">Use system default</button>
                                 </div>
                                 <div class="field">
                                     <label for="project-orchestrator-enabled">Orchestrator</label>

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -275,7 +275,9 @@
             addTicketTimeButton: document.getElementById("add-ticket-time-button"),
             agentHarnessSummary: document.getElementById("agent-harness-summary"),
             systemAgentProvider: document.getElementById("system-agent-provider"),
+            systemAgentModel: document.getElementById("system-agent-model"),
             projectAgentProvider: document.getElementById("project-agent-provider"),
+            projectAgentModel: document.getElementById("project-agent-model"),
             resolvedAgentProvider: document.getElementById("resolved-agent-provider"),
             resolvedAgentModel: document.getElementById("resolved-agent-model"),
             resolvedAgentURL: document.getElementById("resolved-agent-url"),
@@ -5958,17 +5960,19 @@
                 };
             }
 
+            // On provider change, repopulate that scope's model dropdown from the
+            // SELECTED provider (not the saved state, which would clobber the choice).
+            const onProviderChange = (scope, providerEl, modelEl, includeInherit) => {
+                const pid = String(providerEl.value || "").trim();
+                const provider = providerByID(pid);
+                renderModelSelect(modelEl, pid, provider ? provider.default_model : "", includeInherit);
+                applyHarnessRequirements(scope);
+            };
             if (els.systemAgentProvider) {
-                els.systemAgentProvider.addEventListener("change", () => {
-                    applyProviderSelectionDefaults("system");
-                    renderAgentHarnessEditor();
-                });
+                els.systemAgentProvider.addEventListener("change", () => onProviderChange("system", els.systemAgentProvider, els.systemAgentModel, false));
             }
             if (els.projectAgentProvider) {
-                els.projectAgentProvider.addEventListener("change", () => {
-                    applyProviderSelectionDefaults("project");
-                    renderAgentHarnessEditor();
-                });
+                els.projectAgentProvider.addEventListener("change", () => onProviderChange("project", els.projectAgentProvider, els.projectAgentModel, true));
             }
             if (els.providerConfigSelect) {
                 els.providerConfigSelect.addEventListener("change", () => {


### PR DESCRIPTION
Adds the missing UI to pick the default AI provider+model: a system 'Default model' card in Settings -> AI Providers and a per-project default-model dropdown on the Project page. Model is a dropdown that changes with the chosen provider (fixed the change handler that rendered from saved state). URL/key resolve from the provider config. Relabelled project 'Default draft' -> 'New tickets start in draft'. Verified end-to-end; site2 green. refs TK-151