### PR TITLE
TK-169: deeper /tk-NNN palette action stack

### DIFF
--- a/docs/design/multiplayer-chat-epic.md
+++ b/docs/design/multiplayer-chat-epic.md
@@ -111,6 +111,14 @@ Expand the shallow palette ticket-action menu into a richer numbered stack.
   endpoints. Cancel is a no-op (no data loss).
 - Front-end focused (`app.js` ~9715), reusing existing endpoints.
 
+**Resolved (TK-169):** the palette already had the frame stack, ESC frame-pop, and
+number/arrow selection (TK-127/TK-130). This story made action menus support nested
+sub-frames (`{label, submenu}`) and expanded the ticket actions to: Open detail, Add
+comment…, **Lifecycle…** (a pushed sub-frame: next / previous / ready / complete /
+reopen / close), Claim, Open in chat (breakout), Copy key — all wired to existing
+`POST /api/tickets/{key}/{action}` and `/api/tickets/claim`. ESC pops one level
+(submenu → ticket actions → command list → close).
+
 ---
 
 ## Story D (TK-170): Room presence & typing indicators

--- a/tests/playwright/site2.spec.js
+++ b/tests/playwright/site2.spec.js
@@ -2239,3 +2239,37 @@ test("typing a substitution rewrites the previous message in the composer (TK-16
   // The substitution loads the corrected previous message back into the composer.
   await expect(input).toHaveValue("hello world");
 });
+
+test("palette /tk-NNN exposes a deeper action stack with a lifecycle submenu (TK-169)", async ({ page }) => {
+  // The shared beforeEach already logged in and landed on the Board.
+  await page.keyboard.press("Shift");
+  await page.keyboard.press("Shift");
+  await expect(page.locator("#command-palette-overlay")).toBeVisible();
+  await page.locator("#command-palette-input").fill("ops-101");
+  await page.locator("#command-palette-input").press("Enter");
+  // Expanded top-level actions are present.
+  const list = page.locator("#command-palette-list");
+  await expect(list).toContainText("Open detail");
+  await expect(list).toContainText("Lifecycle…");
+  await expect(list).toContainText("Claim");
+  await expect(list).toContainText("Open in chat (breakout)");
+
+  // Entering the Lifecycle submenu pushes a new frame (number key selects it).
+  await page.locator("#command-palette-input").press("3");
+  await expect(list).toContainText("Advance → next");
+  await expect(list).toContainText("Complete");
+  await expect(list).not.toContainText("Open detail"); // we are one frame deeper
+
+  // Esc pops back to the ticket's top-level actions (not closed).
+  await page.locator("#command-palette-input").press("Escape");
+  await expect(page.locator("#command-palette-overlay")).toBeVisible();
+  await expect(list).toContainText("Lifecycle…");
+  await expect(list).not.toContainText("Advance → next");
+
+  // Esc again pops back to the command list; a third closes the palette.
+  await page.locator("#command-palette-input").press("Escape");
+  await expect(page.locator("#command-palette-overlay")).toBeVisible();
+  await expect(list).not.toContainText("Lifecycle…");
+  await page.locator("#command-palette-input").press("Escape");
+  await expect(page.locator("#command-palette-overlay")).toBeHidden();
+});

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -9915,18 +9915,56 @@
                     .catch((err) => setNotice("Comment failed: " + err.message, true));
             });
         }
+        // afterTicketMutation refreshes ticket state + the board after a palette
+        // action changes a ticket, so the change is visible without a manual reload.
+        function afterTicketMutation() {
+            Promise.resolve().then(() => loadTickets()).then(() => {
+                if (typeof renderAll === "function") { renderAll(); }
+            }).catch(() => {});
+        }
+        // ticketLifecycleAction POSTs to a ticket lifecycle endpoint (next, previous,
+        // ready, complete, reopen, close, …) and reports the outcome.
+        function ticketLifecycleAction(key, action, label) {
+            return api("/api/tickets/" + encodeURIComponent(key) + "/" + action, { method: "POST", body: {} })
+                .then(() => { setNotice(key + " — " + label + "."); afterTicketMutation(); })
+                .catch((err) => setNotice(label + " failed: " + err.message, true));
+        }
+        function claimTicket(key) {
+            return api("/api/tickets/claim", { method: "POST", body: { ticket_ref: key } })
+                .then((res) => { setNotice(key + " — " + ((res && res.status) ? String(res.status).toLowerCase() : "claimed") + "."); afterTicketMutation(); })
+                .catch((err) => setNotice("Claim failed: " + err.message, true));
+        }
+        // ticketLifecycleItems is the second-level "Lifecycle…" submenu, pushed as a
+        // new frame so Esc pops back to the ticket's top-level actions (TK-169).
+        function ticketLifecycleItems(key) {
+            return [
+                { label: "Advance → next", run: () => ticketLifecycleAction(key, "next", "advanced") },
+                { label: "Move back ← previous", run: () => ticketLifecycleAction(key, "previous", "moved back") },
+                { label: "Mark ready", run: () => ticketLifecycleAction(key, "ready", "marked ready") },
+                { label: "Complete", run: () => ticketLifecycleAction(key, "complete", "completed") },
+                { label: "Reopen", run: () => ticketLifecycleAction(key, "reopen", "reopened") },
+                { label: "Close", run: () => ticketLifecycleAction(key, "close", "closed") },
+            ];
+        }
         function ticketActionItems(key) {
             return [
                 { label: "Open detail", run: () => openTicketByKey(key) },
                 { label: "Add comment…", run: () => promptTicketComment(key) },
+                { label: "Lifecycle…", title: key + " · lifecycle", submenu: () => ticketLifecycleItems(key) },
+                { label: "Claim", run: () => claimTicket(key) },
+                { label: "Open in chat (breakout)", run: () => openBreakoutRoom((state.tickets || []).find((t) => String(t.id || "").toUpperCase() === key) || { id: key }) },
                 { label: "Copy key", run: () => { try { if (navigator.clipboard) { navigator.clipboard.writeText(key); } } catch (e) {} setNotice("Copied " + key + "."); } },
             ];
         }
-        function pushTicketActions(key) {
-            paletteStack.push({ kind: "actions", title: key, items: ticketActionItems(key) });
+        // pushActionsFrame pushes a generic action menu onto the palette stack.
+        function pushActionsFrame(title, items) {
+            paletteStack.push({ kind: "actions", title: title, items: items });
             paletteActiveIndex = 0;
             paletteEls.input.value = "";
             renderPalette();
+        }
+        function pushTicketActions(key) {
+            pushActionsFrame(key, ticketActionItems(key));
         }
         function popPaletteFrame() {
             if (paletteStack.length <= 1) { return false; }
@@ -9942,7 +9980,15 @@
             if (frame.kind === "actions") {
                 return frame.items
                     .filter((it) => !query || it.label.toLowerCase().includes(query))
-                    .map((it, i) => ({ left: String(i + 1), label: it.label, run: () => { closeCommandPalette(); it.run(); } }));
+                    .map((it, i) => ({
+                        left: String(i + 1),
+                        label: it.label,
+                        // A submenu pushes another frame (Esc pops back); a leaf
+                        // action closes the palette and runs.
+                        run: it.submenu
+                            ? () => pushActionsFrame(it.title || it.label, it.submenu())
+                            : () => { closeCommandPalette(); it.run(); },
+                    }));
             }
             const rank = (cmd) => (cmd.key === query ? 0 : cmd.key.startsWith(query) ? 1 : cmd.label.toLowerCase().startsWith(query) ? 2 : 3);
             const items = buildPaletteCommands()


### PR DESCRIPTION
Part of epic **TK-166** (multiplayer chat). Targets the epic branch.

## What
Palette action menus now support nested sub-frames. The `/tk-NNN` ticket action menu is expanded to: Open detail, Add comment…, **Lifecycle…** (a pushed submenu: next / previous / ready / complete / reopen / close), Claim, Open in chat (breakout), Copy key — wired to existing `POST /api/tickets/{key}/{action}` and `/api/tickets/claim`. Esc pops one frame at a time (submenu → actions → commands → close); number + arrow selection work at every level.

## Tests
- New Playwright test (`TK-169`): expanded actions present, submenu push, multi-level Esc frame-pop.
- `make lint` (0 issues), `make test-browser` (46 passed) green.

refs TK-169

🤖 Generated with [Claude Code](https://claude.com/claude-code)