### PR TITLE
TK-152: log agent-reply decision + surface empty replies

### DIFF
--- a/internal/server/room_agent.go
+++ b/internal/server/room_agent.go
@@ -57,6 +57,9 @@ func replyAsAgents(ctx context.Context, db *sql.DB, room store.Room, msg store.R
 			}
 		}
 	}
+	if posted == 0 {
+		log.Printf("server: no agent reply in room %d (slug=%q): no agent @mentioned and not a personal-agent DM with an agent member", room.ID, room.Slug)
+	}
 	return posted
 }
 
@@ -76,6 +79,8 @@ func postAgentReply(ctx context.Context, db *sql.DB, room store.Room, agent stor
 	}
 	reply = strings.TrimSpace(reply)
 	if reply == "" {
+		log.Printf("server: room agent %s returned an empty reply", agent.Username)
+		postAgentNotice(ctx, db, room, agent, "returned an empty reply (the model produced no output).", hub)
 		return false
 	}
 	out, perr := store.PostRoomMessage(ctx, db, store.RoomMessage{

--- a/internal/server/room_agent_test.go
+++ b/internal/server/room_agent_test.go
@@ -98,6 +98,38 @@ func TestReplyAsAgentsPostsNoticeOnFailure(t *testing.T) {
 	}
 }
 
+func TestReplyAsAgentsPostsNoticeOnEmptyReply(t *testing.T) {
+	_, db := testHandler(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	agent, _, _ := store.CreateAgent(ctx, db, "")
+	uname := "helper"
+	_, _ = store.UpdateAgent(ctx, db, agent.ID, store.AgentUpdateParams{Username: &uname})
+	room, _ := store.CreateRoom(ctx, db, store.Room{Name: "Help", CreatedBy: "admin"})
+	_ = store.JoinRoom(ctx, db, room.ID, agent.ID, "member")
+
+	orig := roomAgentReply
+	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, _, _ string, _ []store.RoomMessage) (string, error) {
+		return "   ", nil // empty after trim, no error
+	}
+	defer func() { roomAgentReply = orig }()
+
+	msg, _ := store.PostRoomMessage(ctx, db, store.RoomMessage{RoomID: room.ID, SenderID: "u1", Body: "hey @helper?"})
+	replyAsAgents(ctx, db, room, msg, nil)
+
+	msgs, _ := store.ListRoomMessages(ctx, db, room.ID, 50, 0)
+	notice := false
+	for _, m := range msgs {
+		if m.SenderID == agent.ID && m.Kind == "agent_event" && strings.Contains(m.Body, "empty reply") {
+			notice = true
+		}
+	}
+	if !notice {
+		t.Fatalf("an empty agent reply should post a notice; messages=%+v", msgs)
+	}
+}
+
 func TestReplyAsAgentsIgnoresNonAgentAndNonMember(t *testing.T) {
 	_, db := testHandler(t)
 	defer db.Close()


### PR DESCRIPTION
Makes 'nothing happens in chat' diagnosable: replyAsAgents logs when no agent matches; postAgentReply posts a notice + logs on an empty (no-error) reply. Complements TK-147 (failure notice) + TK-149 (path log). Tests added. refs TK-152