### PR TITLE
TK-176: Tier-3 generated columns over attrs keys (S5)

### DIFF
--- a/docs/design/extensible-schema.md
+++ b/docs/design/extensible-schema.md
@@ -539,16 +539,38 @@ further churn-prone columns (the prior epic already consolidated them, see §9).
 S3 deliberately moved exactly one evidence-backed column rather than inventing
 make-work.
 
-## 17. Tier-3 generated columns (feeds TK-176/S5, optional)
+## 17. Tier-3 generated columns (TK-176/S5)
 
-Tier-3a (expression index via `EnsureAttrIndex`) ships today. Tier-3b — a
-`GENERATED ALWAYS AS (json_extract(attrs,'$.key')) VIRTUAL` column — is still
-**documented-only**. S5 is optional and should be built only when a concrete
-attrs key needs a first-class typed/indexable column *surface* (e.g. a strict
-type for an external tool, or a UNIQUE constraint over a bag key) that an
-expression index cannot provide. Acceptance for S5, if taken: a worked example
-key promoted to a `VIRTUAL` generated column, an index on it, and a test showing
-`EXPLAIN QUERY PLAN` uses the index — with no table rewrite and no data backfill.
+Two promotion mechanisms now ship, both with no table rewrite, no write-path
+change, and no schema-version bump (the value keeps living in `attrs`):
+
+- **Tier-3a — expression index**: `EnsureAttrIndex(ctx, db, table, key)` creates
+  `idx_<table>_attrs_<key>` over `json_extract(attrs,'$.<key>')`. The value has no
+  column surface; you query it through the `json_extract` expression (which the
+  index serves).
+- **Tier-3b — generated column**: `EnsureGeneratedColumn(ctx, db, table, key, type)`
+  idempotently adds a VIRTUAL generated column `gen_<key>` defined as
+  `json_extract(attrs,'$.<key>')` with a declared affinity (`TEXT`/`INTEGER`/`REAL`),
+  then indexes it (`idx_<table>_gencol_<key>`). Now the value has a real, **typed**
+  column handle.
+
+**When to choose which.** Default to Tier-3a — it is simpler and sufficient for
+filter/sort. Reach for Tier-3b only when you need a true **column surface** that
+an expression cannot give you:
+
+- a **declared type/affinity** so comparisons behave numerically, not lexically
+  (e.g. `gen_health_score >= 6` rather than a string compare on the JSON text);
+- tooling that **introspects columns** (reporting, ORMs, `SELECT *` consumers)
+  and cannot see a bare `json_extract` expression;
+- a column you want to reference by name in many queries without repeating the
+  `json_extract` path.
+
+VIRTUAL (not STORED) is used deliberately: SQLite forbids adding a STORED
+generated column via `ALTER TABLE`, and VIRTUAL costs nothing on disk while the
+index provides lookup speed. Implemented in `internal/store/attrs_query.go`;
+worked example + `EXPLAIN QUERY PLAN` index-usage assertion on `health_score` in
+`attrs_query_test.go`. Idempotency uses `pragma_table_xinfo` because plain
+`pragma_table_info` does not list generated columns.
 
 ## 17a. How to add a Tier-2 field (the declare-once recipe, TK-173)
 

--- a/internal/store/attrs_query.go
+++ b/internal/store/attrs_query.go
@@ -63,6 +63,88 @@ func EnsureAttrIndex(ctx context.Context, db *sql.DB, table, key string) error {
 	return err
 }
 
+// generatedColumnTypes is the allowlist of SQLite column affinities a generated
+// column may declare. The type is interpolated into DDL, so it must never come
+// from unvalidated input.
+var generatedColumnTypes = map[string]bool{
+	"TEXT":    true,
+	"INTEGER": true,
+	"REAL":    true,
+}
+
+// GeneratedColumnName returns the canonical column name for the generated column
+// promoting attrs key on a table (e.g. "gen_health_score"). The "gen_" prefix
+// keeps it from ever colliding with a hand-written Tier-1 column.
+func GeneratedColumnName(key string) string {
+	return "gen_" + key
+}
+
+// EnsureGeneratedColumn promotes a single attrs JSON key to a first-class,
+// typed, indexed SQLite generated column — the Tier-3 mechanism from
+// docs/design/extensible-schema.md. It idempotently adds a VIRTUAL generated
+// column `gen_<key>` defined as json_extract(attrs,'$.<key>') with the given
+// affinity, then an index over it. Unlike a Tier-2 expression index
+// (EnsureAttrIndex), the value gains a real column surface — a typed handle
+// usable anywhere a column is (e.g. typed comparisons, tools that introspect
+// columns) — still with NO table rewrite, NO write-path change, and NO
+// schema-version bump (the value continues to live in attrs; the column is
+// computed). Safe to call repeatedly.
+//
+// VIRTUAL (not STORED) is used deliberately: SQLite forbids adding a STORED
+// generated column via ALTER TABLE, and VIRTUAL adds zero on-disk cost while the
+// index provides the lookup speed.
+func EnsureGeneratedColumn(ctx context.Context, db *sql.DB, table, key, sqlType string) error {
+	if !attrsIndexableTables[table] {
+		return fmt.Errorf("unknown attrs table %q", table)
+	}
+	if !ValidAttrsKey(key) {
+		return fmt.Errorf("invalid attrs key %q", key)
+	}
+	if !generatedColumnTypes[sqlType] {
+		return fmt.Errorf("unsupported generated column type %q", sqlType)
+	}
+	col := GeneratedColumnName(key)
+	exists, err := generatedColumnExists(ctx, db, table, col)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		// #nosec G201 -- table is allowlisted (attrsIndexableTables), key is allowlisted (ValidAttrsKey), sqlType is allowlisted (generatedColumnTypes); no value is interpolated.
+		stmt := fmt.Sprintf(
+			"ALTER TABLE %s ADD COLUMN %s %s GENERATED ALWAYS AS (json_extract(attrs, '$.%s')) VIRTUAL",
+			table, col, sqlType, key,
+		)
+		if _, execErr := db.ExecContext(ctx, stmt); execErr != nil {
+			return execErr
+		}
+	}
+	// #nosec G201 -- identifiers are allowlist-validated as above.
+	idx := fmt.Sprintf("CREATE INDEX IF NOT EXISTS idx_%s_gencol_%s ON %s (%s)", table, key, table, col)
+	_, err = db.ExecContext(ctx, idx)
+	return err
+}
+
+// generatedColumnExists reports whether a table has a column named col, using
+// PRAGMA table_xinfo so it also sees VIRTUAL generated columns (which the plain
+// PRAGMA table_info does not list).
+func generatedColumnExists(ctx context.Context, db *sql.DB, table, col string) (bool, error) {
+	rows, err := db.QueryContext(ctx, `SELECT name FROM pragma_table_xinfo(?)`, table)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		if scanErr := rows.Scan(&name); scanErr != nil {
+			return false, scanErr
+		}
+		if name == col {
+			return true, nil
+		}
+	}
+	return false, rows.Err()
+}
+
 // ListTicketsByAttr returns the live tickets in a project whose attrs bag has the
 // given top-level key equal to value, ordered by that value. It demonstrates the
 // queryable bag end-to-end: filtering and sorting on a json_extract expression that

--- a/internal/store/attrs_query_test.go
+++ b/internal/store/attrs_query_test.go
@@ -94,3 +94,104 @@ func TestListTicketsByAttrUsesIndex(t *testing.T) {
 		t.Fatalf("expression index not used by planner; plan:\n%s", plan)
 	}
 }
+
+func TestEnsureGeneratedColumnRejectsBadInput(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	if err := EnsureGeneratedColumn(ctx, db, "not_a_table", "health_score", "INTEGER"); err == nil {
+		t.Fatal("expected error for unknown table")
+	}
+	if err := EnsureGeneratedColumn(ctx, db, "tickets", "bad key", "INTEGER"); err == nil {
+		t.Fatal("expected error for invalid attrs key")
+	}
+	if err := EnsureGeneratedColumn(ctx, db, "tickets", "health_score", "DROP TABLE tickets"); err == nil {
+		t.Fatal("expected error for unsupported column type")
+	}
+}
+
+// TestEnsureGeneratedColumnTypedIndexedQuery promotes the health_score attrs key
+// to a typed VIRTUAL generated column, proves creation is idempotent, that the
+// column reflects the bag value with INTEGER affinity (typed comparison), and
+// that the planner uses the generated-column index for a range query.
+func TestEnsureGeneratedColumnTypedIndexedQuery(t *testing.T) {
+	// Not parallel: alters the schema of its own DB.
+	ctx := context.Background()
+	db, _ := attrsTestDB(t)
+
+	mk := func(title string, score int) {
+		tk, err := CreateTicket(ctx, db, TicketCreateParams{ProjectID: 1, Type: "task", Title: title})
+		if err != nil {
+			t.Fatalf("CreateTicket(%s) error = %v", title, err)
+		}
+		if _, err := db.ExecContext(ctx,
+			`UPDATE tickets SET attrs = json_set(attrs, '$.health_score', ?) WHERE ticket_id = ?`, score, tk.ID); err != nil {
+			t.Fatalf("seed health_score(%s) error = %v", title, err)
+		}
+	}
+	mk("low", 3)
+	mk("mid", 6)
+	mk("high", 9)
+
+	// Idempotent: declaring the generated column twice must not error.
+	if err := EnsureGeneratedColumn(ctx, db, "tickets", "health_score", "INTEGER"); err != nil {
+		t.Fatalf("EnsureGeneratedColumn() error = %v", err)
+	}
+	if err := EnsureGeneratedColumn(ctx, db, "tickets", "health_score", "INTEGER"); err != nil {
+		t.Fatalf("EnsureGeneratedColumn() second call error = %v", err)
+	}
+
+	col := GeneratedColumnName("health_score") // gen_health_score
+	if exists, err := generatedColumnExists(ctx, db, "tickets", col); err != nil {
+		t.Fatalf("generatedColumnExists error = %v", err)
+	} else if !exists {
+		t.Fatalf("generated column %q was not created", col)
+	}
+
+	// Typed (INTEGER) comparison via the generated column: a numeric range query
+	// returns the rows with score >= 6, ordered, proving the column carries the
+	// bag value with integer affinity (string affinity would mis-sort).
+	// #nosec G202 -- col is the allowlist-derived generated column name, no user input.
+	rows, err := db.QueryContext(ctx,
+		`SELECT title FROM tickets WHERE project_id = 1 AND `+col+` >= 6 ORDER BY `+col)
+	if err != nil {
+		t.Fatalf("range query error = %v", err)
+	}
+	defer rows.Close()
+	var titles []string
+	for rows.Next() {
+		var title string
+		if scanErr := rows.Scan(&title); scanErr != nil {
+			t.Fatalf("scan error = %v", scanErr)
+		}
+		titles = append(titles, title)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows error = %v", err)
+	}
+	if len(titles) != 2 || titles[0] != "mid" || titles[1] != "high" {
+		t.Fatalf("typed range query returned %v, want [mid high]", titles)
+	}
+
+	// The planner uses the generated-column index for the range filter.
+	var plan strings.Builder
+	// #nosec G202 -- col is allowlist-derived.
+	planRows, err := db.QueryContext(ctx, `EXPLAIN QUERY PLAN SELECT title FROM tickets WHERE `+col+` >= 6`)
+	if err != nil {
+		t.Fatalf("EXPLAIN QUERY PLAN error = %v", err)
+	}
+	defer planRows.Close()
+	for planRows.Next() {
+		var id, parent, notused int
+		var detail string
+		if scanErr := planRows.Scan(&id, &parent, &notused, &detail); scanErr != nil {
+			t.Fatalf("scan plan error = %v", scanErr)
+		}
+		plan.WriteString(detail)
+		plan.WriteString("\n")
+	}
+	if !strings.Contains(plan.String(), "idx_tickets_gencol_health_score") {
+		t.Fatalf("generated-column index not used by planner; plan:\n%s", plan.String())
+	}
+}


### PR DESCRIPTION
Epic **TK-171** S5 (refs TK-176, optional — implemented). Adds the Tier-3b promotion mechanism.

`EnsureGeneratedColumn(ctx, db, table, key, type)` — analogous to `EnsureAttrIndex` — idempotently adds a **VIRTUAL generated column** `gen_<key>` defined as `json_extract(attrs,'$.<key>')` with a declared affinity (`TEXT`/`INTEGER`/`REAL`), then indexes it. An attrs value gains a real, **typed** column surface with **no** table rewrite, **no** write-path change, and **no** schema-version bump (the value keeps living in `attrs`; the column is computed).

- Table/key/type all allowlisted → injection-safe DDL. VIRTUAL because SQLite forbids adding STORED generated columns via `ALTER TABLE`.
- Idempotency via `pragma_table_xinfo` (`pragma_table_info` does **not** list generated columns).
- Demonstrated on `health_score`: a typed numeric range query (`gen_health_score >= 6`, ordered) returning the right rows, plus an `EXPLAIN QUERY PLAN` assertion that `idx_tickets_gencol_health_score` is used; plus bad-input rejection tests.
- design doc **§17** documents Tier-3a (expression index) vs Tier-3b (generated column) and when to pick each.

`make test-api` + `make lint` green.

**This completes epic TK-171** (S1–S5: design gate, declare-once framework, the one schema change, migration-safety lock, generated columns).

🤖 Generated with [Claude Code](https://claude.com/claude-code)