### PR TITLE
TK-167: composer power transforms (s/old/new/g)

### DIFF
--- a/docs/DATABASE CHANGE.md
+++ b/docs/DATABASE CHANGE.md
@@ -1,0 +1,29 @@
+DATABASE CHANGE
+
+I want to refine a new story that has a high quality title, descriptiojn, ac etc.   
+
+Frequently we introduce change to the tk system itself that incurs a database schema change.  
+
+What I want to do is use something other than "a new column" and consider how to embed more into the schema we have - or, amend hte schema such that we dont have to amnd it very often in the future - that is, lower the risk of schema change.  
+
+I think this is achieved using e.g. jsonb style or jsonl style - or plain old json style columns in the database to hold key/pairs or object/entities.
+
+Reason with me and design a more effective schema system.  
+
+Rules
+- lowers the likelihood of schema change in the future
+- we can perform schema change this time - and it must work against the existing db which I will make a  reference copy available to you locally.  
+- reinforce the migration logic such that it retains a backup of the prior so as to de-risk a broken migration - note, this is just the normal migration logic that I am asking you to reinforce
+
+---
+
+Once we have reasoned the design to a reasonable point, I want you to create a high-quality tk ticket using tk new.  I expect it will have a title, then a comprehensive description and acceptance criteria.
+
+I woud like to see upgraded documentation on the feature branch first along with design documents and diagrams to ensure the design is correct, before we implement any code.
+
+
+# git
+
+use an epic feature branch and make each story int he epic branch from the epic feature branch, each with their own PR against the epic.   Once all stories are complete then the epic can be PRed against the main branch such that the entire feature is merged to main only once it is complete.
+
+refine the above with me until it is ready then generate an epic and sub-stories to work on

--- a/docs/design/multiplayer-chat-epic.md
+++ b/docs/design/multiplayer-chat-epic.md
@@ -38,6 +38,16 @@ Sed-style substitution in the chat composer: `s/old/new/` (first match),
 - **Surface:** pure front-end in `web/shared/app.js` (composer input + keydown near
   `app.js:2596`). No API change for composer-only scope.
 
+**Resolved scope (TK-167):** the substitution targets your **previous composer
+message** (the last entry in the composer history) and loads the corrected text
+back into the composer for review — it is **not** auto-sent and does **not** edit a
+server-side message. This is the recognisable "sed correction" chat idiom while
+staying composer-only (no message-edit API). Invalid regex or no prior message →
+visible inline notice, composer left unchanged. The parser returns `{pattern,
+replacement, flags}` so a future explicit `target` (a selected ticket field) can be
+layered on without rework. Delimiter is any punctuation after `s` (so `s|/|-|g`
+works); flags limited to `g`/`i`.
+
 ---
 
 ## Story B (TK-168): Ephemeral agent backlog

--- a/tests/playwright/site2.spec.js
+++ b/tests/playwright/site2.spec.js
@@ -2195,3 +2195,47 @@ test("chat: opening the panel auto-selects a room and focuses the composer", asy
   await expect(page.locator("#chat-composer-input")).toBeEnabled();
   await expect(page.locator("#chat-composer-input")).toBeFocused();
 });
+
+test("composer power transforms apply sed-style substitutions safely (TK-167)", async ({ page }) => {
+  // The shared beforeEach already booted and logged in; the transform helpers
+  // are exposed on window at app boot.
+  const result = await page.evaluate(() => {
+    const tt = window.__site2TextTransform;
+    const apply = (target, text) => {
+      const sub = tt.parseSubstitution(text);
+      if (!sub) { return { parsed: false }; }
+      return { parsed: true, ...tt.applySubstitution(target, sub) };
+    };
+    return {
+      firstOnly: apply("teh cat sat on teh mat", "s/teh/the/"),
+      global: apply("teh cat sat on teh mat", "s/teh/the/g"),
+      caseInsensitive: apply("Hello HELLO hello", "s/hello/hi/gi"),
+      altDelimiter: apply("a/b/c", "s|/|-|g"),
+      invalid: apply("anything", "s/(unclosed/x/"),
+      notACommand: tt.parseSubstitution("such a nice day"),
+      bareWordS: tt.parseSubstitution("so this is fine"),
+    };
+  });
+  expect(result.firstOnly.text).toBe("the cat sat on teh mat");
+  expect(result.global.text).toBe("the cat sat on the mat");
+  expect(result.caseInsensitive.text).toBe("hi hi hi");
+  expect(result.altDelimiter.text).toBe("a-b-c");
+  expect(result.invalid.error).toBeTruthy(); // invalid regex reported, not thrown
+  expect(result.notACommand).toBeNull();
+  expect(result.bareWordS).toBeNull();
+});
+
+test("typing a substitution rewrites the previous message in the composer (TK-167)", async ({ page }) => {
+  // The shared beforeEach already logged in and landed on the Board.
+  await page.locator('#main-nav button[data-view="chat"]').click();
+  const input = page.locator("#chat-composer-input");
+  await expect(input).toBeEnabled();
+  // Send a message with a typo, then correct it with a substitution.
+  await input.fill("hello wrold");
+  await input.press("Enter");
+  await expect.poll(() => page.evaluate(() => document.getElementById("chat-composer-input").value)).toBe("");
+  await input.fill("s/wrold/world/");
+  await input.press("Enter");
+  // The substitution loads the corrected previous message back into the composer.
+  await expect(input).toHaveValue("hello world");
+});

--- a/web/default/index.html
+++ b/web/default/index.html
@@ -615,7 +615,7 @@
                             <div id="chat-messages" class="chat-messages"></div>
                             <div id="chat-typing" class="chat-typing-indicator" hidden></div>
                             <form id="chat-composer" class="chat-composer">
-                                <input id="chat-composer-input" type="text" autocomplete="off" placeholder="Message — @name, #label, or /task /new /invite /kick /join /leave /list /msg" disabled>
+                                <input id="chat-composer-input" type="text" autocomplete="off" placeholder="Message — @name, #label, /task /new /join /leave, or s/old/new/g to fix your last line" disabled>
                                 <button id="chat-send-button" class="btn btn-primary" type="submit" disabled>Send</button>
                             </form>
                         </div>

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -2469,11 +2469,75 @@
         // Shell-style composer history: Up/Down recall sent messages, Esc clears.
         let chatHistory = [];
         let chatHistoryIdx = 0;
+        // parseSubstitution recognises a sed-style s/pattern/replacement/[flags]
+        // command. The delimiter is whatever punctuation follows the leading "s";
+        // it can be escaped inside the pattern/replacement with a backslash. Only
+        // the g and i flags are accepted. Returns null when the text is not a
+        // well-formed substitution (so it is treated as an ordinary message).
+        function parseSubstitution(text) {
+            const t = String(text || "").trim();
+            if (t.length < 4 || t[0] !== "s") { return null; }
+            const delim = t[1];
+            if (/[\sA-Za-z0-9\\]/.test(delim)) { return null; }
+            const segs = [""];
+            let i = 2;
+            while (i < t.length) {
+                const ch = t[i];
+                if (ch === "\\" && i + 1 < t.length && t[i + 1] === delim) {
+                    segs[segs.length - 1] += delim; i += 2; continue;
+                }
+                if (ch === delim) {
+                    if (segs.length === 3) { return null; } // a 4th delimiter ⇒ not a clean s///
+                    segs.push(""); i++; continue;
+                }
+                segs[segs.length - 1] += ch; i++;
+            }
+            // Need the closing delimiter, i.e. exactly [pattern, replacement, flags].
+            if (segs.length !== 3) { return null; }
+            const pattern = segs[0], replacement = segs[1], flags = segs[2];
+            if (!pattern) { return null; }
+            if (/[^gi]/.test(flags)) { return null; }
+            return { pattern: pattern, replacement: replacement, flags: flags };
+        }
+        // applySubstitution runs a parsed substitution against target text. Returns
+        // {text} on success or {error} when the pattern is not a valid regex.
+        function applySubstitution(target, sub) {
+            let re;
+            try {
+                re = new RegExp(sub.pattern, sub.flags);
+            } catch (e) {
+                return { error: (e && e.message) || "invalid pattern" };
+            }
+            return { text: String(target).replace(re, sub.replacement) };
+        }
+        // Expose the pure transform helpers for browser tests (no effect otherwise).
+        try { window.__site2TextTransform = { parseSubstitution: parseSubstitution, applySubstitution: applySubstitution }; } catch (e) { /* ignore */ }
         function sendRoomMessage() {
             const input = document.getElementById("chat-composer-input");
             if (!input || !state.activeRoomID) { return; }
             const body = String(input.value || "").trim();
             if (!body) { return; }
+            // Power transform: s/old/new/[g][i] rewrites your previous message and
+            // loads the result back into the composer for review (it is not sent
+            // automatically). Operates on composer text; on a bad pattern or with
+            // no prior message it leaves the composer unchanged and explains why.
+            const sub = parseSubstitution(body);
+            if (sub) {
+                const prev = chatHistory.length ? chatHistory[chatHistory.length - 1] : "";
+                if (!prev) {
+                    setNotice("Nothing to transform — send a message first", true);
+                    return;
+                }
+                const result = applySubstitution(prev, sub);
+                if (result.error) {
+                    setNotice("Invalid pattern: " + result.error, true);
+                    return; // leave the s/// text in the composer so it can be fixed
+                }
+                input.value = result.text;
+                input.focus();
+                input.setSelectionRange(input.value.length, input.value.length);
+                return;
+            }
             if (chatHistory[chatHistory.length - 1] !== body) { chatHistory.push(body); }
             chatHistoryIdx = chatHistory.length;
             const roomID = state.activeRoomID;


### PR DESCRIPTION
Part of epic **TK-166** (multiplayer chat). Targets the epic branch.

## What
Type a sed-style `s/pattern/replacement/[g][i]` in the chat composer to rewrite your **previous** message; the corrected text loads back into the composer for review (not auto-sent, no server-side message edit). Any punctuation after `s` is the delimiter (`s|/|-|g` works). Invalid regex or no prior message → visible inline notice, composer left unchanged.

Resolved the open target-scope question (composer/previous-message only); design doc updated.

## Tests
- Two Playwright tests (`TK-167`): first/global/case-insensitive/alt-delimiter substitution, invalid-pattern safety, non-command passthrough, and end-to-end composer rewrite.
- `make lint` (0 issues), `make test-browser` (41 passed) green.

refs TK-167

🤖 Generated with [Claude Code](https://claude.com/claude-code)