### PR TITLE
TK-157: persisted chat command + {prompt} placeholder

### DIFF
--- a/internal/server/api_personal_agent_test.go
+++ b/internal/server/api_personal_agent_test.go
@@ -43,7 +43,7 @@ func TestPersonalAgentEndpointAndDMReply(t *testing.T) {
 
 	// In the DM, the agent replies to a message with NO @mention (stubbed responder).
 	orig := roomAgentReply
-	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, agentName, _ string, _ []store.RoomMessage) (string, error) {
+	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, _ []string, agentName, _ string, _ []store.RoomMessage) (string, error) {
 		return "hello from " + agentName, nil
 	}
 	defer func() { roomAgentReply = orig }()

--- a/internal/server/api_system.go
+++ b/internal/server/api_system.go
@@ -353,6 +353,37 @@ func (r *router) registerSystemHandlers() {
 	})
 	// Per-user agent-model overrides (TK-149): GET returns the caller's overrides,
 	// PUT replaces them. These override the project and system config at resolve time.
+	// Persisted CLI chat command (TK-157). GET (any user) returns it; PUT (admin)
+	// stores it. A {prompt} placeholder is substituted as an argument at run time.
+	mux.HandleFunc("/api/config/chat-command", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if _, err := requireUser(db, r); err != nil {
+				writeAuthError(w, err)
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"command": store.GetChatCommand(r.Context(), db)})
+		case http.MethodPut:
+			if _, err := requireAdmin(db, r); err != nil {
+				writeAuthError(w, err)
+				return
+			}
+			var body struct {
+				Command string `json:"command"`
+			}
+			if derr := json.NewDecoder(r.Body).Decode(&body); derr != nil {
+				writeError(w, http.StatusBadRequest, "invalid json body")
+				return
+			}
+			if serr := store.SetChatCommand(r.Context(), db, body.Command); serr != nil {
+				writeStoreError(w, serr)
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]any{"command": store.GetChatCommand(r.Context(), db)})
+		default:
+			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+	})
 	mux.HandleFunc("/api/me/agent-model", func(w http.ResponseWriter, r *http.Request) {
 		user, err := requireUser(db, r)
 		if err != nil {

--- a/internal/server/chat_ws.go
+++ b/internal/server/chat_ws.go
@@ -322,17 +322,24 @@ func startChatBridgeWithDuration(send func(chatOutboundMessage), logf func(strin
 }
 
 func resolveChatCommandArgs() []string {
-	if raw := strings.TrimSpace(os.Getenv("TICKET_CHAT_CMD")); raw != "" {
-		parts := strings.Fields(raw)
-		if len(parts) == 0 {
-			return []string{"codex", "exec"}
-		}
-		if strings.EqualFold(parts[0], "codex") && (len(parts) == 1 || strings.HasPrefix(parts[1], "-")) {
-			return append([]string{parts[0], "exec"}, parts[1:]...)
-		}
-		return parts
+	return chatCommandArgsFrom(os.Getenv("TICKET_CHAT_CMD"))
+}
+
+// chatCommandArgsFrom tokenizes a chat-command string into argv, defaulting to
+// "codex exec" when empty and inserting "exec" after a bare "codex".
+func chatCommandArgsFrom(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return []string{"codex", "exec"}
 	}
-	return []string{"codex", "exec"}
+	parts := strings.Fields(raw)
+	if len(parts) == 0 {
+		return []string{"codex", "exec"}
+	}
+	if strings.EqualFold(parts[0], "codex") && (len(parts) == 1 || strings.HasPrefix(parts[1], "-")) {
+		return append([]string{parts[0], "exec"}, parts[1:]...)
+	}
+	return parts
 }
 
 func (b *chatProcessBridge) streamOutput(reader io.Reader, stream string, send func(chatOutboundMessage), logf func(string)) {

--- a/internal/server/room_agent.go
+++ b/internal/server/room_agent.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"log"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -16,7 +17,17 @@ import (
 // roomAgentResponder generates an agent's reply to a room prompt. It is a
 // package var so tests can inject a deterministic stub; the default runs the
 // configured chat/agent command one-shot (TK-131).
-type roomAgentResponder func(ctx context.Context, cfg store.AgentModelConfig, agentName, prompt string, history []store.RoomMessage) (string, error)
+type roomAgentResponder func(ctx context.Context, cfg store.AgentModelConfig, cmdArgs []string, agentName, prompt string, history []store.RoomMessage) (string, error)
+
+// resolveAgentChatCommand resolves the CLI chat command: TICKET_CHAT_CMD env
+// overrides the persisted chat_command setting, which overrides the default
+// (codex exec). The args may contain a {prompt} placeholder (TK-157).
+func resolveAgentChatCommand(ctx context.Context, db *sql.DB) []string {
+	if env := strings.TrimSpace(os.Getenv("TICKET_CHAT_CMD")); env != "" {
+		return chatCommandArgsFrom(env)
+	}
+	return chatCommandArgsFrom(store.GetChatCommand(ctx, db))
+}
 
 var roomAgentReply roomAgentResponder = defaultRoomAgentReply
 
@@ -67,8 +78,9 @@ func replyAsAgents(ctx context.Context, db *sql.DB, room store.Room, msg store.R
 // model is resolved for the requesting user in the room's project (TK-149).
 func postAgentReply(ctx context.Context, db *sql.DB, room store.Room, agent store.User, requesterID, trigger string, hub *liveHub) bool {
 	cfg, _ := store.ResolveAgentModelConfig(ctx, db, requesterID, room.ProjectID)
+	cmdArgs := resolveAgentChatCommand(ctx, db)
 	history, _ := store.ListRoomMessages(ctx, db, room.ID, 20, 0)
-	reply, rerr := roomAgentReply(ctx, cfg, agent.Username, trigger, history)
+	reply, rerr := roomAgentReply(ctx, cfg, cmdArgs, agent.Username, trigger, history)
 	if rerr != nil {
 		log.Printf("server: room agent %s reply failed: %v", agent.Username, rerr)
 		// Surface the failure in the room so the user isn't left wondering why
@@ -125,7 +137,7 @@ func postAgentNotice(ctx context.Context, db *sql.DB, room store.Room, agent sto
 // it a prompt built from the room transcript, and returns its stdout. Requires
 // the agent runtime to be configured; otherwise it returns an error and no reply
 // is posted.
-func defaultRoomAgentReply(ctx context.Context, cfg store.AgentModelConfig, agentName, prompt string, history []store.RoomMessage) (string, error) {
+func defaultRoomAgentReply(ctx context.Context, cfg store.AgentModelConfig, cmdArgs []string, agentName, prompt string, history []store.RoomMessage) (string, error) {
 	full := buildRoomAgentPrompt(agentName, prompt, history)
 	// When a provider API is configured (resolved per user/project/system), call
 	// it directly; otherwise fall back to the configured CLI command (TK-149).
@@ -133,34 +145,52 @@ func defaultRoomAgentReply(ctx context.Context, cfg store.AgentModelConfig, agen
 		log.Printf("server: agent %s replying via %s model %q (api)", agentName, cfg.Provider, cfg.Model)
 		return callAgentModelAPI(ctx, cfg, full)
 	}
-	commandArgs := resolveChatCommandArgs()
-	if len(commandArgs) == 0 {
+	if len(cmdArgs) == 0 {
+		cmdArgs = resolveChatCommandArgs()
+	}
+	if len(cmdArgs) == 0 {
 		return "", errors.New("chat agent command is empty")
 	}
+	// {prompt} placeholder: substitute the prompt as an argument (e.g. claude -p
+	// {prompt}); without it, pipe the prompt to stdin (e.g. codex exec).
+	args := make([]string, len(cmdArgs))
+	usePlaceholder := false
+	for i, a := range cmdArgs {
+		if strings.Contains(a, "{prompt}") {
+			usePlaceholder = true
+			args[i] = strings.ReplaceAll(a, "{prompt}", full)
+		} else {
+			args[i] = a
+		}
+	}
 	if strings.TrimSpace(cfg.Provider) != "" {
-		log.Printf("server: agent %s — no API key/URL resolved for provider %q, falling back to CLI %v (set the provider/system API key to use the API)", agentName, cfg.Provider, commandArgs)
+		log.Printf("server: agent %s — no API key/URL resolved for provider %q, falling back to CLI %v (set the provider/system API key to use the API)", agentName, cfg.Provider, cmdArgs)
 	} else {
-		log.Printf("server: agent %s replying via CLI %v", agentName, commandArgs)
+		log.Printf("server: agent %s replying via CLI %v", agentName, cmdArgs)
 	}
 	cctx, cancel := context.WithTimeout(ctx, 120*time.Second)
 	defer cancel()
-	cmd := exec.CommandContext(cctx, commandArgs[0], commandArgs[1:]...) // #nosec G204 -- commandArgs resolved from trusted server configuration
+	cmd := exec.CommandContext(cctx, args[0], args[1:]...) // #nosec G204 -- args resolved from trusted server configuration
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		return "", err
-	}
-	if err := cmd.Start(); err != nil {
-		return "", err
-	}
-	if _, werr := stdin.Write([]byte(full + "\n")); werr != nil {
-		_ = stdin.Close()
-		return "", werr
-	}
-	if cerr := stdin.Close(); cerr != nil {
-		return "", cerr
+	if !usePlaceholder {
+		stdin, err := cmd.StdinPipe()
+		if err != nil {
+			return "", err
+		}
+		if serr := cmd.Start(); serr != nil {
+			return "", serr
+		}
+		if _, werr := stdin.Write([]byte(full + "\n")); werr != nil {
+			_ = stdin.Close()
+			return "", werr
+		}
+		if cerr := stdin.Close(); cerr != nil {
+			return "", cerr
+		}
+	} else if serr := cmd.Start(); serr != nil {
+		return "", serr
 	}
 	if werr := cmd.Wait(); werr != nil {
 		return "", errors.Join(werr, errors.New(strings.TrimSpace(stderr.String())))

--- a/internal/server/room_agent_test.go
+++ b/internal/server/room_agent_test.go
@@ -34,7 +34,7 @@ func TestReplyAsAgentsPostsAgentReply(t *testing.T) {
 
 	// Stub the responder so the test is deterministic and offline.
 	orig := roomAgentReply
-	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, agentName, prompt string, _ []store.RoomMessage) (string, error) {
+	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, _ []string, agentName, prompt string, _ []store.RoomMessage) (string, error) {
 		return "On it — " + agentName + " here", nil
 	}
 	defer func() { roomAgentReply = orig }()
@@ -78,7 +78,7 @@ func TestReplyAsAgentsPostsNoticeOnFailure(t *testing.T) {
 
 	// The agent command fails.
 	orig := roomAgentReply
-	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, _, _ string, _ []store.RoomMessage) (string, error) {
+	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, _ []string, _, _ string, _ []store.RoomMessage) (string, error) {
 		return "", errors.New("exit status 1: model not supported")
 	}
 	defer func() { roomAgentReply = orig }()
@@ -110,7 +110,7 @@ func TestReplyAsAgentsPostsNoticeOnEmptyReply(t *testing.T) {
 	_ = store.JoinRoom(ctx, db, room.ID, agent.ID, "member")
 
 	orig := roomAgentReply
-	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, _, _ string, _ []store.RoomMessage) (string, error) {
+	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, _ []string, _, _ string, _ []store.RoomMessage) (string, error) {
 		return "   ", nil // empty after trim, no error
 	}
 	defer func() { roomAgentReply = orig }()
@@ -138,7 +138,7 @@ func TestReplyAsAgentsIgnoresNonAgentAndNonMember(t *testing.T) {
 
 	called := false
 	orig := roomAgentReply
-	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, _, _ string, _ []store.RoomMessage) (string, error) {
+	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, _ []string, _, _ string, _ []store.RoomMessage) (string, error) {
 		called = true
 		return "should not happen", nil
 	}
@@ -148,5 +148,25 @@ func TestReplyAsAgentsIgnoresNonAgentAndNonMember(t *testing.T) {
 	msg, _ := store.PostRoomMessage(ctx, db, store.RoomMessage{RoomID: room.ID, SenderID: "u1", Body: "ping @admin and @ghost"})
 	if n := replyAsAgents(ctx, db, room, msg, nil); n != 0 || called {
 		t.Fatalf("replyAsAgents should not respond for non-agents/non-members (n=%d called=%v)", n, called)
+	}
+}
+
+func TestDefaultRoomAgentReplyPromptPlaceholder(t *testing.T) {
+	ctx := context.Background()
+	// {prompt} placeholder: substituted as an argument (echo prints it back).
+	out, err := defaultRoomAgentReply(ctx, store.AgentModelConfig{}, []string{"echo", "{prompt}"}, "helper", "ping me", nil)
+	if err != nil {
+		t.Fatalf("echo placeholder: %v", err)
+	}
+	if !strings.Contains(out, "helper") || !strings.Contains(out, "ping me") {
+		t.Fatalf("placeholder output missing prompt: %q", out)
+	}
+	// No placeholder: prompt is piped to stdin (cat echoes it).
+	out2, err := defaultRoomAgentReply(ctx, store.AgentModelConfig{}, []string{"cat"}, "helper", "ping me", nil)
+	if err != nil {
+		t.Fatalf("cat stdin: %v", err)
+	}
+	if !strings.Contains(out2, "ping me") {
+		t.Fatalf("stdin output missing prompt: %q", out2)
 	}
 }

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -397,3 +397,17 @@ func parsePositiveInt(raw string) int {
 	}
 	return n
 }
+
+// GetChatCommand returns the persisted chat/agent CLI command (TK-157), or "".
+func GetChatCommand(ctx context.Context, db *sql.DB) string {
+	var v string
+	if err := db.QueryRowContext(ctx, `SELECT value FROM app_settings WHERE key = 'chat_command'`).Scan(&v); err != nil {
+		return ""
+	}
+	return v
+}
+
+// SetChatCommand persists the chat/agent CLI command.
+func SetChatCommand(ctx context.Context, db *sql.DB, command string) error {
+	return SetAppSetting(ctx, db, "chat_command", strings.TrimSpace(command))
+}

--- a/web/default/index.html
+++ b/web/default/index.html
@@ -278,7 +278,12 @@
                                     <input id="system-agent-url" autocomplete="off" placeholder="defaults to the provider's URL">
                                 </div>
                             </div>
-                            <p class="meta">Resolved: <span id="resolved-agent-provider"></span> / <span id="resolved-agent-model"></span>. Without an API key, replies fall back to the CLI command.</p>
+                            <p class="meta">Resolved: <span id="resolved-agent-provider"></span> / <span id="resolved-agent-model"></span>. Without an API key, replies fall back to the CLI command below.</p>
+                            <div class="field">
+                                <label for="system-chat-command">CLI command (fallback)</label>
+                                <input id="system-chat-command" autocomplete="off" placeholder="e.g. claude -p {prompt}  (or leave blank for codex exec)">
+                                <p class="meta">Used when no API key is set. Use <code>{prompt}</code> to pass the prompt as an argument; otherwise it is piped to stdin. The TICKET_CHAT_CMD env var overrides this.</p>
+                            </div>
                             <div class="form-actions">
                                 <button id="save-system-agent-model" class="btn btn-primary" type="button">Save default model</button>
                             </div>

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -1806,6 +1806,14 @@
             } catch (error) {
                 state.systemAgentModelConfig = emptyAgentModelConfig();
             }
+            // Load the persisted CLI fallback command into its field.
+            const cmdEl = document.getElementById("system-chat-command");
+            if (cmdEl) {
+                try {
+                    const res = await api("/api/config/chat-command");
+                    cmdEl.value = (res && res.command) || "";
+                } catch (e) { /* non-admins / unset: leave blank */ }
+            }
         }
 
         async function loadProjectAgentModelConfig() {
@@ -6257,6 +6265,10 @@
                             method: "PUT",
                             body: JSON.stringify(buildAgentModelPayload("system")),
                         });
+                        const cmdEl = document.getElementById("system-chat-command");
+                        if (cmdEl) {
+                            await api("/api/config/chat-command", { method: "PUT", body: JSON.stringify({ command: cmdEl.value.trim() }) });
+                        }
                         await Promise.all([loadSystemAgentModelConfig()]);
                         renderAll();
                         setNotice("System agent model configuration saved.");


### PR DESCRIPTION
Store the CLI chat command (Settings -> AI Providers -> CLI command field, or PUT /api/config/chat-command), with a {prompt} placeholder substituted as an argument (e.g. 'claude -p {prompt}'); else piped to stdin. Resolution: env > stored > codex exec. Tests for both paths; site2 green. refs TK-157