### PR TITLE
TK-156: chat bubbles — self left / responder right, avatars, model, typing

### DIFF
--- a/internal/server/room_agent.go
+++ b/internal/server/room_agent.go
@@ -83,12 +83,16 @@ func postAgentReply(ctx context.Context, db *sql.DB, room store.Room, agent stor
 		postAgentNotice(ctx, db, room, agent, "returned an empty reply (the model produced no output).", hub)
 		return false
 	}
+	agentAttrs := store.Attrs{"agent": true}
+	if strings.TrimSpace(cfg.Model) != "" {
+		agentAttrs["model"] = cfg.Model
+	}
 	out, perr := store.PostRoomMessage(ctx, db, store.RoomMessage{
 		RoomID:   room.ID,
 		SenderID: agent.ID,
 		Kind:     "text",
 		Body:     reply,
-		Attrs:    store.Attrs{"agent": true},
+		Attrs:    agentAttrs,
 	})
 	if perr != nil {
 		return false

--- a/web/default/site.css
+++ b/web/default/site.css
@@ -2112,3 +2112,20 @@ select {
     flex: 1;
     min-height: 0;
 }
+
+/* Chat message bubbles (TK-156): self aligns left; responder (agent/person) right with an avatar. */
+.chat-bubble-row { display: flex; gap: 8px; margin: 6px 0; align-items: flex-end; }
+.chat-bubble-row.chat-msg-self { justify-content: flex-start; }
+.chat-bubble-row.chat-msg-other { justify-content: flex-end; }
+.chat-bubble { max-width: 76%; padding: 7px 11px; border-radius: 12px; background: var(--card-border, #2a2a2a); }
+.chat-msg-self .chat-bubble { background: var(--accent-soft, rgba(255,122,26,.14)); border-bottom-left-radius: 4px; }
+.chat-msg-other .chat-bubble { border-bottom-right-radius: 4px; }
+.chat-msg-meta { font-size: 11px; opacity: .75; margin-bottom: 2px; }
+.chat-msg-model { margin-left: 6px; opacity: .6; font-style: italic; }
+.chat-avatar { width: 26px; height: 26px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; flex-shrink: 0; font-size: 13px; font-weight: 600; background: var(--card-border, #333); }
+.chat-avatar-agent { background: var(--accent-soft, rgba(255,122,26,.2)); }
+.chat-typing-dots { display: inline-flex; gap: 3px; align-items: center; padding: 3px 2px; }
+.chat-typing-dots span { width: 6px; height: 6px; border-radius: 50%; background: currentColor; opacity: .4; animation: chatTyping 1.2s infinite; }
+.chat-typing-dots span:nth-child(2) { animation-delay: .2s; }
+.chat-typing-dots span:nth-child(3) { animation-delay: .4s; }
+@keyframes chatTyping { 0%,60%,100% { opacity: .25; transform: translateY(0); } 30% { opacity: .9; transform: translateY(-3px); } }

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -2409,13 +2409,55 @@
                 if (state.activeRoomID !== roomID) { return; }
                 const box = document.getElementById("chat-messages");
                 if (!box) { return; }
-                box.innerHTML = (Array.isArray(msgs) ? msgs : []).map((m) =>
-                    "<div class=\"chat-msg chat-msg-" + escapeHTML(m.kind || "text") + "\" data-message-id=\"" + m.message_id + "\">" +
-                    "<span class=\"chat-msg-sender\">" + escapeHTML(m.sender_name || m.sender_id) + "</span> " +
-                    "<span class=\"chat-msg-body\">" + highlightRoomText(m.body) + "</span></div>").join("");
+                const me = currentUserID();
+                box.innerHTML = (Array.isArray(msgs) ? msgs : []).map((m) => renderChatMessage(m, me)).join("");
                 box.scrollTop = box.scrollHeight;
             }).catch(() => {});
         }
+        // Render one chat message. Self (the current user) aligns left; the
+        // responder — an agent or another person — aligns right with an avatar
+        // (robot for agents, initial for people) and, for agents, the model used.
+        function renderChatMessage(m, me) {
+            const kind = m.kind || "text";
+            if (kind === "system" || kind === "agent_event") {
+                return "<div class=\"chat-msg chat-msg-" + escapeHTML(kind) + "\">" + highlightRoomText(m.body) + "</div>";
+            }
+            const attrs = m.attrs || {};
+            const isSelf = m.sender_id === me;
+            const isAgent = Boolean(attrs.agent);
+            const name = escapeHTML(m.sender_name || m.sender_id || "?");
+            const initial = escapeHTML(String(m.sender_name || "?").slice(0, 1).toUpperCase());
+            const avatar = isAgent
+                ? "<span class=\"chat-avatar chat-avatar-agent\" title=\"agent\">🤖</span>"
+                : "<span class=\"chat-avatar chat-avatar-person\">" + initial + "</span>";
+            const model = (isAgent && attrs.model) ? "<span class=\"chat-msg-model\">via " + escapeHTML(String(attrs.model)) + "</span>" : "";
+            const bubble = "<div class=\"chat-bubble\">" +
+                (isSelf ? "" : "<div class=\"chat-msg-meta\">" + name + model + "</div>") +
+                "<div class=\"chat-msg-body\">" + highlightRoomText(m.body) + "</div></div>";
+            const side = isSelf ? "chat-msg-self" : "chat-msg-other";
+            return "<div class=\"chat-msg chat-bubble-row " + side + "\" data-message-id=\"" + m.message_id + "\">" +
+                (isSelf ? bubble : bubble + avatar) + "</div>";
+        }
+
+        // After sending, show an animated typing bubble while an agent reply is
+        // pending (a DM, or a message that @mentions someone). It is transient: the
+        // next message render (the reply, via the live socket) rebuilds the list.
+        function maybeShowAgentTyping(roomID, body) {
+            const room = (state.rooms || []).find((r) => r.room_id === roomID);
+            const isDM = room && room.slug && room.slug.indexOf("dm-") === 0;
+            const mentions = body.indexOf("/") !== 0 && /@[A-Za-z0-9]/.test(body);
+            if (!isDM && !mentions) { return; }
+            const box = document.getElementById("chat-messages");
+            if (!box || box.querySelector(".chat-typing")) { return; }
+            const el = document.createElement("div");
+            el.className = "chat-msg chat-bubble-row chat-msg-other chat-typing";
+            el.innerHTML = "<div class=\"chat-bubble\"><span class=\"chat-typing-dots\"><span></span><span></span><span></span></span></div>" +
+                "<span class=\"chat-avatar chat-avatar-agent\">🤖</span>";
+            box.appendChild(el);
+            box.scrollTop = box.scrollHeight;
+            setTimeout(() => { if (el.parentNode) { el.remove(); } }, 90000);
+        }
+
         // Shell-style composer history: Up/Down recall sent messages, Esc clears.
         let chatHistory = [];
         let chatHistoryIdx = 0;
@@ -2448,7 +2490,7 @@
                     // /msg routes to a DM room and /new + /join switch rooms — follow
                     // the message if the server placed it somewhere other than here.
                     const target = (msg && msg.room_id && msg.room_id !== roomID) ? msg.room_id : roomID;
-                    if (target !== roomID) { selectRoom(target); } else { loadRoomMessages(roomID); }
+                    if (target !== roomID) { selectRoom(target); } else { loadRoomMessages(roomID).then(() => maybeShowAgentTyping(roomID, body)); }
                 }))
                 .catch((err) => setNotice("Send failed: " + err.message, true));
         }


### PR DESCRIPTION
Messages render as bubbles: self aligns left, the responder (agent/person) aligns right with an avatar (robot for agents, initial for people) + name; agent replies show the model in small text (stamped server-side); an animated typing indicator shows while an agent reply is pending. Verified; site2 chat green. refs TK-156