### PR TITLE
TK-170: room presence & typing indicators

### DIFF
--- a/internal/server/api_auth.go
+++ b/internal/server/api_auth.go
@@ -33,11 +33,12 @@ func (r *router) registerAuthHandlers() {
 			writeError(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}
-		if _, err := store.GetUserByToken(r.Context(), db, token); err != nil {
+		wsUser, err := store.GetUserByToken(r.Context(), db, token)
+		if err != nil {
 			writeAuthError(w, err)
 			return
 		}
-		if err := websocketServe(live, w, r); err != nil {
+		if err := websocketServe(live, w, r, wsUser.ID, presenceName(wsUser)); err != nil {
 			if strings.Contains(err.Error(), "websocket") || strings.Contains(err.Error(), "upgrade") {
 				writeStoreError(w, err)
 				return

--- a/internal/server/realtime.go
+++ b/internal/server/realtime.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/simonski/ticket/internal/store"
@@ -41,8 +42,16 @@ type liveClient struct {
 	send      chan []byte
 	done      chan struct{}
 	once      sync.Once
-	projectID int64 // if set, only receive events for this project
-	roomID    int64 // if set, also receive room events for this room
+	projectID int64  // if set, only receive events for this project
+	roomID    int64  // if set, also receive room events for this room
+	userID    string // identity of the connected user (for room presence)
+	userName  string // display name of the connected user (for room presence)
+}
+
+// presenceUser is one occupant of a room, derived purely from live connections.
+type presenceUser struct {
+	UserID string `json:"user_id"`
+	Name   string `json:"name"`
 }
 
 func newLiveHub() *liveHub {
@@ -66,8 +75,79 @@ func (h *liveHub) add(conn net.Conn) *liveClient {
 func (h *liveHub) remove(client *liveClient) {
 	client.close()
 	h.mu.Lock()
+	roomID := client.roomID
 	delete(h.clients, client)
 	h.mu.Unlock()
+	// A departing client changes who is present in its room.
+	if roomID != 0 {
+		h.broadcastRoomPresence(roomID)
+	}
+}
+
+// setSubscription updates a client's project/room subscription under the hub lock
+// and returns the room the client was previously in (0 if none). Mutating the
+// fields under the lock keeps them consistent with concurrent presence reads.
+func (h *liveHub) setSubscription(client *liveClient, projectID, roomID int64) (oldRoom int64) {
+	h.mu.Lock()
+	oldRoom = client.roomID
+	if projectID > 0 {
+		client.projectID = projectID
+	}
+	if roomID > 0 {
+		client.roomID = roomID
+	}
+	h.mu.Unlock()
+	return oldRoom
+}
+
+// presenceFor returns the distinct users currently subscribed to a room, sorted
+// for stable output. Presence is ephemeral — derived only from live connections.
+func (h *liveHub) presenceFor(roomID int64) []presenceUser {
+	h.mu.RLock()
+	seen := make(map[string]string)
+	for client := range h.clients {
+		if client.roomID == roomID && client.userID != "" {
+			if _, ok := seen[client.userID]; !ok {
+				seen[client.userID] = client.userName
+			}
+		}
+	}
+	h.mu.RUnlock()
+	users := make([]presenceUser, 0, len(seen))
+	for id, name := range seen {
+		users = append(users, presenceUser{UserID: id, Name: name})
+	}
+	sort.Slice(users, func(i, j int) bool {
+		if users[i].Name != users[j].Name {
+			return users[i].Name < users[j].Name
+		}
+		return users[i].UserID < users[j].UserID
+	})
+	return users
+}
+
+// broadcastRoomPresence sends the current occupant list to a room's subscribers.
+func (h *liveHub) broadcastRoomPresence(roomID int64) {
+	if roomID == 0 {
+		return
+	}
+	h.broadcast(liveEvent{Type: "room_presence", RoomID: roomID, Payload: h.presenceFor(roomID)})
+}
+
+// presenceName picks the best human-readable label for a user in presence lists.
+func presenceName(u store.User) string {
+	if strings.TrimSpace(u.DisplayName) != "" {
+		return u.DisplayName
+	}
+	return u.Username
+}
+
+// broadcastTyping fans a transient typing notice to a room's subscribers.
+func (h *liveHub) broadcastTyping(roomID int64, u presenceUser) {
+	if roomID == 0 {
+		return
+	}
+	h.broadcast(liveEvent{Type: "typing", RoomID: roomID, Payload: u})
 }
 
 func (h *liveHub) broadcast(event liveEvent) {
@@ -116,12 +196,14 @@ func (c *liveClient) close() {
 	})
 }
 
-func websocketServe(hub *liveHub, w http.ResponseWriter, r *http.Request) error {
+func websocketServe(hub *liveHub, w http.ResponseWriter, r *http.Request, userID, userName string) error {
 	conn, err := upgradeWebSocket(w, r)
 	if err != nil {
 		return err
 	}
 	client := hub.add(conn)
+	client.userID = userID
+	client.userName = userName
 
 	go func() {
 		defer hub.remove(client)
@@ -160,19 +242,32 @@ func websocketServe(hub *liveHub, w http.ResponseWriter, r *http.Request) error 
 				hub.remove(client)
 				return nil
 			}
-		case 0x1: // text frame — handle subscribe messages
+		case 0x1: // text frame — handle subscribe / typing messages
 			var msg struct {
 				Type      string `json:"type"`
 				ProjectID int64  `json:"project_id"`
 				RoomID    int64  `json:"room_id"`
 			}
-			if json.Unmarshal(payload, &msg) == nil && msg.Type == "subscribe" {
-				if msg.ProjectID > 0 {
-					client.projectID = msg.ProjectID
-				}
+			if json.Unmarshal(payload, &msg) != nil {
+				continue
+			}
+			switch msg.Type {
+			case "subscribe":
+				oldRoom := hub.setSubscription(client, msg.ProjectID, msg.RoomID)
 				if msg.RoomID > 0 {
-					client.roomID = msg.RoomID
+					// Leaving the previous room and joining the new one both
+					// change presence; refresh occupants for each affected room.
+					if oldRoom != 0 && oldRoom != msg.RoomID {
+						hub.broadcastRoomPresence(oldRoom)
+					}
+					hub.broadcastRoomPresence(msg.RoomID)
 				}
+			case "typing":
+				roomID := msg.RoomID
+				if roomID == 0 {
+					roomID = client.roomID
+				}
+				hub.broadcastTyping(roomID, presenceUser{UserID: client.userID, Name: client.userName})
 			}
 		}
 	}

--- a/internal/server/realtime_presence_test.go
+++ b/internal/server/realtime_presence_test.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// addTestClient inserts a synthetic client into the hub without a real
+// connection. Safe for presence/broadcast tests that never touch conn.
+func addTestClient(h *liveHub, userID, name string, roomID int64) *liveClient {
+	c := &liveClient{
+		send:     make(chan []byte, 8),
+		done:     make(chan struct{}),
+		roomID:   roomID,
+		userID:   userID,
+		userName: name,
+	}
+	h.mu.Lock()
+	h.clients[c] = struct{}{}
+	h.mu.Unlock()
+	return c
+}
+
+func TestPresenceForDedupesAndSorts(t *testing.T) {
+	h := newLiveHub()
+	// Two connections for the same user in room 1 should collapse to one entry.
+	addTestClient(h, "u-bob", "Bob", 1)
+	addTestClient(h, "u-bob", "Bob", 1)
+	addTestClient(h, "u-amy", "Amy", 1)
+	addTestClient(h, "u-cid", "Cid", 2) // different room — excluded
+
+	got := h.presenceFor(1)
+	if len(got) != 2 {
+		t.Fatalf("presenceFor(1) returned %d users, want 2: %+v", len(got), got)
+	}
+	if got[0].Name != "Amy" || got[1].Name != "Bob" {
+		t.Fatalf("presenceFor not sorted by name: %+v", got)
+	}
+}
+
+func TestPresenceForIgnoresAnonymousClients(t *testing.T) {
+	h := newLiveHub()
+	addTestClient(h, "", "", 1) // no identity (e.g. legacy connection)
+	addTestClient(h, "u-amy", "Amy", 1)
+	if got := h.presenceFor(1); len(got) != 1 {
+		t.Fatalf("presenceFor(1) = %+v, want only the identified user", got)
+	}
+}
+
+func TestBroadcastRoomPresenceReachesRoomSubscribers(t *testing.T) {
+	h := newLiveHub()
+	inRoom := addTestClient(h, "u-amy", "Amy", 7)
+	other := addTestClient(h, "u-bob", "Bob", 9)
+
+	h.broadcastRoomPresence(7)
+
+	select {
+	case payload := <-inRoom.send:
+		var ev liveEvent
+		if err := json.Unmarshal(payload, &ev); err != nil {
+			t.Fatalf("unmarshal presence event: %v", err)
+		}
+		if ev.Type != "room_presence" || ev.RoomID != 7 {
+			t.Fatalf("unexpected event: %+v", ev)
+		}
+	default:
+		t.Fatal("room subscriber did not receive presence event")
+	}
+
+	select {
+	case <-other.send:
+		t.Fatal("client in a different room received the presence event")
+	default:
+	}
+}
+
+func TestBroadcastTypingReachesRoomSubscribers(t *testing.T) {
+	h := newLiveHub()
+	inRoom := addTestClient(h, "u-amy", "Amy", 3)
+
+	h.broadcastTyping(3, presenceUser{UserID: "u-bob", Name: "Bob"})
+
+	select {
+	case payload := <-inRoom.send:
+		var ev liveEvent
+		if err := json.Unmarshal(payload, &ev); err != nil {
+			t.Fatalf("unmarshal typing event: %v", err)
+		}
+		if ev.Type != "typing" || ev.RoomID != 3 {
+			t.Fatalf("unexpected event: %+v", ev)
+		}
+	default:
+		t.Fatal("room subscriber did not receive typing event")
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -865,7 +865,7 @@ func TestWebSocketServeConnectsSubscribesPingsAndCloses(t *testing.T) {
 	errc := make(chan error, 1)
 	hub := newLiveHub()
 	go func() {
-		errc <- websocketServe(hub, rec, req)
+		errc <- websocketServe(hub, rec, req, "u-test", "Tester")
 	}()
 
 	reader := bufio.NewReader(clientConn)

--- a/internal/store/email_settings.go
+++ b/internal/store/email_settings.go
@@ -17,7 +17,7 @@ const (
 	emailKeyHost        = "email.smtp_host"
 	emailKeyPort        = "email.smtp_port"
 	emailKeyUsername    = "email.smtp_username"
-	emailKeyPassword    = "email.smtp_password"
+	emailKeyPassword    = "email.smtp_password" // #nosec G101 -- app_settings key name, not a credential
 	emailKeyFromAddress = "email.from_address"
 	emailKeyFromName    = "email.from_name"
 	emailKeySecurity    = "email.security"

--- a/web/default/index.html
+++ b/web/default/index.html
@@ -604,6 +604,7 @@
                                 <div>
                                     <h2 id="chat-room-title">Select a room</h2>
                                     <p class="meta" id="chat-room-topic"></p>
+                                    <p class="meta chat-presence" id="chat-presence" hidden></p>
                                 </div>
                                 <div class="view-actions">
                                     <button id="chat-rename-button" class="btn btn-ghost" type="button" hidden>Rename</button>
@@ -612,6 +613,7 @@
                                 </div>
                             </div>
                             <div id="chat-messages" class="chat-messages"></div>
+                            <div id="chat-typing" class="chat-typing-indicator" hidden></div>
                             <form id="chat-composer" class="chat-composer">
                                 <input id="chat-composer-input" type="text" autocomplete="off" placeholder="Message — @name, #label, or /task /new /invite /kick /join /leave /list /msg" disabled>
                                 <button id="chat-send-button" class="btn btn-primary" type="submit" disabled>Send</button>

--- a/web/default/site.css
+++ b/web/default/site.css
@@ -2131,3 +2131,5 @@ select {
 .chat-typing-dots span:nth-child(2) { animation-delay: .2s; }
 .chat-typing-dots span:nth-child(3) { animation-delay: .4s; }
 @keyframes chatTyping { 0%,60%,100% { opacity: .25; transform: translateY(0); } 30% { opacity: .9; transform: translateY(-3px); } }
+.chat-presence { margin-top: 2px; color: var(--accent, #2ea043); font-size: 0.75rem; }
+.chat-typing-indicator { padding: 2px 8px; color: var(--fg-2); font-size: 0.75rem; font-style: italic; min-height: 1em; }

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -2546,6 +2546,55 @@
                     state.liveSocket.send(JSON.stringify({ type: "subscribe", room_id: roomID }));
                 }
             } catch (e) { /* ignore */ }
+            // Switching rooms clears any presence/typing state from the old room.
+            renderRoomPresence([]);
+            clearTypingIndicator();
+        }
+        // emitTyping sends a typing notice for the active room, throttled so we
+        // don't flood the socket on every keystroke.
+        function emitTyping() {
+            if (!state.activeRoomID) { return; }
+            const now = Date.now();
+            if (state._lastTypingSentAt && now - state._lastTypingSentAt < 1500) { return; }
+            state._lastTypingSentAt = now;
+            try {
+                if (state.liveSocket && state.liveSocket.readyState === 1) {
+                    state.liveSocket.send(JSON.stringify({ type: "typing", room_id: state.activeRoomID }));
+                }
+            } catch (e) { /* ignore */ }
+        }
+        // renderRoomPresence shows who is currently present in the active room
+        // (excluding the current user — "you" is implied).
+        function renderRoomPresence(users) {
+            const el = document.getElementById("chat-presence");
+            if (!el) { return; }
+            const me = currentUserID();
+            const others = (Array.isArray(users) ? users : []).filter((u) => u && u.user_id !== me);
+            if (!others.length) {
+                el.hidden = true;
+                el.textContent = "";
+                return;
+            }
+            const names = others.map((u) => String(u.name || u.user_id || "?"));
+            el.hidden = false;
+            el.textContent = "● " + names.join(", ") + (names.length === 1 ? " is here" : " are here");
+        }
+        function clearTypingIndicator() {
+            const el = document.getElementById("chat-typing");
+            if (el) { el.hidden = true; el.textContent = ""; }
+            if (state._typingTimer) { clearTimeout(state._typingTimer); state._typingTimer = null; }
+        }
+        // showTypingIndicator displays a transient "X is typing…" that auto-expires
+        // if no further typing notice arrives.
+        function showTypingIndicator(who) {
+            const me = currentUserID();
+            if (!who || who.user_id === me) { return; }
+            const el = document.getElementById("chat-typing");
+            if (!el) { return; }
+            el.hidden = false;
+            el.textContent = String(who.name || "Someone") + " is typing…";
+            if (state._typingTimer) { clearTimeout(state._typingTimer); }
+            state._typingTimer = setTimeout(clearTypingIndicator, 3000);
         }
         function setupChat() {
             const list = document.getElementById("chat-rooms-list");
@@ -2613,6 +2662,10 @@
                         composerInput.value = "";
                         chatHistoryIdx = chatHistory.length;
                     }
+                });
+                // Emit a debounced typing notice so others see "X is typing…".
+                composerInput.addEventListener("input", () => {
+                    if (composerInput.value) { emitTyping(); }
                 });
             }
             const joinBtn = document.getElementById("chat-join-button");
@@ -2979,6 +3032,18 @@
                     if (payload.type === "room_message") {
                         if (state.activeRoomID && Number(payload.room_id) === state.activeRoomID) {
                             loadRoomMessages(state.activeRoomID);
+                        }
+                        return;
+                    }
+                    if (payload.type === "room_presence") {
+                        if (state.activeRoomID && Number(payload.room_id) === state.activeRoomID) {
+                            renderRoomPresence(payload.payload || []);
+                        }
+                        return;
+                    }
+                    if (payload.type === "typing") {
+                        if (state.activeRoomID && Number(payload.room_id) === state.activeRoomID) {
+                            showTypingIndicator(payload.payload || {});
                         }
                         return;
                     }


### PR DESCRIPTION
Part of epic **TK-166** (multiplayer chat). Targets the epic branch.

## What
- **Server**: live WS clients carry user identity. The hub derives per-room presence purely from live connections and broadcasts `room_presence` on subscribe / leave / disconnect, plus a transient `typing` event.
- **Web**: the chat header shows who else is present; a debounced typing notice drives an auto-expiring "X is typing…" indicator above the composer.

## Tests
- New `internal/server/realtime_presence_test.go`: presence dedup/sort, anonymous-client exclusion, room-scoped presence + typing fan-out.
- `make test`, `go test ./internal/server/`, `make lint` (0 issues), `make test-browser` (40 passed) all green.

Also includes a one-line `#nosec G101` fix for a pre-existing gosec false positive that was failing `make lint` on main.

refs TK-170

🤖 Generated with [Claude Code](https://claude.com/claude-code)