### PR TITLE
TK-162: robust interactive login (filter terminal escapes + Ctrl-C)

### DIFF
--- a/cmd/tk/prompt.go
+++ b/cmd/tk/prompt.go
@@ -11,13 +11,56 @@ import (
 	"golang.org/x/term"
 )
 
+// errPromptInterrupted is returned when the user presses Ctrl-C at a prompt.
+var errPromptInterrupted = errors.New("cancelled")
+
 func promptForCredentials(in io.Reader, out io.Writer, defaultUsername, defaultPassword string) (username, password string, err error) {
-	reader := bufio.NewReader(in)
+	usernameLabel := "username: "
 	if defaultUsername != "" {
-		fmt.Fprintf(out, "username [%s]: ", defaultUsername)
-	} else {
-		fmt.Fprint(out, "username: ")
+		usernameLabel = fmt.Sprintf("username [%s]: ", defaultUsername)
 	}
+	passwordLabel := "password: "
+	if defaultPassword != "" {
+		passwordLabel = "password [press enter to use default]: "
+	}
+
+	// On a real terminal, read both fields in raw mode with a single MakeRaw.
+	// This filters terminal escape sequences (e.g. OSC 11 / cursor-position query
+	// responses emitted by color detection at startup, which would otherwise leak
+	// into the read) and handles Ctrl-C consistently for both prompts (TK-162).
+	if inFile, _, ok := promptTerminal(in, out); ok {
+		oldState, rawErr := term.MakeRaw(int(inFile.Fd())) // #nosec G115
+		if rawErr != nil {
+			return "", "", rawErr
+		}
+		defer func() {
+			if restoreErr := term.Restore(int(inFile.Fd()), oldState); restoreErr != nil { // #nosec G115
+				fmt.Fprintf(out, "warning: failed to restore terminal state: %v\r\n", restoreErr)
+			}
+		}()
+		fmt.Fprint(out, usernameLabel)
+		username, err = readRawLine(inFile, out, false)
+		if err != nil {
+			return "", "", err
+		}
+		username = strings.TrimSpace(username)
+		if username == "" {
+			username = defaultUsername
+		}
+		fmt.Fprint(out, passwordLabel)
+		password, err = readRawLine(inFile, out, true)
+		if err != nil {
+			return "", "", err
+		}
+		if password == "" {
+			password = defaultPassword
+		}
+		return username, password, nil
+	}
+
+	// Non-terminal fallback (pipes/tests): line-based reads.
+	reader := bufio.NewReader(in)
+	fmt.Fprint(out, usernameLabel)
 	username, err = reader.ReadString('\n')
 	if err != nil {
 		return "", "", err
@@ -26,11 +69,7 @@ func promptForCredentials(in io.Reader, out io.Writer, defaultUsername, defaultP
 	if username == "" {
 		username = defaultUsername
 	}
-	if defaultPassword != "" {
-		fmt.Fprint(out, "password [press enter to use default]: ")
-	} else {
-		fmt.Fprint(out, "password: ")
-	}
+	fmt.Fprint(out, passwordLabel)
 	password, err = readPasswordPrompt(reader, in, out)
 	if err != nil {
 		return "", "", err
@@ -39,6 +78,93 @@ func promptForCredentials(in io.Reader, out io.Writer, defaultUsername, defaultP
 		password = defaultPassword
 	}
 	return username, password, nil
+}
+
+// promptTerminal reports whether in/out are a usable interactive terminal.
+func promptTerminal(in io.Reader, out io.Writer) (inFile, outFile *os.File, ok bool) {
+	inF, inOK := in.(*os.File)
+	outF, outOK := out.(*os.File)
+	if !inOK || !outOK {
+		return nil, nil, false
+	}
+	if !term.IsTerminal(int(inF.Fd())) || !term.IsTerminal(int(outF.Fd())) { // #nosec G115
+		return nil, nil, false
+	}
+	return inF, outF, true
+}
+
+// readRawLine reads one line from a terminal already in raw mode. It echoes input
+// (asterisks when mask is set), supports backspace, returns errPromptInterrupted
+// on Ctrl-C, and silently discards terminal escape sequences (leaked query
+// responses) so they don't corrupt the value (TK-162).
+func readRawLine(inFile *os.File, out io.Writer, mask bool) (string, error) {
+	var buf []byte
+	single := make([]byte, 1)
+	for {
+		if _, err := inFile.Read(single); err != nil {
+			return "", err
+		}
+		switch single[0] {
+		case '\r', '\n':
+			fmt.Fprint(out, "\r\n")
+			return string(buf), nil
+		case 3: // Ctrl-C
+			fmt.Fprint(out, "^C\r\n")
+			return "", errPromptInterrupted
+		case 8, 127: // backspace / delete
+			if len(buf) > 0 {
+				buf = buf[:len(buf)-1]
+				fmt.Fprint(out, "\b \b")
+			}
+		case 0x1b: // ESC — consume and ignore a terminal escape/query response
+			consumeEscapeSequence(inFile)
+		default:
+			if single[0] >= 32 && single[0] <= 126 {
+				buf = append(buf, single[0])
+				if mask {
+					fmt.Fprint(out, "*")
+				} else {
+					fmt.Fprint(out, string(single[0]))
+				}
+			}
+		}
+	}
+}
+
+// consumeEscapeSequence reads and discards the remainder of a terminal escape
+// sequence after an ESC byte: CSI (\x1b[ … final byte 0x40-0x7e), OSC (\x1b] …
+// terminated by BEL or ST), or a single-byte escape.
+func consumeEscapeSequence(inFile *os.File) {
+	b := make([]byte, 1)
+	if _, err := inFile.Read(b); err != nil {
+		return
+	}
+	switch b[0] {
+	case '[': // CSI
+		for {
+			if _, err := inFile.Read(b); err != nil {
+				return
+			}
+			if b[0] >= 0x40 && b[0] <= 0x7e {
+				return
+			}
+		}
+	case ']': // OSC, terminated by BEL (0x07) or ST (ESC \)
+		for {
+			if _, err := inFile.Read(b); err != nil {
+				return
+			}
+			if b[0] == 0x07 {
+				return
+			}
+			if b[0] == 0x1b {
+				_, _ = inFile.Read(b) // consume the trailing backslash of ST
+				return
+			}
+		}
+	default:
+		return
+	}
 }
 
 func readPasswordPrompt(reader *bufio.Reader, in io.Reader, out io.Writer) (string, error) {

--- a/cmd/tk/prompt_test.go
+++ b/cmd/tk/prompt_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"os"
+	"testing"
+)
+
+func TestReadRawLineFiltersEscapeSequences(t *testing.T) {
+	// A leaked cursor-position (DSR) response and an OSC color response prepended
+	// to the typed input must be discarded, leaving just the value (TK-162).
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		_, _ = w.Write([]byte("\x1b[24;1R\x1b]11;rgb:0000/0000/0000\x07admin\r"))
+		_ = w.Close()
+	}()
+	got, err := readRawLine(r, io.Discard, false)
+	if err != nil {
+		t.Fatalf("readRawLine: %v", err)
+	}
+	if got != "admin" {
+		t.Fatalf("got %q, want %q", got, "admin")
+	}
+}
+
+func TestReadRawLineCtrlCInterrupts(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	go func() {
+		_, _ = w.Write([]byte{3}) // Ctrl-C
+		_ = w.Close()
+	}()
+	if _, err := readRawLine(r, io.Discard, false); !errors.Is(err, errPromptInterrupted) {
+		t.Fatalf("want errPromptInterrupted, got %v", err)
+	}
+}


### PR DESCRIPTION
Interactive login on a TTY was corrupted by terminal-detection query responses leaking onto stdin (no real password prompt), and Ctrl-C didn't abort. Read credentials in raw mode filtering escape sequences + handling Ctrl-C; piped fallback unchanged. Tests + PTY-verified. refs TK-162