### PR TITLE
TK-161: fix indented output after masked password prompt

### DIFF
--- a/cmd/tk/prompt.go
+++ b/cmd/tk/prompt.go
@@ -70,10 +70,13 @@ func readPasswordPrompt(reader *bufio.Reader, in io.Reader, out io.Writer) (stri
 		}
 		switch single[0] {
 		case '\r', '\n':
-			fmt.Fprint(out, "\n")
+			// Raw mode: \n is line-feed only, so emit \r\n to return the cursor to
+			// column 0 — otherwise the next output is indented by the password
+			// length (the count of asterisks just printed) (TK-161).
+			fmt.Fprint(out, "\r\n")
 			return string(buf), nil
 		case 3:
-			fmt.Fprint(out, "^C\n")
+			fmt.Fprint(out, "^C\r\n")
 			return "", errors.New("interrupt")
 		case 8, 127:
 			if len(buf) > 0 {


### PR DESCRIPTION
The masked password prompt runs in raw mode where \n is line-feed only, so output after the password (e.g. 'logged in as admin') was indented by the password length. Emit \r\n to return the cursor to column 0. refs TK-161