### PR TITLE
TK-160: tk complete reconciles the linked PR

### DIFF
--- a/cmd/tk/cmd_pull_request.go
+++ b/cmd/tk/cmd_pull_request.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strconv"
@@ -382,6 +384,130 @@ func ghCreatePullRequest(title, body, head, base string) (string, error) {
 		return "", fmt.Errorf("gh pr create succeeded but no PR url was found in its output")
 	}
 	return url, nil
+}
+
+// interactiveStdio reports whether both stdin and stdout are a real terminal, so
+// the user can be prompted (TK-160).
+func interactiveStdio() bool {
+	_, _, ok := promptTerminal(os.Stdin, os.Stdout)
+	return ok
+}
+
+// reconcileTicketPullRequests reconciles a completed ticket's open linked PRs
+// (TK-160). For each PR still open/draft it applies action ("merged"/"closed"),
+// or — when action is empty — prompts on an interactive terminal, else skips with
+// a printed warning so an open PR is never left silently. PR-side failures are
+// non-fatal: the ticket is already complete. Messages go to out.
+func reconcileTicketPullRequests(ctx context.Context, svc libticket.Service, ticketID, action string, interactive bool, out io.Writer) {
+	prs, err := svc.ListPullRequestsByTicket(ctx, ticketID)
+	if err != nil {
+		fmt.Fprintf(out, "warning: could not check linked PRs for %s: %v\n", ticketID, err)
+		return
+	}
+	reader := bufio.NewReader(os.Stdin)
+	for _, pr := range prs {
+		if pr.Status != store.PullRequestStatusOpen && pr.Status != store.PullRequestStatusDraft {
+			continue // already merged/closed — nothing to reconcile
+		}
+		act := action
+		if act == "" {
+			if interactive {
+				act = promptPRReconcile(reader, pr, out)
+			} else {
+				act = "skip"
+			}
+		}
+		switch act {
+		case store.PullRequestStatusMerged:
+			reconcilePRStatus(ctx, svc, pr, store.PullRequestStatusMerged, out)
+		case store.PullRequestStatusClosed:
+			reconcilePRStatus(ctx, svc, pr, store.PullRequestStatusClosed, out)
+		default:
+			fmt.Fprintf(out, "note: %s still has open PR #%d (%s) — left untouched. Use --merge-pr/--close-pr or `tk pr merge|close %d`.\n",
+				ticketID, pr.ID, prRef(pr), pr.ID)
+		}
+	}
+}
+
+// promptPRReconcile asks the user what to do with an open linked PR.
+func promptPRReconcile(reader *bufio.Reader, pr store.PullRequest, out io.Writer) string {
+	for {
+		fmt.Fprintf(out, "Ticket %s has open PR #%d (%s) — [m]erge / [c]lose / [s]kip? ", pr.TicketID, pr.ID, prRef(pr))
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return "skip"
+		}
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "m", "merge":
+			return store.PullRequestStatusMerged
+		case "c", "close":
+			return store.PullRequestStatusClosed
+		case "s", "skip", "":
+			return "skip"
+		}
+	}
+}
+
+// reconcilePRStatus drives a single PR to the target status. For GitHub PRs it
+// acts on the host via the gh CLI first, then records the status locally; a host
+// failure is reported and the local record is left open.
+func reconcilePRStatus(ctx context.Context, svc libticket.Service, pr store.PullRequest, target string, out io.Writer) {
+	verb := statusVerb(target)
+	if pr.Provider == store.PullRequestProviderGitHub {
+		number := extractPRNumber(pr.URL)
+		if number == "" {
+			fmt.Fprintf(out, "warning: PR #%d is a GitHub PR but its URL has no number; left open — run `gh pr %s` manually.\n", pr.ID, verb)
+			return
+		}
+		if err := ghPullRequestAction(verb, number); err != nil {
+			fmt.Fprintf(out, "warning: could not %s GitHub PR #%s: %v; left open.\n", verb, number, err)
+			return
+		}
+	}
+	if _, err := svc.SetPullRequestStatus(ctx, pr.ID, target); err != nil {
+		fmt.Fprintf(out, "warning: %s on host but failed to record PR #%d status: %v\n", verb, pr.ID, err)
+		return
+	}
+	fmt.Fprintf(out, "%s linked PR #%d\n", verb+"d", pr.ID)
+}
+
+// prRef returns a short human reference for a PR: its URL when present, else its
+// provider.
+func prRef(pr store.PullRequest) string {
+	if strings.TrimSpace(pr.URL) != "" {
+		return pr.URL
+	}
+	return pr.Provider
+}
+
+// extractPRNumber pulls the PR number from a GitHub PR URL (…/pull/123).
+func extractPRNumber(url string) string {
+	url = strings.TrimRight(strings.TrimSpace(url), "/")
+	idx := strings.LastIndex(url, "/")
+	if idx < 0 || idx == len(url)-1 {
+		return ""
+	}
+	candidate := url[idx+1:]
+	if _, err := strconv.Atoi(candidate); err != nil {
+		return ""
+	}
+	return candidate
+}
+
+// ghPullRequestAction merges or closes a PR on GitHub via the gh CLI.
+func ghPullRequestAction(verb, number string) error {
+	if _, err := exec.LookPath("gh"); err != nil {
+		return fmt.Errorf("gh CLI not found on PATH")
+	}
+	args := []string{"pr", verb, number}
+	if verb == "merge" {
+		args = append(args, "--rebase")
+	}
+	out, err := exec.Command("gh", args...).CombinedOutput() // #nosec G204 -- verb is a fixed literal and number is validated as an integer
+	if err != nil {
+		return fmt.Errorf("%s", strings.TrimSpace(string(out)))
+	}
+	return nil
 }
 
 // extractFirstURL returns the first https:// token found in s, or "".

--- a/cmd/tk/cmd_ticket_lifecycle.go
+++ b/cmd/tk/cmd_ticket_lifecycle.go
@@ -404,13 +404,18 @@ func runComplete(args []string) error {
 	fs.SetOutput(os.Stderr)
 	id := fs.String("id", "", "ticket id")
 	message := fs.String("m", "", "comment to attach")
+	mergePR := fs.Bool("merge-pr", false, "merge the ticket's open linked PR(s) on completion")
+	closePR := fs.Bool("close-pr", false, "close the ticket's open linked PR(s) on completion")
 	positional, err := parseFlagsWithPositionals(fs, args)
 	if err != nil {
 		return err
 	}
 	idVal, rest, err := resolveIDFlag(*id, positional)
 	if err != nil || len(rest) != 0 {
-		return errors.New("usage: tk complete [-id] <id> [-m comment]")
+		return errors.New("usage: tk complete [-id] <id> [-m comment] [--merge-pr|--close-pr]")
+	}
+	if *mergePR && *closePR {
+		return errors.New("choose only one of --merge-pr or --close-pr")
 	}
 	cfg, err := config.Load()
 	if err != nil {
@@ -420,14 +425,32 @@ func runComplete(args []string) error {
 	if err != nil {
 		return err
 	}
-	updated, err := svc.CompleteTicket(context.Background(), idVal, *message)
+	ctx := context.Background()
+	updated, err := svc.CompleteTicket(ctx, idVal, *message)
 	if err != nil {
 		return err
 	}
+	if !outputJSON {
+		fmt.Printf("%s completed (stage: done, complete: true)\n", updated.ID)
+	}
+	// Reconcile any open linked PR (TK-160): act on the flag, else prompt on an
+	// interactive terminal, else skip with a printed warning. PR-side failures are
+	// non-fatal — the ticket is already complete.
+	prAction := ""
+	if *mergePR {
+		prAction = store.PullRequestStatusMerged
+	} else if *closePR {
+		prAction = store.PullRequestStatusClosed
+	}
+	msgOut := os.Stdout
+	if outputJSON {
+		// Keep machine-readable stdout clean; route reconciliation notes to stderr.
+		msgOut = os.Stderr
+	}
+	reconcileTicketPullRequests(ctx, svc, updated.ID, prAction, !outputJSON && interactiveStdio(), msgOut)
 	if outputJSON {
 		return printJSON(updated)
 	}
-	fmt.Printf("%s completed (stage: done, complete: true)\n", updated.ID)
 	return nil
 }
 

--- a/cmd/tk/main_test.go
+++ b/cmd/tk/main_test.go
@@ -11279,3 +11279,94 @@ func TestUnassignWithoutNameAsAdmin(t *testing.T) {
 		t.Fatalf("expected already-unassigned message, got %q", out2)
 	}
 }
+
+func TestExtractPRNumber(t *testing.T) {
+	cases := map[string]string{
+		"https://github.com/acme/repo/pull/94":  "94",
+		"https://github.com/acme/repo/pull/94/": "94",
+		"https://github.com/acme/repo/pull/abc": "",
+		"":                                      "",
+		"not-a-url":                             "",
+	}
+	for url, want := range cases {
+		if got := extractPRNumber(url); got != want {
+			t.Errorf("extractPRNumber(%q) = %q, want %q", url, got, want)
+		}
+	}
+}
+
+func TestCompleteReconcilesLinkedNativePR(t *testing.T) {
+	setupLocalCLI(t)
+	svc := localCLIService(t)
+	ctx := context.Background()
+
+	// --close-pr closes an open native PR when completing the ticket.
+	closeTicket := createLocalTask(t, []string{"add", "Close PR on complete"})
+	if _, err := svc.CreatePullRequest(ctx, libticket.PullRequestRequest{
+		TicketID: closeTicket, Provider: "none", SourceBranch: "f-close",
+	}); err != nil {
+		t.Fatalf("CreatePullRequest(close) error = %v", err)
+	}
+	out := captureStdout(t, func() {
+		if err := run([]string{"complete", closeTicket, "--close-pr"}); err != nil {
+			t.Fatalf("complete --close-pr error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "closed linked PR") {
+		t.Fatalf("expected close confirmation, got:\n%s", out)
+	}
+	prs, _ := svc.ListPullRequestsByTicket(ctx, closeTicket)
+	if len(prs) != 1 || prs[0].Status != "closed" {
+		t.Fatalf("PR after --close-pr = %+v, want status closed", prs)
+	}
+
+	// --merge-pr merges an open native PR.
+	mergeTicket := createLocalTask(t, []string{"add", "Merge PR on complete"})
+	if _, err := svc.CreatePullRequest(ctx, libticket.PullRequestRequest{
+		TicketID: mergeTicket, Provider: "none", SourceBranch: "f-merge",
+	}); err != nil {
+		t.Fatalf("CreatePullRequest(merge) error = %v", err)
+	}
+	if err := run([]string{"complete", mergeTicket, "--merge-pr"}); err != nil {
+		t.Fatalf("complete --merge-pr error = %v", err)
+	}
+	prs, _ = svc.ListPullRequestsByTicket(ctx, mergeTicket)
+	if len(prs) != 1 || prs[0].Status != "merged" {
+		t.Fatalf("PR after --merge-pr = %+v, want status merged", prs)
+	}
+}
+
+func TestCompleteNonInteractiveWarnsAboutOpenPR(t *testing.T) {
+	setupLocalCLI(t)
+	svc := localCLIService(t)
+	ctx := context.Background()
+
+	ticket := createLocalTask(t, []string{"add", "Skip PR on complete"})
+	if _, err := svc.CreatePullRequest(ctx, libticket.PullRequestRequest{
+		TicketID: ticket, Provider: "none", SourceBranch: "f-skip",
+	}); err != nil {
+		t.Fatalf("CreatePullRequest error = %v", err)
+	}
+	// No flag + non-interactive stdout (test): the open PR is left untouched but
+	// the user is warned, never silently skipped.
+	out := captureStdout(t, func() {
+		if err := run([]string{"complete", ticket}); err != nil {
+			t.Fatalf("complete error = %v", err)
+		}
+	})
+	if !strings.Contains(out, "still has open PR") {
+		t.Fatalf("expected an open-PR warning, got:\n%s", out)
+	}
+	prs, _ := svc.ListPullRequestsByTicket(ctx, ticket)
+	if len(prs) != 1 || prs[0].Status != "open" {
+		t.Fatalf("PR should remain open after skip, got %+v", prs)
+	}
+}
+
+func TestCompleteRejectsBothPRFlags(t *testing.T) {
+	setupLocalCLI(t)
+	ticket := createLocalTask(t, []string{"add", "Both flags"})
+	if err := run([]string{"complete", ticket, "--merge-pr", "--close-pr"}); err == nil {
+		t.Fatal("expected an error when both --merge-pr and --close-pr are given")
+	}
+}


### PR DESCRIPTION
Closes the gap where completing a ticket left its linked PR untouched.

## What
`tk complete N` now reconciles any **open/draft** linked PR:
- `--merge-pr` / `--close-pr` act non-interactively.
- Otherwise, on an interactive terminal, prompt: `Ticket N has open PR #NN — [m]erge / [c]lose / [s]kip?`
- Non-interactive with no flag → **skip but print a warning** naming the PR (never silent).

GitHub PRs (provider `github`) are merged/closed on the host via the `gh` CLI (`gh pr merge --rebase` / `gh pr close`) then the stored status is updated; native PRs just update their stored status. PR-side failures are non-fatal — the ticket is already complete. `--merge-pr`+`--close-pr` together is rejected. JSON mode keeps stdout clean (notes go to stderr).

## Tests
- `extractPRNumber` parsing; `--close-pr`/`--merge-pr` on native PRs; non-interactive skip-with-warning; both-flags error.
- `make lint` (0 issues); full `cmd/tk` package green.

refs TK-160

🤖 Generated with [Claude Code](https://claude.com/claude-code)