### PR TITLE
TK-175: lock migration-safety entry points + document restore (S4)

### DIFF
--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -135,6 +135,53 @@ sidebar section):
   whose data backs the board (Workflows, Roles, Teams) are hidden in the nav but
   their shared data stays reachable so ticket flows keep working.
 
+## Database upgrades, backups & restore (admin)
+
+`tk` stores everything in a single SQLite database (`$TICKET_HOME/ticket.db` by
+default). When you upgrade `tk` to a build with a newer schema, the database is
+migrated — **always behind a verified, automatic backup**.
+
+**How upgrades happen**
+
+- **Server startup** auto-upgrades the database when the schema is out of date.
+- **`tk admin upgrade-database [-f <db>]`** upgrades a database on demand.
+- The **local/CLI path refuses to migrate silently**: if you point the CLI at an
+  older database, it stops with a clear error telling you to run
+  `tk admin upgrade-database -f <db>` rather than touching your data unexpectedly.
+
+In every case that *does* migrate, the upgrade first takes a backup, verifies it,
+and **rolls the database back automatically if the migration fails** — so a
+failed upgrade leaves your original database intact.
+
+**What the backup contains and where it lives**
+
+- Before migrating, the WAL is checkpointed into the main file and the database is
+  copied to a timestamped file **next to your database**:
+  `ticket.db.bak-YYYYMMDD-HHMMSS.<nanos>`. The backup is a self-contained,
+  consistent copy (any `-wal`/`-shm` sidecars present are copied too).
+- The backup is verified (`PRAGMA integrity_check` + a readable schema version)
+  *before* the live database is touched; if verification fails, the upgrade
+  aborts without modifying your data.
+- The **5 most recent** backups are retained; older ones are pruned only after a
+  successful upgrade, so the last known-good backup is never removed.
+
+**Restoring manually**
+
+If you ever need to roll back yourself (the database is corrupt, or you want the
+pre-upgrade state):
+
+1. **Stop the `tk` server** (no process may be using the database).
+2. Find the newest backup beside your database:
+   `ls -t ticket.db.bak-*` — the first entry is the most recent.
+3. Remove any stale sidecars and restore the backup over the live file:
+   ```bash
+   rm -f ticket.db-wal ticket.db-shm
+   cp "ticket.db.bak-YYYYMMDD-HHMMSS.<nanos>" ticket.db
+   ```
+4. Restart the server. (If the backup is older than your current binary's schema,
+   run `tk admin upgrade-database -f ticket.db` — which will itself take a fresh
+   backup first.)
+
 ## More
 
 - Tickets, the board, projects, workflows, roles, and the mailbox are reachable

--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -572,6 +572,30 @@ Nested object fields (like the `dor_map`/`dod_map`/`ac_map` guidance maps) have
 bespoke marshalling and are folded explicitly in `hydrateTicketAttrs` /
 `ticketAttrsForWrite` alongside the registry; only scalars use the one-liner.
 
+## 19. Migration safety: proven & documented (TK-175/S4)
+
+The §15 matrix is now locked by tests and the restore path is documented.
+
+- **Entry-point audit (proven).** Both auto-migrating paths — server startup
+  (`autoUpgradeDatabase`) and `tk admin upgrade-database` — go through
+  `UpgradeInPlace` → `UpgradeInPlaceWithBackup`, so every migration is preceded by
+  a verified backup with auto-rollback. The local/CLI `Open()` path **refuses**
+  (returns `SchemaVersionError` with upgrade guidance) and is regression-guarded
+  by `TestOpenDoesNotMigrateOlderDatabase`, which asserts a refused open neither
+  changes the schema version nor writes a backup. If anyone later makes `Open()`
+  auto-upgrade without the backed-up path, that test fails.
+- **Rollback (proven).** `TestUpgradeInPlaceRollsBackOnFailedMigration` injects a
+  migration that deletes data then errors; the test asserts the rows and schema
+  version are restored from the verified backup and a clear error is surfaced.
+- **Backup verification & retention (proven).**
+  `TestUpgradeInPlaceTakesVerifiedBackup`, `TestVerifyDatabaseBackupRejectsBadBackups`
+  (corrupt file / wrong version rejected before the live DB is touched), and
+  `TestPruneOldBackupsRetainsNewest` (keeps the newest `DefaultBackupRetention=5`,
+  never the last good backup). The WAL is checkpointed (`TRUNCATE`) into the main
+  file before copy, so the backup is self-contained.
+- **Restore procedure.** Documented step-by-step for operators in
+  `docs/USER_GUIDE.md` → "Database upgrades, backups & restore (admin)".
+
 ## 18. Sign-off checklist (this story, TK-172)
 
 - [x] Three-tier model + **enforced** decision rule (§13) with worked examples.

--- a/internal/store/migration_safety_test.go
+++ b/internal/store/migration_safety_test.go
@@ -93,6 +93,43 @@ func TestUpgradeInPlaceRollsBackOnFailedMigration(t *testing.T) {
 	}
 }
 
+// TestOpenDoesNotMigrateOlderDatabase is the entry-point regression guard for the
+// epic's safety contract: the local/CLI Open() path must NEVER migrate in place
+// (which would skip the verified backup). It must refuse with a SchemaVersionError
+// and leave the database byte-untouched at its original version. If a future change
+// makes Open() auto-upgrade, this test fails and forces it to go through the
+// backed-up UpgradeInPlaceWithBackup path instead.
+func TestOpenDoesNotMigrateOlderDatabase(t *testing.T) {
+	t.Parallel()
+	path := createPreviousSchemaDatabaseForTest(t)
+
+	before, err := DetectSchemaVersion(path)
+	if err != nil {
+		t.Fatalf("DetectSchemaVersion() before = %v", err)
+	}
+	if before >= CurrentSchemaVersion {
+		t.Fatalf("precondition: fixture version %d is not older than current %d", before, CurrentSchemaVersion)
+	}
+
+	_, openErr := Open(path)
+	var versionErr *SchemaVersionError
+	if !errors.As(openErr, &versionErr) {
+		t.Fatalf("Open() error = %v, want SchemaVersionError (must refuse, not migrate)", openErr)
+	}
+
+	after, err := DetectSchemaVersion(path)
+	if err != nil {
+		t.Fatalf("DetectSchemaVersion() after = %v", err)
+	}
+	if after != before {
+		t.Fatalf("Open() migrated the database without a backup: version %d -> %d", before, after)
+	}
+	// No backup should have been produced by a refused open.
+	if matches, _ := filepath.Glob(path + ".bak-*"); len(matches) != 0 {
+		t.Fatalf("refused Open() unexpectedly produced backups: %v", matches)
+	}
+}
+
 // TestUpgradeInPlaceTakesVerifiedBackup confirms a verifiable backup is produced
 // before the migration runs.
 func TestUpgradeInPlaceTakesVerifiedBackup(t *testing.T) {


### PR DESCRIPTION
Epic **TK-171** S4 (refs TK-175). Guarantees no migration runs without a verified backup + tested rollback, and documents recovery.

The mechanism already existed (prior epic TK-107): `UpgradeInPlaceWithBackup` (WAL checkpoint → integrity-verified backup → migrate → auto-rollback on failure → retain 5), with rollback/backup/bad-backup/prune tests. This story **audits, regression-guards, and documents** it.

**Entry-point audit (now proven)**
| Entry point | Behaviour |
|---|---|
| Server startup (`autoUpgradeDatabase`) | migrates via `UpgradeInPlaceWithBackup` (backed up) |
| `tk admin upgrade-database` | migrates via `UpgradeInPlaceWithBackup` (backed up) |
| Local/CLI `Open()` | **refuses** with `SchemaVersionError` + guidance — never migrates in place |

**Added**
- `TestOpenDoesNotMigrateOlderDatabase` — regression guard asserting a refused `Open()` neither changes the schema version nor writes a backup. If anyone later makes `Open()` auto-upgrade, this fails and forces the backed-up path.
- `docs/USER_GUIDE.md` → "Database upgrades, backups & restore (admin)": step-by-step manual restore, backup location (`ticket.db.bak-<ts>`), retention (5).
- design doc **§19**: the audit + the test inventory proving rollback, verified backup, bad-backup rejection, and retention.

**Verification.** All migration-safety tests green; full **code** suite green (`test-unit`, `test-api-cli`, `test-browser-full`, build). The only `make test-all` failures are the QUICKSTART docs harness (needs a live server + remote creds absent in CI/sandbox) — **identical on `main`**, pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)