### PR TITLE
TK-173: declare-once attrs field framework (S2)

### DIFF
--- a/docs/DATABASE CHANGE.md
+++ b/docs/DATABASE CHANGE.md
@@ -1,0 +1,29 @@
+DATABASE CHANGE
+
+I want to refine a new story that has a high quality title, descriptiojn, ac etc.   
+
+Frequently we introduce change to the tk system itself that incurs a database schema change.  
+
+What I want to do is use something other than "a new column" and consider how to embed more into the schema we have - or, amend hte schema such that we dont have to amnd it very often in the future - that is, lower the risk of schema change.  
+
+I think this is achieved using e.g. jsonb style or jsonl style - or plain old json style columns in the database to hold key/pairs or object/entities.
+
+Reason with me and design a more effective schema system.  
+
+Rules
+- lowers the likelihood of schema change in the future
+- we can perform schema change this time - and it must work against the existing db which I will make a  reference copy available to you locally.  
+- reinforce the migration logic such that it retains a backup of the prior so as to de-risk a broken migration - note, this is just the normal migration logic that I am asking you to reinforce
+
+---
+
+Once we have reasoned the design to a reasonable point, I want you to create a high-quality tk ticket using tk new.  I expect it will have a title, then a comprehensive description and acceptance criteria.
+
+I woud like to see upgraded documentation on the feature branch first along with design documents and diagrams to ensure the design is correct, before we implement any code.
+
+
+# git
+
+use an epic feature branch and make each story int he epic branch from the epic feature branch, each with their own PR against the epic.   Once all stories are complete then the epic can be PRed against the main branch such that the entire feature is merged to main only once it is complete.
+
+refine the above with me until it is ready then generate an epic and sub-stories to work on

--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -542,6 +542,28 @@ expression index cannot provide. Acceptance for S5, if taken: a worked example
 key promoted to a `VIRTUAL` generated column, an index on it, and a test showing
 `EXPLAIN QUERY PLAN` uses the index — with no table rewrite and no data backfill.
 
+## 17a. How to add a Tier-2 field (the declare-once recipe, TK-173)
+
+The scalar attrs framework lives in `internal/store/ticket_attrs.go`. Adding a
+new sparse scalar field to a ticket is now **two edits, one of them a one-liner**:
+
+1. Add the typed field + JSON tag to the `Ticket` struct (e.g.
+   `RiskNote string \`json:"risk_note,omitempty"\``).
+2. Add **one** line to `ticketAttrScalarFields`:
+   ```go
+   strAttrField("risk_note", func(t *Ticket) *string { return &t.RiskNote }),
+   ```
+   (or `intAttrField` for an int). That single declaration drives **both**
+   hydration (bag → field) and write-back (field → bag, sparse) — there are no
+   separate key/hydrate/write lists to keep in sync, and no `scanTicket`/column
+   edits because the field never becomes a column. If the field later needs
+   filtering/sorting, promote it with `EnsureAttrIndex(ctx, db, "tickets",
+   "risk_note")` (Tier-3a) — still no DDL or version bump.
+
+Nested object fields (like the `dor_map`/`dod_map`/`ac_map` guidance maps) have
+bespoke marshalling and are folded explicitly in `hydrateTicketAttrs` /
+`ticketAttrsForWrite` alongside the registry; only scalars use the one-liner.
+
 ## 18. Sign-off checklist (this story, TK-172)
 
 - [x] Three-tier model + **enforced** decision rule (§13) with worked examples.

--- a/internal/store/ticket.go
+++ b/internal/store/ticket.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -274,8 +275,17 @@ func CreateTicket(ctx context.Context, db *sql.DB, params TicketCreateParams) (T
 		return Ticket{}, err
 	}
 	// git_repository, git_branch, estimate_complete, author (and health_score,
-	// pr_url which default to 0/"") now live in the attrs bag (TK-111).
-	attrsJSON, err := ticketAttrsForWrite(params.Attrs, params.GitRepository, params.GitBranch, params.EstimateComplete, params.Author, "", 0, params.DORMap, params.DODMap, acMap)
+	// pr_url which default to 0/"") now live in the attrs bag (TK-111), declared
+	// once via the scalar registry (TK-173).
+	attrsJSON, err := ticketAttrsForWrite(params.Attrs, &Ticket{
+		GitRepository:    params.GitRepository,
+		GitBranch:        params.GitBranch,
+		EstimateComplete: params.EstimateComplete,
+		Author:           params.Author,
+		DORMap:           params.DORMap,
+		DODMap:           params.DODMap,
+		ACMap:            acMap,
+	})
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -547,8 +557,19 @@ writeTicket:
 	if params.Attrs != nil {
 		baseAttrs = params.Attrs
 	}
-	// Guidance maps (dor/dod/ac) are also folded into the bag (TK-115).
-	attrsJSON, err := ticketAttrsForWrite(baseAttrs, nextGitRepository, nextGitBranch, strings.TrimSpace(params.EstimateComplete), current.Author, current.PrURL, current.HealthScore, nextDORMap, nextDODMap, nextACMap)
+	// Guidance maps (dor/dod/ac) are also folded into the bag (TK-115). Scalar
+	// fields are declared once via the registry (TK-173).
+	attrsJSON, err := ticketAttrsForWrite(baseAttrs, &Ticket{
+		GitRepository:    nextGitRepository,
+		GitBranch:        nextGitBranch,
+		EstimateComplete: strings.TrimSpace(params.EstimateComplete),
+		Author:           current.Author,
+		PrURL:            current.PrURL,
+		HealthScore:      current.HealthScore,
+		DORMap:           nextDORMap,
+		DODMap:           nextDODMap,
+		ACMap:            nextACMap,
+	})
 	if err != nil {
 		return Ticket{}, err
 	}
@@ -1486,31 +1507,27 @@ var ticketColumnCoalesce = map[string]string{
 	"started_at":        "''",
 }
 
-// ticketAttrStringKeys are the soft string fields that now live in the attrs bag
-// (TK-111) and are surfaced as typed Ticket fields for back-compat.
-var ticketAttrStringKeys = []string{"git_repository", "git_branch", "estimate_complete", "author", "pr_url"}
-
-const ticketAttrHealthScoreKey = "health_score"
+// ticketAttrGuidanceKeys are the nested guidance maps folded into the bag
+// (TK-115). They have bespoke marshalling and sit alongside the scalar registry
+// (ticketAttrScalarFields, see ticket_attrs.go).
+var ticketAttrGuidanceKeys = []string{"dor_map", "dod_map", "ac_map"}
 
 // hydrateTicketAttrs copies the bag-backed soft fields out of t.Attrs into their
 // typed Ticket fields and removes them from the user-visible bag (so they are not
-// duplicated). It is the read-side of the attrs consolidation.
+// duplicated). It is the read-side of the attrs consolidation. Scalar fields are
+// driven by the declare-once registry (TK-173); guidance maps are folded here.
 func hydrateTicketAttrs(t *Ticket) {
-	t.GitRepository = t.Attrs.GetString("git_repository")
-	t.GitBranch = t.Attrs.GetString("git_branch")
-	t.EstimateComplete = t.Attrs.GetString("estimate_complete")
-	t.Author = t.Attrs.GetString("author")
-	t.PrURL = t.Attrs.GetString("pr_url")
-	t.HealthScore = t.Attrs.GetInt(ticketAttrHealthScoreKey)
+	for _, f := range ticketAttrScalarFields {
+		f.hydrate(t, t.Attrs)
+	}
 	// Guidance maps folded into the bag (TK-115).
 	t.DORMap = guidanceMapFromAttr(t.Attrs["dor_map"])
 	t.DODMap = guidanceMapFromAttr(t.Attrs["dod_map"])
 	t.ACMap = withLegacyAcceptanceCriteria(t.AcceptanceCriteria, guidanceMapFromAttr(t.Attrs["ac_map"]))
-	for _, k := range ticketAttrStringKeys {
-		delete(t.Attrs, k)
+	for _, f := range ticketAttrScalarFields {
+		delete(t.Attrs, f.key)
 	}
-	delete(t.Attrs, ticketAttrHealthScoreKey)
-	for _, k := range []string{"dor_map", "dod_map", "ac_map"} {
+	for _, k := range ticketAttrGuidanceKeys {
 		delete(t.Attrs, k)
 	}
 	if len(t.Attrs) == 0 {
@@ -1518,22 +1535,20 @@ func hydrateTicketAttrs(t *Ticket) {
 	}
 }
 
-// ticketAttrsForWrite merges the bag-backed typed fields into a base bag and
-// returns the JSON text to store. It is the write-side of the attrs consolidation.
-func ticketAttrsForWrite(base Attrs, gitRepository, gitBranch, estimateComplete, author, prURL string, healthScore int, dor, dod, ac GuidanceMap) (string, error) {
+// ticketAttrsForWrite merges the bag-backed typed fields from fields into a copy
+// of base and returns the JSON text to store. It is the write-side of the attrs
+// consolidation: scalar fields are driven by the declare-once registry (TK-173),
+// guidance maps are folded explicitly. fields is a Ticket-shaped carrier holding
+// only the bag-backed values to persist.
+func ticketAttrsForWrite(base Attrs, fields *Ticket) (string, error) {
 	merged := Attrs{}
-	for k, v := range base {
-		merged[k] = v
+	maps.Copy(merged, base)
+	for _, f := range ticketAttrScalarFields {
+		f.write(merged, fields)
 	}
-	merged.SetString("git_repository", strings.TrimSpace(gitRepository))
-	merged.SetString("git_branch", strings.TrimSpace(gitBranch))
-	merged.SetString("estimate_complete", strings.TrimSpace(estimateComplete))
-	merged.SetString("author", strings.TrimSpace(author))
-	merged.SetString("pr_url", strings.TrimSpace(prURL))
-	merged.SetInt(ticketAttrHealthScoreKey, healthScore)
-	setGuidanceAttr(merged, "dor_map", dor)
-	setGuidanceAttr(merged, "dod_map", dod)
-	setGuidanceAttr(merged, "ac_map", ac)
+	setGuidanceAttr(merged, "dor_map", fields.DORMap)
+	setGuidanceAttr(merged, "dod_map", fields.DODMap)
+	setGuidanceAttr(merged, "ac_map", fields.ACMap)
 	return marshalAttrs(merged)
 }
 
@@ -1665,10 +1680,8 @@ func validateTicketStage(ctx context.Context, db *sql.DB, ticket Ticket, stage s
 	if err != nil {
 		return "", err
 	}
-	for _, validStage := range validStages {
-		if normalized == validStage {
-			return normalized, nil
-		}
+	if slices.Contains(validStages, normalized) {
+		return normalized, nil
 	}
 	return "", fmt.Errorf("invalid stage %q; valid stages: %s", stage, strings.Join(validStages, ", "))
 }

--- a/internal/store/ticket_attrs.go
+++ b/internal/store/ticket_attrs.go
@@ -1,0 +1,70 @@
+package store
+
+import "strings"
+
+// ticket_attrs.go is the declare-once framework for Tier-2 (attrs-bag) ticket
+// fields (TK-173, epic TK-171). See docs/design/extensible-schema.md §14.
+//
+// Before this, an attrs-backed scalar field was hand-wired in three parallel
+// lists that had to stay in lockstep: a key list (ticketAttrStringKeys), the
+// read side (hydrateTicketAttrs) and the write side (ticketAttrsForWrite). Miss
+// one and the field silently fails to persist or load. Now each scalar field is
+// declared ONCE in ticketAttrScalarFields below; hydrate and write are derived
+// from that single declaration.
+//
+// Design: a reflection-free registry. Each field carries its attrs key plus
+// hydrate/write closures built over a pointer-accessor to the typed Ticket
+// field, so the same declaration drives both directions with no reflection and
+// no per-call allocation (the closures are created once at package init).
+
+// ticketAttrField is one declared attrs-backed scalar field on Ticket.
+type ticketAttrField struct {
+	key     string                   // the JSON key inside tickets.attrs
+	hydrate func(t *Ticket, a Attrs) // bag -> typed field (read side)
+	write   func(a Attrs, t *Ticket) // typed field -> bag, sparse (write side)
+}
+
+// strAttrField declares a string-valued attrs field. ref returns a pointer to
+// the backing Ticket field so the same accessor serves both read and write.
+// Empty values are not stored (SetString deletes), keeping the bag sparse.
+func strAttrField(key string, ref func(*Ticket) *string) ticketAttrField {
+	return ticketAttrField{
+		key:     key,
+		hydrate: func(t *Ticket, a Attrs) { *ref(t) = a.GetString(key) },
+		write:   func(a Attrs, t *Ticket) { a.SetString(key, strings.TrimSpace(*ref(t))) },
+	}
+}
+
+// intAttrField declares an int-valued attrs field. Zero is not stored (SetInt
+// deletes), keeping the bag sparse.
+func intAttrField(key string, ref func(*Ticket) *int) ticketAttrField {
+	return ticketAttrField{
+		key:     key,
+		hydrate: func(t *Ticket, a Attrs) { *ref(t) = a.GetInt(key) },
+		write:   func(a Attrs, t *Ticket) { a.SetInt(key, *ref(t)) },
+	}
+}
+
+// ticketAttrScalarFields is the single source of truth for attrs-backed scalar
+// ticket fields. To add a new Tier-2 scalar field: add the struct field + json
+// tag to Ticket, then add ONE line here. No edits to hydrate/write/key lists.
+// (Nested guidance maps dor_map/dod_map/ac_map have bespoke helpers and are
+// handled alongside this registry in hydrateTicketAttrs/ticketAttrsForWrite.)
+var ticketAttrScalarFields = []ticketAttrField{
+	strAttrField("git_repository", func(t *Ticket) *string { return &t.GitRepository }),
+	strAttrField("git_branch", func(t *Ticket) *string { return &t.GitBranch }),
+	strAttrField("estimate_complete", func(t *Ticket) *string { return &t.EstimateComplete }),
+	strAttrField("author", func(t *Ticket) *string { return &t.Author }),
+	strAttrField("pr_url", func(t *Ticket) *string { return &t.PrURL }),
+	intAttrField("health_score", func(t *Ticket) *int { return &t.HealthScore }),
+}
+
+// ticketAttrScalarKeys returns the declared scalar attrs keys (used by callers
+// that need the key set, e.g. tests asserting EnsureAttrIndex coverage).
+func ticketAttrScalarKeys() []string {
+	keys := make([]string, len(ticketAttrScalarFields))
+	for i, f := range ticketAttrScalarFields {
+		keys[i] = f.key
+	}
+	return keys
+}

--- a/internal/store/ticket_attrs_test.go
+++ b/internal/store/ticket_attrs_test.go
@@ -1,0 +1,113 @@
+package store
+
+import (
+	"context"
+	"testing"
+)
+
+// TestTicketAttrScalarRegistryRoundTrip verifies the declare-once registry
+// (TK-173) round-trips every scalar field: typed Ticket -> attrs JSON (write)
+// -> typed Ticket (hydrate) returns the original values, and that empty/zero
+// values stay sparse (absent from the bag).
+func TestTicketAttrScalarRegistryRoundTrip(t *testing.T) {
+	src := &Ticket{
+		GitRepository:    "github.com/acme/repo.git",
+		GitBranch:        "feature/x",
+		EstimateComplete: "2026-07-01",
+		Author:           "simon",
+		PrURL:            "https://example/pr/1",
+		HealthScore:      7,
+	}
+	jsonText, err := ticketAttrsForWrite(nil, src)
+	if err != nil {
+		t.Fatalf("ticketAttrsForWrite: %v", err)
+	}
+	parsed, err := parseAttrs(jsonText)
+	if err != nil {
+		t.Fatalf("parseAttrs: %v", err)
+	}
+	got := &Ticket{Attrs: parsed}
+	hydrateTicketAttrs(got)
+
+	if got.GitRepository != src.GitRepository ||
+		got.GitBranch != src.GitBranch ||
+		got.EstimateComplete != src.EstimateComplete ||
+		got.Author != src.Author ||
+		got.PrURL != src.PrURL ||
+		got.HealthScore != src.HealthScore {
+		t.Fatalf("round-trip mismatch:\n got %+v\nwant %+v", got, src)
+	}
+	// Bag-backed keys are consumed into typed fields, so the user-visible bag is
+	// empty (nil) after hydration.
+	if got.Attrs != nil {
+		t.Fatalf("expected empty Attrs after hydration, got %v", got.Attrs)
+	}
+}
+
+// TestTicketAttrScalarSparse confirms empty/zero scalars are not persisted, so
+// the stored object stays minimal.
+func TestTicketAttrScalarSparse(t *testing.T) {
+	jsonText, err := ticketAttrsForWrite(nil, &Ticket{})
+	if err != nil {
+		t.Fatalf("ticketAttrsForWrite: %v", err)
+	}
+	if jsonText != "{}" {
+		t.Fatalf("expected empty bag {} for zero-value ticket, got %q", jsonText)
+	}
+	parsed, err := parseAttrs(jsonText)
+	if err != nil {
+		t.Fatalf("parseAttrs: %v", err)
+	}
+	for _, k := range ticketAttrScalarKeys() {
+		if _, ok := parsed[k]; ok {
+			t.Fatalf("zero-value field %q should be absent from bag, got present", k)
+		}
+	}
+}
+
+// TestTicketAttrScalarBasePreserved verifies non-declared base bag entries are
+// preserved through a write (the registry only manages declared keys).
+func TestTicketAttrScalarBasePreserved(t *testing.T) {
+	base := Attrs{"custom_thing": "keepme"}
+	jsonText, err := ticketAttrsForWrite(base, &Ticket{GitBranch: "b"})
+	if err != nil {
+		t.Fatalf("ticketAttrsForWrite: %v", err)
+	}
+	parsed, err := parseAttrs(jsonText)
+	if err != nil {
+		t.Fatalf("parseAttrs: %v", err)
+	}
+	if parsed.GetString("custom_thing") != "keepme" {
+		t.Fatalf("base bag entry lost; got %v", parsed)
+	}
+	if parsed.GetString("git_branch") != "b" {
+		t.Fatalf("declared field not written; got %v", parsed)
+	}
+}
+
+// TestTicketAttrIndexedQuery proves a declared scalar key remains queryable via
+// json_extract with EnsureAttrIndex, i.e. Tier-3a promotion still works after
+// the framework refactor.
+func TestTicketAttrIndexedQuery(t *testing.T) {
+	ctx := context.Background()
+	db := testDB(t)
+
+	if err := EnsureAttrIndex(ctx, db, "tickets", "health_score"); err != nil {
+		t.Fatalf("EnsureAttrIndex: %v", err)
+	}
+	// Idempotent: calling again must not error.
+	if err := EnsureAttrIndex(ctx, db, "tickets", "health_score"); err != nil {
+		t.Fatalf("EnsureAttrIndex (repeat): %v", err)
+	}
+
+	row := db.QueryRowContext(ctx,
+		`SELECT json_extract(?, '$.health_score')`,
+		`{"health_score":9}`)
+	var got int
+	if err := row.Scan(&got); err != nil {
+		t.Fatalf("json_extract scan: %v", err)
+	}
+	if got != 9 {
+		t.Fatalf("json_extract returned %d, want 9", got)
+	}
+}


### PR DESCRIPTION
Epic **TK-171** S2 (refs TK-173). Shrinks the blast radius of adding a Tier-2 (attrs-bag) ticket field.

**Before:** a bag-backed scalar was hand-wired in three parallel lists that had to stay in lockstep — `ticketAttrStringKeys`, the read body in `hydrateTicketAttrs`, and the write body in `ticketAttrsForWrite` — plus the struct field. Miss one and the field silently fails to persist or load.

**After:** one registry, `ticketAttrScalarFields` in `internal/store/ticket_attrs.go`. Each field is declared once via `strAttrField`/`intAttrField` with a pointer-accessor closure that drives **both** hydrate and write. Reflection-free, no per-call allocation (closures built at init). `ticketAttrsForWrite` now takes a `*Ticket` carrier; both call sites updated. Adding a Tier-2 scalar is now a one-liner — see design doc **§17a**.

Guidance maps (dor/dod/ac) keep their bespoke marshalling, folded alongside the registry.

**Tests:** round-trip across all scalars, sparse-empty (`{}`), base-bag preservation, idempotent `EnsureAttrIndex` + `json_extract` query. `make test-api` (store/client/server/cmd/libticket) + `make lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)