### PR TITLE
TK-164: tk logout uses resolved server + retains username

### DIFF
--- a/cmd/tk/cmd_user.go
+++ b/cmd/tk/cmd_user.go
@@ -218,38 +218,38 @@ func runLogout(args []string) error {
 	if len(args) != 0 {
 		return errors.New("usage: tk logout")
 	}
-	location := strings.TrimSpace(os.Getenv("TICKET_URL"))
-	if location == "" {
-		return errors.New("ticket logout only works in remote mode; set TICKET_URL and try again")
-	}
-	resolved, err := config.ResolveLocation(location)
+	// Resolve the server the same way as every other command (TICKET_URL, else the
+	// default remote), so logout targets whatever you're actually logged in to —
+	// not only when TICKET_URL is set (TK-164).
+	cfg, err := config.Load()
 	if err != nil {
 		return err
 	}
-	if resolved.Mode != config.ModeRemote || strings.TrimSpace(resolved.ServerURL) == "" {
-		return errors.New("ticket logout requires a remote server URL; set TICKET_URL to http:// or https://")
+	serverURL, err := resolveServerURLForAuth(cfg)
+	if err != nil {
+		return err
 	}
 	creds, err := config.LoadCredentials()
 	if err != nil {
 		return err
 	}
-	remoteCreds, ok := creds.Remote(resolved.ServerURL)
+	remoteCreds, ok := creds.Remote(serverURL)
 	if !ok || strings.TrimSpace(remoteCreds.Token) == "" {
-		return fmt.Errorf("no stored login session for %s; nothing to log out", resolved.ServerURL)
+		return fmt.Errorf("no stored login session for %s; nothing to log out", serverURL)
 	}
 	svc := libticket.NewHTTP(config.Config{
-		Location: resolved.ServerURL,
+		Location: serverURL,
 		Username: remoteCreds.Username,
 		Token:    remoteCreds.Token,
 	})
-	if err := svc.Logout(context.Background()); err != nil {
-		if clearErr := config.ClearRemoteCredentials(resolved.ServerURL); clearErr != nil {
-			return clearErr
-		}
-		return err
+	logoutErr := svc.Logout(context.Background())
+	// Always clear the local token (keeping the username so the next login
+	// remembers it), even if the server-side logout call fails.
+	if clearErr := config.ClearRemoteToken(serverURL); clearErr != nil {
+		return clearErr
 	}
-	if err := config.ClearRemoteCredentials(resolved.ServerURL); err != nil {
-		return err
+	if logoutErr != nil {
+		return logoutErr
 	}
 	if outputJSON {
 		return printJSON(map[string]string{"status": "logged_out"})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -271,6 +271,34 @@ func ClearCredentials() error {
 	return nil
 }
 
+// ClearRemoteToken clears the session token for a remote but retains the stored
+// username, so the next login can pre-fill it (the password is never stored).
+func ClearRemoteToken(location string) error {
+	location, err := CanonicalizeRemoteURL(location)
+	if err != nil {
+		return err
+	}
+	creds, err := LoadCredentials()
+	if err != nil {
+		return err
+	}
+	if location == "" {
+		creds.Token = ""
+		return SaveCredentials(creds)
+	}
+	if creds.Remotes == nil {
+		return nil
+	}
+	rc, ok := creds.Remotes[location]
+	if !ok {
+		return nil
+	}
+	rc.Token = ""
+	creds.Remotes[location] = rc
+	creds.Token = ""
+	return SaveCredentials(creds)
+}
+
 func ClearRemoteCredentials(location string) error {
 	var err error
 	location, err = CanonicalizeRemoteURL(location)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -753,3 +753,28 @@ func TestRemoteHelpersAndValidationBranches(t *testing.T) {
 		t.Fatal("RemoveRemote(empty) removed = true, want false")
 	}
 }
+
+func TestClearRemoteTokenRetainsUsername(t *testing.T) {
+	t.Setenv("TICKET_HOME", t.TempDir())
+	const url = "http://127.0.0.1:9999"
+	if err := SaveRemoteCredentials(url, "admin", "tok-123"); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if err := ClearRemoteToken(url); err != nil {
+		t.Fatalf("clear token: %v", err)
+	}
+	creds, err := LoadCredentials()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	rc, ok := creds.Remote(url)
+	if !ok {
+		t.Fatalf("credential entry should be retained for %s", url)
+	}
+	if rc.Username != "admin" {
+		t.Fatalf("username should be retained, got %q", rc.Username)
+	}
+	if rc.Token != "" {
+		t.Fatalf("token should be cleared, got %q", rc.Token)
+	}
+}


### PR DESCRIPTION
logout read TICKET_URL directly (refused when empty, while ls/login used the default) and deleted the whole credential entry. Now it resolves the server like other commands and clears only the token (config.ClearRemoteToken), keeping the username so the next login remembers it. Verified end-to-end; unit test added. refs TK-164