### PR TITLE
TK-168: ephemeral agent backlog (@agent do/queue)

### DIFF
--- a/docs/design/multiplayer-chat-epic.md
+++ b/docs/design/multiplayer-chat-epic.md
@@ -96,6 +96,18 @@ created_at, updated_at}` where `state ∈ {queued, running, done, failed}`.
 Reuses: room membership, WS hub, `room_agent.go`, `/task` path.
 New: queue table + worker loop + panel + enqueue rule + `/promote`.
 
+**Resolved (TK-168):** new `room_agent_tasks` table (distinct from `work_items`);
+always-ephemeral with TTL purge (`PurgeFinishedRoomAgentTasks`). `ClaimNextRoomAgentTask`
+atomically marks the oldest queued task running **only if** no task for the same
+`(room, agent)` is already running — serial per (room,agent), concurrent across keys.
+A server-lifecycle dispatcher (`runRoomAgentTaskWorker`, gated by `roomWorkerEnabled`
+so tests don't race it) drains eligible tasks, runs each via the existing
+`roomAgentReply`, posts the result into the room, and broadcasts a `room_queue` WS
+event. `@agent do/queue X` enqueues (`parseAgentTaskInstruction`); other mentions
+still reply once. `GET /api/rooms/{id}/agent-queue` feeds the live panel;
+`/promote [id]` converts a task into a real ticket via `createRoomTask` and removes
+it from the queue.
+
 ---
 
 ## Story C (TK-169): Deeper `/tk-NNN` palette action stack

--- a/internal/server/api_auth_passkey_test.go
+++ b/internal/server/api_auth_passkey_test.go
@@ -60,7 +60,7 @@ func testHandlerWithPasskeys(t *testing.T, svc passkey.Service) (http.Handler, *
 	if err != nil {
 		t.Fatalf("Open() error = %v", err)
 	}
-	handler, err := handlerWithPasskeyFactory(db, "1.2.3", false, nil, "", "", nil, nil, func(*http.Request) (passkey.Service, error) {
+	handler, _, err := handlerWithPasskeyFactory(db, "1.2.3", false, nil, "", "", nil, nil, func(*http.Request) (passkey.Service, error) {
 		return svc, nil
 	})
 	if err != nil {

--- a/internal/server/api_rooms.go
+++ b/internal/server/api_rooms.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log"
 	"net/http"
 	"regexp"
 	"sort"
@@ -169,6 +170,8 @@ func (r *router) registerRoomHandlers() {
 			handleRoomMembers(w, req, db, roomID)
 		case "messages":
 			handleRoomMessages(w, req, db, user, room, r.live)
+		case "agent-queue":
+			handleRoomAgentQueue(w, req, db, roomID)
 		default:
 			writeError(w, http.StatusNotFound, "unknown room subresource")
 		}
@@ -222,6 +225,48 @@ func handleRoomItem(w http.ResponseWriter, req *http.Request, db *sql.DB, user s
 	default:
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 	}
+}
+
+// resolvePromoteTask picks the agent task to promote: the one named by id, or —
+// when no id is given — the most recent task in the room.
+func resolvePromoteTask(ctx context.Context, db *sql.DB, roomID int64, arg string) (store.RoomAgentTask, error) {
+	arg = strings.TrimSpace(arg)
+	if arg != "" {
+		id, err := strconv.ParseInt(arg, 10, 64)
+		if err != nil {
+			return store.RoomAgentTask{}, fmt.Errorf("usage: /promote <task id>")
+		}
+		task, gerr := store.GetRoomAgentTask(ctx, db, id)
+		if gerr != nil || task.RoomID != roomID {
+			return store.RoomAgentTask{}, fmt.Errorf("no such task in this room")
+		}
+		return task, nil
+	}
+	tasks, err := store.ListRoomAgentTasks(ctx, db, roomID)
+	if err != nil {
+		return store.RoomAgentTask{}, err
+	}
+	if len(tasks) == 0 {
+		return store.RoomAgentTask{}, fmt.Errorf("no agent tasks to promote")
+	}
+	return tasks[len(tasks)-1], nil
+}
+
+// handleRoomAgentQueue returns the room's ephemeral agent task queue (TK-168).
+func handleRoomAgentQueue(w http.ResponseWriter, req *http.Request, db *sql.DB, roomID int64) {
+	if req.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	tasks, err := store.ListRoomAgentTasks(req.Context(), db, roomID)
+	if err != nil {
+		writeStoreError(w, err)
+		return
+	}
+	if tasks == nil {
+		tasks = []store.RoomAgentTask{}
+	}
+	writeJSON(w, http.StatusOK, tasks)
 }
 
 func handleRoomMembers(w http.ResponseWriter, req *http.Request, db *sql.DB, roomID int64) {
@@ -456,6 +501,27 @@ func handleRoomCommand(w http.ResponseWriter, req *http.Request, db *sql.DB, roo
 			writeError(w, http.StatusBadRequest, terr.Error())
 			return true
 		}
+		if hub != nil {
+			hub.broadcastRoomMessage(room.ID, msg)
+		}
+		writeJSON(w, http.StatusCreated, msg)
+		return true
+	case "promote":
+		task, perr := resolvePromoteTask(ctx, db, room.ID, arg)
+		if perr != nil {
+			writeError(w, http.StatusBadRequest, perr.Error())
+			return true
+		}
+		msg, terr := createRoomTask(ctx, db, room, user, "", task.Instruction)
+		if terr != nil {
+			writeError(w, http.StatusBadRequest, terr.Error())
+			return true
+		}
+		// The ephemeral task has become a real ticket; drop it from the queue.
+		if derr := store.DeleteRoomAgentTask(ctx, db, task.ID); derr != nil {
+			log.Printf("server: delete promoted room agent task: %v", derr)
+		}
+		broadcastRoomQueue(ctx, db, hub, room.ID)
 		if hub != nil {
 			hub.broadcastRoomMessage(room.ID, msg)
 		}

--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -1,0 +1,14 @@
+package server
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain disables the ephemeral agent-task dispatcher for the server test
+// suite. Tests drive the queue directly (enqueue/claim/execute), so a live
+// background worker would race with them; production keeps it enabled (TK-168).
+func TestMain(m *testing.M) {
+	roomWorkerEnabled = false
+	os.Exit(m.Run())
+}

--- a/internal/server/room_agent.go
+++ b/internal/server/room_agent.go
@@ -45,6 +45,14 @@ func replyAsAgents(ctx context.Context, db *sql.DB, room store.Room, msg store.R
 		if merr != nil || !member {
 			continue
 		}
+		// "@agent do X" / "@agent queue X" enqueues an ephemeral work-item the
+		// worker processes serially; any other "@agent X" is a one-shot reply.
+		if instruction, ok := parseAgentTaskInstruction(msg.Body, agent.Username); ok {
+			if enqueueAgentTask(ctx, db, room, agent, msg.SenderID, instruction, hub) {
+				posted++
+			}
+			continue
+		}
 		if postAgentReply(ctx, db, room, agent, msg.SenderID, msg.Body, hub) {
 			posted++
 		}
@@ -72,6 +80,49 @@ func replyAsAgents(ctx context.Context, db *sql.DB, room store.Room, msg store.R
 		log.Printf("server: no agent reply in room %d (slug=%q): no agent @mentioned and not a personal-agent DM with an agent member", room.ID, room.Slug)
 	}
 	return posted
+}
+
+// parseAgentTaskInstruction detects the "@agent do X" / "@agent queue X" pattern
+// addressed to agentName and returns the instruction (the text after the verb).
+// The match is case-insensitive and the verb must be a whole word; otherwise it
+// returns ok=false so the message is treated as an ordinary mention/reply.
+func parseAgentTaskInstruction(body, agentName string) (string, bool) {
+	lower := strings.ToLower(body)
+	marker := "@" + strings.ToLower(strings.TrimSpace(agentName))
+	idx := strings.Index(lower, marker)
+	if idx < 0 {
+		return "", false
+	}
+	rest := strings.TrimSpace(body[idx+len(marker):])
+	restLower := strings.ToLower(rest)
+	for _, verb := range []string{"do", "queue"} {
+		if restLower == verb {
+			return "", false // a verb with no instruction is not a task
+		}
+		if strings.HasPrefix(restLower, verb+" ") {
+			return strings.TrimSpace(rest[len(verb):]), true
+		}
+	}
+	return "", false
+}
+
+// enqueueAgentTask adds an ephemeral task to the room's agent queue, posts a brief
+// acknowledgement, refreshes the live queue, and wakes the worker (TK-168).
+func enqueueAgentTask(ctx context.Context, db *sql.DB, room store.Room, agent store.User, requesterID, instruction string, hub *liveHub) bool {
+	if _, err := store.EnqueueRoomAgentTask(ctx, db, store.RoomAgentTask{
+		RoomID:      room.ID,
+		AgentID:     agent.ID,
+		AgentName:   agent.Username,
+		RequesterID: requesterID,
+		Instruction: instruction,
+	}); err != nil {
+		log.Printf("server: enqueue room agent task: %v", err)
+		return false
+	}
+	postAgentEvent(ctx, db, room, agent, "📋 queued: "+instruction, hub)
+	broadcastRoomQueue(ctx, db, hub, room.ID)
+	signalRoomTaskWorker()
+	return true
 }
 
 // postAgentReply generates and posts a single agent reply into the room. The
@@ -118,11 +169,16 @@ func postAgentReply(ctx context.Context, db *sql.DB, room store.Room, agent stor
 // postAgentNotice posts a muted agent_event line (e.g. a reply failure) into the
 // room from the agent, so failures are visible rather than silent.
 func postAgentNotice(ctx context.Context, db *sql.DB, room store.Room, agent store.User, text string, hub *liveHub) {
+	postAgentEvent(ctx, db, room, agent, "⚠️ "+text, hub)
+}
+
+// postAgentEvent posts a muted agent_event line into the room from the agent.
+func postAgentEvent(ctx context.Context, db *sql.DB, room store.Room, agent store.User, text string, hub *liveHub) {
 	out, err := store.PostRoomMessage(ctx, db, store.RoomMessage{
 		RoomID:   room.ID,
 		SenderID: agent.ID,
 		Kind:     "agent_event",
-		Body:     "⚠️ " + text,
+		Body:     text,
 		Attrs:    store.Attrs{"agent": true},
 	})
 	if err != nil {

--- a/internal/server/room_agent_task_test.go
+++ b/internal/server/room_agent_task_test.go
@@ -1,0 +1,258 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/simonski/ticket/internal/store"
+)
+
+func TestParseAgentTaskInstruction(t *testing.T) {
+	cases := []struct {
+		body, agent  string
+		wantInstr    string
+		wantIsTask   bool
+		caseExplains string
+	}{
+		{"@bot do fix the build", "bot", "fix the build", true, "do verb"},
+		{"@bot queue run the tests", "bot", "run the tests", true, "queue verb"},
+		{"@BOT DO shout", "bot", "shout", true, "case-insensitive"},
+		{"@bot hello there", "bot", "", false, "plain mention"},
+		{"@bot do", "bot", "", false, "verb without instruction"},
+		{"@bot doom the world", "bot", "", false, "verb must be a whole word"},
+		{"no mention here", "bot", "", false, "no mention"},
+	}
+	for _, c := range cases {
+		instr, ok := parseAgentTaskInstruction(c.body, c.agent)
+		if ok != c.wantIsTask || instr != c.wantInstr {
+			t.Errorf("%s: parseAgentTaskInstruction(%q) = (%q, %v), want (%q, %v)",
+				c.caseExplains, c.body, instr, ok, c.wantInstr, c.wantIsTask)
+		}
+	}
+}
+
+func TestRoomAgentTaskQueueLifecycle(t *testing.T) {
+	_, db := testHandler(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	agent, _, err := store.CreateAgent(ctx, db, "")
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	room, err := store.CreateRoom(ctx, db, store.Room{Name: "Work", CreatedBy: "admin"})
+	if err != nil {
+		t.Fatalf("create room: %v", err)
+	}
+
+	// Enqueue two tasks for the same (room, agent).
+	t1, err := store.EnqueueRoomAgentTask(ctx, db, store.RoomAgentTask{RoomID: room.ID, AgentID: agent.ID, AgentName: agent.Username, Instruction: "first"})
+	if err != nil {
+		t.Fatalf("enqueue 1: %v", err)
+	}
+	if t1.State != store.RoomAgentTaskQueued || !t1.Ephemeral {
+		t.Fatalf("enqueued task = %+v, want queued+ephemeral", t1)
+	}
+	if _, err := store.EnqueueRoomAgentTask(ctx, db, store.RoomAgentTask{RoomID: room.ID, AgentID: agent.ID, AgentName: agent.Username, Instruction: "second"}); err != nil {
+		t.Fatalf("enqueue 2: %v", err)
+	}
+
+	// First claim returns task 1 and marks it running.
+	claimed, ok, err := store.ClaimNextRoomAgentTask(ctx, db)
+	if err != nil || !ok {
+		t.Fatalf("claim 1: ok=%v err=%v", ok, err)
+	}
+	if claimed.ID != t1.ID || claimed.State != store.RoomAgentTaskRunning {
+		t.Fatalf("claimed = %+v, want task %d running", claimed, t1.ID)
+	}
+
+	// Second claim must NOT return task 2: serial concurrency-1 per (room, agent)
+	// while task 1 is still running.
+	if _, ok2, err := store.ClaimNextRoomAgentTask(ctx, db); err != nil || ok2 {
+		t.Fatalf("claim 2 returned ok=%v (want no eligible task while one runs)", ok2)
+	}
+
+	// Finishing task 1 frees the (room, agent) so task 2 becomes claimable.
+	if _, err := store.FinishRoomAgentTask(ctx, db, t1.ID, store.RoomAgentTaskDone, "done one"); err != nil {
+		t.Fatalf("finish 1: %v", err)
+	}
+	claimed2, ok, err := store.ClaimNextRoomAgentTask(ctx, db)
+	if err != nil || !ok {
+		t.Fatalf("claim after finish: ok=%v err=%v", ok, err)
+	}
+	if claimed2.Instruction != "second" {
+		t.Fatalf("claimed2 = %+v, want the second task", claimed2)
+	}
+
+	// Listing shows both tasks for the room.
+	tasks, err := store.ListRoomAgentTasks(ctx, db, room.ID)
+	if err != nil || len(tasks) != 2 {
+		t.Fatalf("list tasks = %d (%v)", len(tasks), err)
+	}
+}
+
+func TestRoomAgentTaskClaimSeparateAgentsConcurrent(t *testing.T) {
+	_, db := testHandler(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	a1, _, _ := store.CreateAgent(ctx, db, "")
+	a2, _, _ := store.CreateAgent(ctx, db, "")
+	room, _ := store.CreateRoom(ctx, db, store.Room{Name: "Multi", CreatedBy: "admin"})
+	if _, err := store.EnqueueRoomAgentTask(ctx, db, store.RoomAgentTask{RoomID: room.ID, AgentID: a1.ID, AgentName: a1.Username, Instruction: "x"}); err != nil {
+		t.Fatalf("enqueue a1: %v", err)
+	}
+	if _, err := store.EnqueueRoomAgentTask(ctx, db, store.RoomAgentTask{RoomID: room.ID, AgentID: a2.ID, AgentName: a2.Username, Instruction: "y"}); err != nil {
+		t.Fatalf("enqueue a2: %v", err)
+	}
+
+	// Both tasks belong to different agents, so both are simultaneously claimable.
+	c1, ok1, _ := store.ClaimNextRoomAgentTask(ctx, db)
+	c2, ok2, _ := store.ClaimNextRoomAgentTask(ctx, db)
+	if !ok1 || !ok2 {
+		t.Fatalf("expected two concurrent claims for distinct agents, got ok1=%v ok2=%v", ok1, ok2)
+	}
+	if c1.AgentID == c2.AgentID {
+		t.Fatalf("claims went to the same agent: %s twice", c1.AgentID)
+	}
+}
+
+func TestExecuteRoomAgentTaskPostsResultAndCompletes(t *testing.T) {
+	_, db := testHandler(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	agent, _, _ := store.CreateAgent(ctx, db, "")
+	room, _ := store.CreateRoom(ctx, db, store.Room{Name: "Run", CreatedBy: "admin"})
+
+	orig := roomAgentReply
+	roomAgentReply = func(_ context.Context, _ store.AgentModelConfig, _ []string, agentName, instruction string, _ []store.RoomMessage) (string, error) {
+		return "result for: " + instruction, nil
+	}
+	defer func() { roomAgentReply = orig }()
+
+	task, err := store.EnqueueRoomAgentTask(ctx, db, store.RoomAgentTask{RoomID: room.ID, AgentID: agent.ID, AgentName: agent.Username, Instruction: "summarise"})
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	claimed, ok, err := store.ClaimNextRoomAgentTask(ctx, db)
+	if err != nil || !ok {
+		t.Fatalf("claim: ok=%v err=%v", ok, err)
+	}
+
+	s := &Server{}
+	s.executeRoomAgentTask(db, nil, claimed)
+
+	// Task is now done with the result recorded.
+	got, err := store.GetRoomAgentTask(ctx, db, task.ID)
+	if err != nil {
+		t.Fatalf("get task: %v", err)
+	}
+	if got.State != store.RoomAgentTaskDone || !strings.Contains(got.Result, "summarise") {
+		t.Fatalf("task after run = %+v, want done with result", got)
+	}
+
+	// The result is posted into the room as an agent message.
+	msgs, _ := store.ListRoomMessages(ctx, db, room.ID, 50, 0)
+	found := false
+	for _, m := range msgs {
+		if m.SenderID == agent.ID && strings.Contains(m.Body, "result for: summarise") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("agent result not posted into the room; messages=%+v", msgs)
+	}
+}
+
+func TestPurgeFinishedRoomAgentTasks(t *testing.T) {
+	_, db := testHandler(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	agent, _, _ := store.CreateAgent(ctx, db, "")
+	room, _ := store.CreateRoom(ctx, db, store.Room{Name: "Purge", CreatedBy: "admin"})
+	task, _ := store.EnqueueRoomAgentTask(ctx, db, store.RoomAgentTask{RoomID: room.ID, AgentID: agent.ID, AgentName: agent.Username, Instruction: "old"})
+	if _, err := store.FinishRoomAgentTask(ctx, db, task.ID, store.RoomAgentTaskDone, "ok"); err != nil {
+		t.Fatalf("finish: %v", err)
+	}
+
+	// A finished task is not purged while still within its TTL.
+	if removed, err := store.PurgeFinishedRoomAgentTasks(ctx, db, 3600); err != nil || removed != 0 {
+		t.Fatalf("purge within TTL removed=%d err=%v, want 0", removed, err)
+	}
+	// With a zero age, finished tasks are eligible and removed.
+	if removed, err := store.PurgeFinishedRoomAgentTasks(ctx, db, 0); err != nil || removed != 1 {
+		t.Fatalf("purge age=0 removed=%d err=%v, want 1", removed, err)
+	}
+}
+
+func TestRoomAgentQueueEnqueueListAndPromote(t *testing.T) {
+	handler, db := testHandler(t)
+	defer db.Close()
+	ctx := context.Background()
+	admin := roomLoginToken(t, handler, "admin", "password")
+
+	// A project so the room is project-scoped (promotion creates a ticket there).
+	projResp := doJSONRequest(t, handler, http.MethodPost, "/api/projects", map[string]any{"title": "Queue Project"}, admin)
+	if projResp.Code != http.StatusCreated {
+		t.Fatalf("create project: %d %s", projResp.Code, projResp.Body.String())
+	}
+	var project store.Project
+	decodeResponse(t, projResp, &project)
+
+	// An agent named "buildbot", joined to a project room.
+	agent, _, err := store.CreateAgent(ctx, db, "")
+	if err != nil {
+		t.Fatalf("create agent: %v", err)
+	}
+	uname := "buildbot"
+	if _, uerr := store.UpdateAgent(ctx, db, agent.ID, store.AgentUpdateParams{Username: &uname}); uerr != nil {
+		t.Fatalf("rename agent: %v", uerr)
+	}
+	pid := project.ID
+	room, err := store.CreateRoom(ctx, db, store.Room{Name: "BuildRoom", ProjectID: &pid, CreatedBy: "admin"})
+	if err != nil {
+		t.Fatalf("create room: %v", err)
+	}
+	if jerr := store.JoinRoom(ctx, db, room.ID, agent.ID, "member"); jerr != nil {
+		t.Fatalf("join agent: %v", jerr)
+	}
+
+	roomPath := "/api/rooms/" + itoa(room.ID)
+
+	// "@buildbot do …" enqueues an ephemeral task rather than replying.
+	postResp := doJSONRequest(t, handler, http.MethodPost, roomPath+"/messages", map[string]string{"body": "@buildbot do run the linter"}, admin)
+	if postResp.Code != http.StatusCreated {
+		t.Fatalf("post task message: %d %s", postResp.Code, postResp.Body.String())
+	}
+
+	// The queue endpoint lists the queued task.
+	queueResp := doJSONRequest(t, handler, http.MethodGet, roomPath+"/agent-queue", nil, admin)
+	if queueResp.Code != http.StatusOK {
+		t.Fatalf("agent-queue: %d %s", queueResp.Code, queueResp.Body.String())
+	}
+	var tasks []store.RoomAgentTask
+	decodeResponse(t, queueResp, &tasks)
+	if len(tasks) != 1 || tasks[0].Instruction != "run the linter" || tasks[0].State != store.RoomAgentTaskQueued {
+		t.Fatalf("queue = %+v, want one queued 'run the linter'", tasks)
+	}
+
+	// /promote turns the queued task into a real ticket and clears it from the queue.
+	promoteResp := doJSONRequest(t, handler, http.MethodPost, roomPath+"/messages", map[string]string{"body": "/promote " + itoa(tasks[0].ID)}, admin)
+	if promoteResp.Code != http.StatusCreated {
+		t.Fatalf("promote: %d %s", promoteResp.Code, promoteResp.Body.String())
+	}
+	var promoted store.RoomMessage
+	decodeResponse(t, promoteResp, &promoted)
+	if promoted.Kind != "task" || promoted.Attrs["task_id"] == nil {
+		t.Fatalf("promote message = %+v, want a task message with task_id", promoted)
+	}
+
+	afterTasks, _ := store.ListRoomAgentTasks(ctx, db, room.ID)
+	if len(afterTasks) != 0 {
+		t.Fatalf("queue after promote = %+v, want empty", afterTasks)
+	}
+}

--- a/internal/server/room_agent_worker.go
+++ b/internal/server/room_agent_worker.go
@@ -1,0 +1,160 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/simonski/ticket/internal/store"
+)
+
+const (
+	// roomAgentTaskTTLSeconds is how long a finished ephemeral task is retained
+	// before the worker purges it, so the live panel can show recent results.
+	roomAgentTaskTTLSeconds = 3600
+	// roomAgentTaskPoll is the idle poll cadence; enqueue also wakes the worker.
+	roomAgentTaskPoll = 3 * time.Second
+)
+
+// roomTaskSignal wakes the dispatcher when a task is enqueued or finishes, so the
+// queue drains promptly instead of waiting for the poll tick.
+var roomTaskSignal = make(chan struct{}, 1)
+
+func signalRoomTaskWorker() {
+	select {
+	case roomTaskSignal <- struct{}{}:
+	default:
+	}
+}
+
+// runRoomAgentTaskWorker is the dispatcher for the ephemeral agent backlog
+// (TK-168). It repeatedly claims eligible queued tasks — at most one running per
+// (room, agent) — runs each concurrently, and periodically purges finished items.
+func (s *Server) runRoomAgentTaskWorker(db *sql.DB, hub *liveHub) {
+	poll := time.NewTicker(roomAgentTaskPoll)
+	defer poll.Stop()
+	purge := time.NewTicker(2 * time.Minute)
+	defer purge.Stop()
+	for {
+		// Drain everything currently eligible; each claim marks a task running so
+		// the same (room, agent) is not picked again until it finishes.
+		for {
+			select {
+			case <-s.stopRoomWorker:
+				return
+			default:
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			task, ok, err := store.ClaimNextRoomAgentTask(ctx, db)
+			cancel()
+			if err != nil {
+				log.Printf("server: claim room agent task: %v", err)
+				break
+			}
+			if !ok {
+				break
+			}
+			broadcastRoomQueue(context.Background(), db, hub, task.RoomID)
+			go s.executeRoomAgentTask(db, hub, task)
+		}
+		select {
+		case <-s.stopRoomWorker:
+			return
+		case <-roomTaskSignal:
+		case <-poll.C:
+		case <-purge.C:
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			if _, err := store.PurgeFinishedRoomAgentTasks(ctx, db, roomAgentTaskTTLSeconds); err != nil {
+				log.Printf("server: purge room agent tasks: %v", err)
+			}
+			cancel()
+		}
+	}
+}
+
+// executeRoomAgentTask runs a single claimed task: it generates the agent reply,
+// posts the result into the room, marks the task done/failed, and refreshes the
+// live queue. It always signals the dispatcher so the next item for the same
+// (room, agent) can be picked up.
+func (s *Server) executeRoomAgentTask(db *sql.DB, hub *liveHub, task store.RoomAgentTask) {
+	defer signalRoomTaskWorker()
+	ctx, cancel := context.WithTimeout(context.Background(), 130*time.Second)
+	defer cancel()
+
+	room, err := store.GetRoom(ctx, db, task.RoomID)
+	if err != nil {
+		if _, ferr := store.FinishRoomAgentTask(ctx, db, task.ID, store.RoomAgentTaskFailed, "room not found"); ferr != nil {
+			log.Printf("server: finish room agent task: %v", ferr)
+		}
+		broadcastRoomQueue(ctx, db, hub, task.RoomID)
+		return
+	}
+	agent, aerr := store.GetUserByID(ctx, db, task.AgentID)
+	if aerr != nil {
+		if _, ferr := store.FinishRoomAgentTask(ctx, db, task.ID, store.RoomAgentTaskFailed, "agent not found"); ferr != nil {
+			log.Printf("server: finish room agent task: %v", ferr)
+		}
+		broadcastRoomQueue(ctx, db, hub, task.RoomID)
+		return
+	}
+
+	cfg, _ := store.ResolveAgentModelConfig(ctx, db, task.RequesterID, room.ProjectID)
+	cmdArgs := resolveAgentChatCommand(ctx, db)
+	history, _ := store.ListRoomMessages(ctx, db, room.ID, 20, 0)
+	reply, rerr := roomAgentReply(ctx, cfg, cmdArgs, agent.Username, task.Instruction, history)
+	if rerr != nil {
+		log.Printf("server: room agent task %d failed: %v", task.ID, rerr)
+		postAgentNotice(ctx, db, room, agent, "task failed — "+task.Instruction+" (see server logs).", hub)
+		if _, ferr := store.FinishRoomAgentTask(ctx, db, task.ID, store.RoomAgentTaskFailed, rerr.Error()); ferr != nil {
+			log.Printf("server: finish room agent task: %v", ferr)
+		}
+		broadcastRoomQueue(ctx, db, hub, task.RoomID)
+		return
+	}
+
+	reply = strings.TrimSpace(reply)
+	if reply != "" {
+		postAgentText(ctx, db, room, agent, reply, cfg.Model, hub)
+	}
+	if _, ferr := store.FinishRoomAgentTask(ctx, db, task.ID, store.RoomAgentTaskDone, reply); ferr != nil {
+		log.Printf("server: finish room agent task: %v", ferr)
+	}
+	broadcastRoomQueue(ctx, db, hub, task.RoomID)
+}
+
+// postAgentText posts a normal agent chat message (with the model annotation) and
+// broadcasts it. Shared by one-shot replies and queue task results.
+func postAgentText(ctx context.Context, db *sql.DB, room store.Room, agent store.User, text, model string, hub *liveHub) {
+	attrs := store.Attrs{"agent": true}
+	if strings.TrimSpace(model) != "" {
+		attrs["model"] = model
+	}
+	out, err := store.PostRoomMessage(ctx, db, store.RoomMessage{
+		RoomID:   room.ID,
+		SenderID: agent.ID,
+		Kind:     "text",
+		Body:     text,
+		Attrs:    attrs,
+	})
+	if err != nil {
+		log.Printf("server: post agent task result: %v", err)
+		return
+	}
+	if hub != nil {
+		hub.broadcastRoomMessage(room.ID, out)
+	}
+}
+
+// broadcastRoomQueue pushes the room's current agent task list to subscribers.
+func broadcastRoomQueue(ctx context.Context, db *sql.DB, hub *liveHub, roomID int64) {
+	if hub == nil || roomID == 0 {
+		return
+	}
+	tasks, err := store.ListRoomAgentTasks(ctx, db, roomID)
+	if err != nil {
+		return
+	}
+	hub.broadcast(liveEvent{Type: "room_queue", RoomID: roomID, Payload: tasks})
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -35,10 +35,16 @@ type Server struct {
 	httpServer       *http.Server
 	stopReaper       chan struct{}
 	stopOrchestrator chan struct{}
+	stopRoomWorker   chan struct{}
 }
 
+// roomWorkerEnabled gates the ephemeral agent-task dispatcher. It is true in
+// production; the server test suite disables it (TestMain) so the background
+// worker does not race with tests that drive the queue directly (TK-168).
+var roomWorkerEnabled = true
+
 func New(addr string, db *sql.DB, version string, verbose bool, output io.Writer, staticPath, siteName string, enableOrchestrator bool, accessLog, errorLog io.Writer) (*Server, error) {
-	handler, err := handlerWithPasskeyFactory(db, version, verbose, output, staticPath, siteName, accessLog, errorLog, defaultPasskeyServiceFactory)
+	handler, live, err := handlerWithPasskeyFactory(db, version, verbose, output, staticPath, siteName, accessLog, errorLog, defaultPasskeyServiceFactory)
 	if err != nil {
 		return nil, err
 	}
@@ -54,10 +60,14 @@ func New(addr string, db *sql.DB, version string, verbose bool, output io.Writer
 		},
 		stopReaper:       make(chan struct{}),
 		stopOrchestrator: make(chan struct{}),
+		stopRoomWorker:   make(chan struct{}),
 	}
 	go s.runAgentReaper(db, verbose, output)
 	go s.runRetentionPurge(db, verbose)
 	go s.runRefinementReaper(db)
+	if roomWorkerEnabled {
+		go s.runRoomAgentTaskWorker(db, live)
+	}
 	if enableOrchestrator {
 		go s.runOrchestrator(db, verbose)
 	}
@@ -210,10 +220,11 @@ func (s *Server) runRetentionPurge(db *sql.DB, verbose bool) {
 }
 
 func Handler(db *sql.DB, version string, verbose bool, output io.Writer, staticPath, siteName string) (http.Handler, error) {
-	return handlerWithPasskeyFactory(db, version, verbose, output, staticPath, siteName, nil, nil, defaultPasskeyServiceFactory)
+	handler, _, err := handlerWithPasskeyFactory(db, version, verbose, output, staticPath, siteName, nil, nil, defaultPasskeyServiceFactory)
+	return handler, err
 }
 
-func handlerWithPasskeyFactory(db *sql.DB, version string, verbose bool, output io.Writer, staticPath, siteName string, accessLog, errorLog io.Writer, passkeys passkeyServiceFactory) (http.Handler, error) {
+func handlerWithPasskeyFactory(db *sql.DB, version string, verbose bool, output io.Writer, staticPath, siteName string, accessLog, errorLog io.Writer, passkeys passkeyServiceFactory) (http.Handler, *liveHub, error) {
 	var staticFS fs.FS
 	if staticPath != "" {
 		staticFS = os.DirFS(staticPath)
@@ -221,7 +232,7 @@ func handlerWithPasskeyFactory(db *sql.DB, version string, verbose bool, output 
 		var err error
 		staticFS, err = web.SiteFS(siteName)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
 
@@ -254,7 +265,7 @@ func handlerWithPasskeyFactory(db *sql.DB, version string, verbose bool, output 
 		handler = loggingHandler(handler, stdoutLog, accessLog, errorLog)
 	}
 	handler = compressionMiddleware(handler)
-	return handler, nil
+	return handler, live, nil
 }
 
 func writeRateLimitFromEnv() int {
@@ -525,6 +536,7 @@ func (s *Server) ListenAndServe() error {
 func (s *Server) Shutdown(ctx context.Context) error {
 	close(s.stopReaper)
 	close(s.stopOrchestrator)
+	close(s.stopRoomWorker)
 	sharedChatRuntime.stopHeartbeat()
 	return s.httpServer.Shutdown(ctx)
 }

--- a/internal/store/room_agent_task.go
+++ b/internal/store/room_agent_task.go
@@ -1,0 +1,184 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Room agent task states. Tasks are ephemeral: they move queued → running →
+// done/failed and are then auto-purged, never reaching the ticket backlog.
+const (
+	RoomAgentTaskQueued  = "queued"
+	RoomAgentTaskRunning = "running"
+	RoomAgentTaskDone    = "done"
+	RoomAgentTaskFailed  = "failed"
+)
+
+// RoomAgentTask is a single ephemeral work-item enqueued for an agent in a room
+// via "@agent do X" / "@agent queue X" (TK-168). It is intentionally separate
+// from WorkItem (ticket execution packets).
+type RoomAgentTask struct {
+	ID          int64  `json:"task_id"`
+	RoomID      int64  `json:"room_id"`
+	AgentID     string `json:"agent_id"`
+	AgentName   string `json:"agent_name"`
+	RequesterID string `json:"requester_id"`
+	Instruction string `json:"instruction"`
+	State       string `json:"state"`
+	Result      string `json:"result"`
+	Ephemeral   bool   `json:"ephemeral"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+const roomAgentTaskColumns = `task_id, room_id, agent_id, agent_name, requester_id, instruction, state, result, ephemeral, created_at, updated_at`
+
+func scanRoomAgentTask(s interface{ Scan(...any) error }) (RoomAgentTask, error) {
+	var (
+		t         RoomAgentTask
+		ephemeral int64
+	)
+	if err := s.Scan(&t.ID, &t.RoomID, &t.AgentID, &t.AgentName, &t.RequesterID, &t.Instruction, &t.State, &t.Result, &ephemeral, &t.CreatedAt, &t.UpdatedAt); err != nil {
+		return RoomAgentTask{}, err
+	}
+	t.Ephemeral = ephemeral != 0
+	return t, nil
+}
+
+// EnqueueRoomAgentTask adds a queued task for an agent in a room.
+func EnqueueRoomAgentTask(ctx context.Context, db *sql.DB, task RoomAgentTask) (RoomAgentTask, error) {
+	if task.RoomID == 0 || strings.TrimSpace(task.AgentID) == "" {
+		return RoomAgentTask{}, fmt.Errorf("room id and agent id are required")
+	}
+	instruction := strings.TrimSpace(task.Instruction)
+	if instruction == "" {
+		return RoomAgentTask{}, fmt.Errorf("instruction is required")
+	}
+	// These queue items are always ephemeral — they exist to keep throwaway agent
+	// work out of the permanent ticket backlog. The column is kept for clarity and
+	// future use, but enqueue always sets it.
+	res, err := db.ExecContext(ctx,
+		`INSERT INTO room_agent_tasks (room_id, agent_id, agent_name, requester_id, instruction, state, ephemeral) VALUES (?, ?, ?, ?, ?, ?, 1)`,
+		task.RoomID, strings.TrimSpace(task.AgentID), task.AgentName, task.RequesterID, instruction, RoomAgentTaskQueued)
+	if err != nil {
+		return RoomAgentTask{}, fmt.Errorf("enqueue room agent task: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return RoomAgentTask{}, err
+	}
+	return GetRoomAgentTask(ctx, db, id)
+}
+
+// GetRoomAgentTask returns a single task by id.
+func GetRoomAgentTask(ctx context.Context, db *sql.DB, id int64) (RoomAgentTask, error) {
+	row := db.QueryRowContext(ctx, `SELECT `+roomAgentTaskColumns+` FROM room_agent_tasks WHERE task_id = ?`, id)
+	return scanRoomAgentTask(row)
+}
+
+// ListRoomAgentTasks returns the tasks for a room in creation order. This drives
+// the live queue panel, so it includes queued/running and recently finished items
+// (the worker purges old finished ones separately).
+func ListRoomAgentTasks(ctx context.Context, db *sql.DB, roomID int64) ([]RoomAgentTask, error) {
+	rows, err := db.QueryContext(ctx, `SELECT `+roomAgentTaskColumns+` FROM room_agent_tasks WHERE room_id = ? ORDER BY task_id ASC`, roomID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var tasks []RoomAgentTask
+	for rows.Next() {
+		t, err := scanRoomAgentTask(rows)
+		if err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, t)
+	}
+	return tasks, rows.Err()
+}
+
+// ClaimNextRoomAgentTask atomically marks the oldest eligible queued task as
+// running and returns it. A task is eligible only when no other task for the same
+// (room, agent) is already running — this enforces serial, concurrency-1 execution
+// per (room, agent) while letting different agents/rooms proceed in parallel.
+// Returns ok=false when nothing is eligible.
+func ClaimNextRoomAgentTask(ctx context.Context, db *sql.DB) (RoomAgentTask, bool, error) {
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		return RoomAgentTask{}, false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var id int64
+	row := tx.QueryRowContext(ctx, `
+		SELECT t.task_id FROM room_agent_tasks t
+		WHERE t.state = ?
+		  AND NOT EXISTS (
+		      SELECT 1 FROM room_agent_tasks r
+		      WHERE r.room_id = t.room_id AND r.agent_id = t.agent_id AND r.state = ?
+		  )
+		ORDER BY t.task_id ASC LIMIT 1`, RoomAgentTaskQueued, RoomAgentTaskRunning)
+	if scanErr := row.Scan(&id); scanErr != nil {
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return RoomAgentTask{}, false, nil
+		}
+		return RoomAgentTask{}, false, scanErr
+	}
+	if _, execErr := tx.ExecContext(ctx, `UPDATE room_agent_tasks SET state = ?, updated_at = CURRENT_TIMESTAMP WHERE task_id = ?`, RoomAgentTaskRunning, id); execErr != nil {
+		return RoomAgentTask{}, false, execErr
+	}
+	if commitErr := tx.Commit(); commitErr != nil {
+		return RoomAgentTask{}, false, commitErr
+	}
+	t, err := GetRoomAgentTask(ctx, db, id)
+	if err != nil {
+		return RoomAgentTask{}, false, err
+	}
+	return t, true, nil
+}
+
+// FinishRoomAgentTask records the terminal state (done/failed) and result.
+func FinishRoomAgentTask(ctx context.Context, db *sql.DB, id int64, state, result string) (RoomAgentTask, error) {
+	if state != RoomAgentTaskDone && state != RoomAgentTaskFailed {
+		return RoomAgentTask{}, fmt.Errorf("invalid terminal state %q", state)
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE room_agent_tasks SET state = ?, result = ?, updated_at = CURRENT_TIMESTAMP WHERE task_id = ?`, state, result, id); err != nil {
+		return RoomAgentTask{}, err
+	}
+	return GetRoomAgentTask(ctx, db, id)
+}
+
+// DeleteRoomAgentTask removes a single task (e.g. after promotion to a ticket).
+func DeleteRoomAgentTask(ctx context.Context, db *sql.DB, id int64) error {
+	_, err := db.ExecContext(ctx, `DELETE FROM room_agent_tasks WHERE task_id = ?`, id)
+	return err
+}
+
+// HasPendingRoomAgentTasks reports whether any task is queued or running (used to
+// decide whether the worker should keep polling).
+func HasPendingRoomAgentTasks(ctx context.Context, db *sql.DB) (bool, error) {
+	var n int
+	err := db.QueryRowContext(ctx, `SELECT COUNT(1) FROM room_agent_tasks WHERE state IN (?, ?)`, RoomAgentTaskQueued, RoomAgentTaskRunning).Scan(&n)
+	return n > 0, err
+}
+
+// PurgeFinishedRoomAgentTasks deletes ephemeral done/failed tasks older than the
+// given age (in seconds), keeping the queue from accumulating. Non-ephemeral tasks
+// are retained. Returns the number removed.
+func PurgeFinishedRoomAgentTasks(ctx context.Context, db *sql.DB, olderThanSeconds int) (int64, error) {
+	if olderThanSeconds < 0 {
+		olderThanSeconds = 0
+	}
+	cutoff := fmt.Sprintf("-%d seconds", olderThanSeconds)
+	res, err := db.ExecContext(ctx, `
+		DELETE FROM room_agent_tasks
+		WHERE ephemeral = 1
+		  AND state IN (?, ?)
+		  AND updated_at <= datetime('now', ?)`, RoomAgentTaskDone, RoomAgentTaskFailed, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -827,10 +827,31 @@ CREATE TABLE IF NOT EXISTS room_messages (
 	FOREIGN KEY(room_id) REFERENCES rooms(room_id)
 );
 
+-- Ephemeral, in-room agent task queue (TK-168). Distinct from work_items, which
+-- track ticket execution packets. These are short-lived: "@agent do X" enqueues
+-- one, a serial per-(room,agent) worker processes it, and finished items are
+-- auto-purged so they never reach the permanent ticket backlog.
+CREATE TABLE IF NOT EXISTS room_agent_tasks (
+	task_id INTEGER PRIMARY KEY AUTOINCREMENT,
+	room_id INTEGER NOT NULL,
+	agent_id TEXT NOT NULL,
+	agent_name TEXT NOT NULL DEFAULT '',
+	requester_id TEXT NOT NULL DEFAULT '',
+	instruction TEXT NOT NULL DEFAULT '',
+	state TEXT NOT NULL DEFAULT 'queued',
+	result TEXT NOT NULL DEFAULT '',
+	ephemeral INTEGER NOT NULL DEFAULT 1,
+	created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	FOREIGN KEY(room_id) REFERENCES rooms(room_id)
+);
+
 CREATE INDEX IF NOT EXISTS idx_rooms_slug ON rooms(slug);
 CREATE INDEX IF NOT EXISTS idx_rooms_project_id ON rooms(project_id);
 CREATE INDEX IF NOT EXISTS idx_rooms_ticket_id ON rooms(ticket_id);
 CREATE INDEX IF NOT EXISTS idx_room_members_member_id ON room_members(member_id);
+CREATE INDEX IF NOT EXISTS idx_room_agent_tasks_room ON room_agent_tasks(room_id);
+CREATE INDEX IF NOT EXISTS idx_room_agent_tasks_state ON room_agent_tasks(state);
 CREATE INDEX IF NOT EXISTS idx_room_messages_room_id ON room_messages(room_id, message_id);
 
 -- Access roles: per-panel feature flags. Each access role grants a set of UI

--- a/tests/playwright/site2.spec.js
+++ b/tests/playwright/site2.spec.js
@@ -2273,3 +2273,29 @@ test("palette /tk-NNN exposes a deeper action stack with a lifecycle submenu (TK
   await page.locator("#command-palette-input").press("Escape");
   await expect(page.locator("#command-palette-overlay")).toBeHidden();
 });
+
+test("agent queue panel renders pending/running/done states (TK-168)", async ({ page }) => {
+  // The shared beforeEach logged in; go to chat so the panel element exists.
+  await page.locator('#main-nav button[data-view="chat"]').click();
+  await expect(page.locator("#chat-composer-input")).toBeEnabled();
+
+  // Drive the live panel renderer directly (the same path room_queue WS events use).
+  await page.evaluate(() => {
+    window.__site2RenderAgentQueue([
+      { task_id: 1, instruction: "run the linter", state: "done", agent_name: "buildbot" },
+      { task_id: 2, instruction: "summarise the thread", state: "running", agent_name: "buildbot" },
+      { task_id: 3, instruction: "draft release notes", state: "queued", agent_name: "buildbot" },
+    ]);
+  });
+
+  const panel = page.locator("#chat-queue");
+  await expect(panel).toBeVisible();
+  await expect(panel).toContainText("Agent queue");
+  await expect(panel.locator(".chat-queue-running")).toContainText("summarise the thread");
+  await expect(panel.locator(".chat-queue-done")).toContainText("run the linter");
+  await expect(panel.locator(".chat-queue-item")).toHaveCount(3);
+
+  // An empty queue hides the panel.
+  await page.evaluate(() => window.__site2RenderAgentQueue([]));
+  await expect(panel).toBeHidden();
+});

--- a/web/default/index.html
+++ b/web/default/index.html
@@ -613,9 +613,10 @@
                                 </div>
                             </div>
                             <div id="chat-messages" class="chat-messages"></div>
+                            <div id="chat-queue" class="chat-queue" hidden></div>
                             <div id="chat-typing" class="chat-typing-indicator" hidden></div>
                             <form id="chat-composer" class="chat-composer">
-                                <input id="chat-composer-input" type="text" autocomplete="off" placeholder="Message — @name, #label, /task /new /join /leave, or s/old/new/g to fix your last line" disabled>
+                                <input id="chat-composer-input" type="text" autocomplete="off" placeholder="Message — @agent do …, #label, /task /promote, or s/old/new/g to fix your last line" disabled>
                                 <button id="chat-send-button" class="btn btn-primary" type="submit" disabled>Send</button>
                             </form>
                         </div>

--- a/web/default/site.css
+++ b/web/default/site.css
@@ -2133,3 +2133,13 @@ select {
 @keyframes chatTyping { 0%,60%,100% { opacity: .25; transform: translateY(0); } 30% { opacity: .9; transform: translateY(-3px); } }
 .chat-presence { margin-top: 2px; color: var(--accent, #2ea043); font-size: 0.75rem; }
 .chat-typing-indicator { padding: 2px 8px; color: var(--fg-2); font-size: 0.75rem; font-style: italic; min-height: 1em; }
+.chat-queue { border-top: 1px solid var(--card-border, #333); padding: 6px 8px; max-height: 30%; overflow-y: auto; }
+.chat-queue-title { font-size: 0.7rem; text-transform: uppercase; letter-spacing: .04em; color: var(--fg-2); margin-bottom: 4px; }
+.chat-queue-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 2px; }
+.chat-queue-item { display: flex; align-items: baseline; gap: 6px; font-size: 0.8125rem; }
+.chat-queue-state { width: 1em; flex-shrink: 0; text-align: center; }
+.chat-queue-instr { flex: 1; }
+.chat-queue-agent { color: var(--fg-2); font-size: 0.75rem; flex-shrink: 0; }
+.chat-queue-running .chat-queue-state { color: var(--accent, #2ea043); }
+.chat-queue-done .chat-queue-instr { opacity: .6; text-decoration: line-through; }
+.chat-queue-failed .chat-queue-state { color: var(--danger, #d33); }

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -2411,6 +2411,7 @@
             // Loading messages marks the room read server-side; refresh the list
             // afterwards so the unread marker clears.
             loadRoomMessages(roomID).then(() => loadRooms()).then(renderRoomsList);
+            loadAgentQueue(roomID);
         }
         function loadRoomMessages(roomID) {
             return api("/api/rooms/" + roomID + "/messages").then((msgs) => {
@@ -2610,9 +2611,10 @@
                     state.liveSocket.send(JSON.stringify({ type: "subscribe", room_id: roomID }));
                 }
             } catch (e) { /* ignore */ }
-            // Switching rooms clears any presence/typing state from the old room.
+            // Switching rooms clears any presence/typing/queue state from the old room.
             renderRoomPresence([]);
             clearTypingIndicator();
+            renderAgentQueue([]);
         }
         // emitTyping sends a typing notice for the active room, throttled so we
         // don't flood the socket on every keystroke.
@@ -2643,6 +2645,37 @@
             el.hidden = false;
             el.textContent = "● " + names.join(", ") + (names.length === 1 ? " is here" : " are here");
         }
+        // loadAgentQueue fetches the room's ephemeral agent task queue and renders
+        // the live panel (TK-168). The panel also updates via room_queue WS events.
+        function loadAgentQueue(roomID) {
+            return api("/api/rooms/" + roomID + "/agent-queue").then((tasks) => {
+                if (state.activeRoomID !== roomID) { return; }
+                renderAgentQueue(Array.isArray(tasks) ? tasks : []);
+            }).catch(() => { renderAgentQueue([]); });
+        }
+        // renderAgentQueue draws the pending/running/done agent task panel.
+        function renderAgentQueue(tasks) {
+            const el = document.getElementById("chat-queue");
+            if (!el) { return; }
+            const list = Array.isArray(tasks) ? tasks : [];
+            if (!list.length) {
+                el.hidden = true;
+                el.innerHTML = "";
+                return;
+            }
+            const icon = (s) => s === "running" ? "▶" : s === "done" ? "✓" : s === "failed" ? "✗" : "•";
+            const rows = list.map((t) => {
+                const state = String(t.state || "queued");
+                return "<li class=\"chat-queue-item chat-queue-" + escapeHTML(state) + "\">" +
+                    "<span class=\"chat-queue-state\">" + icon(state) + "</span>" +
+                    "<span class=\"chat-queue-instr\">" + escapeHTML(String(t.instruction || "")) + "</span>" +
+                    "<span class=\"chat-queue-agent\">@" + escapeHTML(String(t.agent_name || "agent")) + "</span></li>";
+            }).join("");
+            el.hidden = false;
+            el.innerHTML = "<div class=\"chat-queue-title\">Agent queue</div><ul class=\"chat-queue-list\">" + rows + "</ul>";
+        }
+        // Expose for browser tests (no effect otherwise).
+        try { window.__site2RenderAgentQueue = renderAgentQueue; } catch (e) { /* ignore */ }
         function clearTypingIndicator() {
             const el = document.getElementById("chat-typing");
             if (el) { el.hidden = true; el.textContent = ""; }
@@ -3108,6 +3141,12 @@
                     if (payload.type === "typing") {
                         if (state.activeRoomID && Number(payload.room_id) === state.activeRoomID) {
                             showTypingIndicator(payload.payload || {});
+                        }
+                        return;
+                    }
+                    if (payload.type === "room_queue") {
+                        if (state.activeRoomID && Number(payload.room_id) === state.activeRoomID) {
+                            renderAgentQueue(payload.payload || []);
                         }
                         return;
                     }


### PR DESCRIPTION
Part of epic **TK-166** (multiplayer chat). Targets the epic branch.

## What
A short-lived, in-room agent task queue distinct from `/task` (which creates a permanent ticket).

- **Store**: new `room_agent_tasks` table (always ephemeral, TTL-purged). Atomic `ClaimNextRoomAgentTask` enforces serial concurrency-1 per `(room, agent)` while allowing different agents/rooms to run concurrently.
- **Server**: a lifecycle dispatcher (`runRoomAgentTaskWorker`, gated by `roomWorkerEnabled` so the test suite doesn't race it) drains eligible tasks, runs each via the existing `roomAgentReply`, posts the result into the room, and broadcasts a `room_queue` WS event. `@agent do/queue X` enqueues; other `@agent` mentions still reply once.
- **API**: `GET /api/rooms/{id}/agent-queue`; `/promote [id]` converts a queued task into a real ticket via the existing `/task` path and clears it.
- **Web**: a live pending/running/done queue panel in the chat room, updated over WebSocket.

## Tests
- Go: parser, queue lifecycle + per-(room,agent) serialisation, cross-agent concurrency, worker execution, TTL purge, and the enqueue→list→promote API.
- Playwright: queue panel render (pending/running/done + empty hides).
- `make lint` (0), `make test-api`, `make test-browser` (42 passed) green.

refs TK-168

🤖 Generated with [Claude Code](https://claude.com/claude-code)