### PR TITLE
TK-158: parse Claude CLI stream-json/json output into reply text

### DIFF
--- a/internal/server/agent_model_api.go
+++ b/internal/server/agent_model_api.go
@@ -132,3 +132,81 @@ func callOpenAICompatible(ctx context.Context, cfg store.AgentModelConfig, promp
 	}
 	return strings.TrimSpace(parsed.Choices[0].Message.Content), nil
 }
+
+// claudeJSONEvent is one line of Claude CLI --output-format (stream-)json output.
+type claudeJSONEvent struct {
+	Type    string `json:"type"`
+	Result  string `json:"result"`
+	Message struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+	} `json:"message"`
+}
+
+// extractAgentReply turns a CLI command's stdout into the assistant text. For a
+// command using Claude's --output-format stream-json it parses the NDJSON events
+// line by line (preferring the final result, else concatenated assistant text);
+// for --output-format json it parses the single result object; otherwise it
+// returns the raw stdout (TK-158).
+func extractAgentReply(cmdArgs []string, raw string) string {
+	joined := strings.ToLower(strings.Join(cmdArgs, " "))
+	if strings.Contains(joined, "stream-json") {
+		if text := parseClaudeStreamJSON(raw); text != "" {
+			return text
+		}
+		return strings.TrimSpace(raw)
+	}
+	if strings.Contains(joined, "output-format json") {
+		var ev claudeJSONEvent
+		if json.Unmarshal([]byte(strings.TrimSpace(raw)), &ev) == nil {
+			if t := claudeEventText(ev); t != "" {
+				return t
+			}
+		}
+		return strings.TrimSpace(raw)
+	}
+	return strings.TrimSpace(raw)
+}
+
+func parseClaudeStreamJSON(raw string) string {
+	var result string
+	var acc strings.Builder
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || line[0] != '{' {
+			continue
+		}
+		var ev claudeJSONEvent
+		if json.Unmarshal([]byte(line), &ev) != nil {
+			continue
+		}
+		if ev.Type == "result" && strings.TrimSpace(ev.Result) != "" {
+			result = ev.Result
+		} else if ev.Type == "assistant" {
+			for _, c := range ev.Message.Content {
+				if c.Type == "text" {
+					acc.WriteString(c.Text)
+				}
+			}
+		}
+	}
+	if strings.TrimSpace(result) != "" {
+		return strings.TrimSpace(result)
+	}
+	return strings.TrimSpace(acc.String())
+}
+
+func claudeEventText(ev claudeJSONEvent) string {
+	if strings.TrimSpace(ev.Result) != "" {
+		return strings.TrimSpace(ev.Result)
+	}
+	var acc strings.Builder
+	for _, c := range ev.Message.Content {
+		if c.Type == "text" {
+			acc.WriteString(c.Text)
+		}
+	}
+	return strings.TrimSpace(acc.String())
+}

--- a/internal/server/room_agent.go
+++ b/internal/server/room_agent.go
@@ -195,7 +195,9 @@ func defaultRoomAgentReply(ctx context.Context, cfg store.AgentModelConfig, cmdA
 	if werr := cmd.Wait(); werr != nil {
 		return "", errors.Join(werr, errors.New(strings.TrimSpace(stderr.String())))
 	}
-	return strings.TrimSpace(stdout.String()), nil
+	// Parse Claude --output-format (stream-)json into plain text when configured;
+	// otherwise return raw stdout (TK-158).
+	return extractAgentReply(cmdArgs, stdout.String()), nil
 }
 
 func buildRoomAgentPrompt(agentName, latest string, history []store.RoomMessage) string {

--- a/internal/server/room_agent_test.go
+++ b/internal/server/room_agent_test.go
@@ -170,3 +170,29 @@ func TestDefaultRoomAgentReplyPromptPlaceholder(t *testing.T) {
 		t.Fatalf("stdin output missing prompt: %q", out2)
 	}
 }
+
+func TestExtractAgentReplyStreamJSON(t *testing.T) {
+	// Claude stream-json: NDJSON events; prefer the final result.
+	nd := `{"type":"system","subtype":"init"}
+{"type":"assistant","message":{"content":[{"type":"text","text":"Hello "}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"there"}]}}
+{"type":"result","subtype":"success","result":"Hello there"}`
+	if got := extractAgentReply([]string{"claude", "-p", "{prompt}", "--output-format", "stream-json", "--verbose"}, nd); got != "Hello there" {
+		t.Fatalf("stream-json = %q, want 'Hello there'", got)
+	}
+	// stream-json with no result event falls back to concatenated assistant text.
+	nd2 := `{"type":"assistant","message":{"content":[{"type":"text","text":"part1 "}]}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"part2"}]}}`
+	if got := extractAgentReply([]string{"claude", "--output-format", "stream-json"}, nd2); got != "part1 part2" {
+		t.Fatalf("stream-json accum = %q, want 'part1 part2'", got)
+	}
+	// --output-format json: single result object.
+	single := `{"type":"result","subtype":"success","result":"single answer"}`
+	if got := extractAgentReply([]string{"claude", "-p", "{prompt}", "--output-format", "json"}, single); got != "single answer" {
+		t.Fatalf("json = %q, want 'single answer'", got)
+	}
+	// Plain command: raw stdout passthrough.
+	if got := extractAgentReply([]string{"codex", "exec"}, "raw reply text"); got != "raw reply text" {
+		t.Fatalf("raw = %q", got)
+	}
+}


### PR DESCRIPTION
When the chat command uses Claude's --output-format stream-json (NDJSON line-by-line) or --output-format json, the server parses it and extracts the assistant text (final result, else concatenated text) instead of posting raw JSON. Plain commands unchanged. Tests added. refs TK-158