### PR TITLE
TK-177: structured JSON render-spec for rich chat rendering (tables/lists/charts)

### DIFF
--- a/docs/DESIGN_ORCHESTRATOR.md
+++ b/docs/DESIGN_ORCHESTRATOR.md
@@ -81,6 +81,18 @@ comment-thread transcript and interoperate:
 The UI connects the WebSocket when the refinement panel opens, renders streamed
 chunks into a live bubble, and reconciles from the server on `message_done`.
 
+**Structured rich rendering (TK-177).** The refiner prompt (and any chat over the same
+command bridge) invites the model to append a single fenced ```` ```render ```` block
+holding a JSON render-spec — `{"blocks":[…]}` with `text` (markdown), `list`, `table`,
+and `chart` (bar/line) block types — so a reply like "make a table" renders as an HTML
+table, list, or inline-SVG chart instead of prose. The spec rides *inside* the persisted
+comment text (no schema change), so it survives thread reloads. The server validates it
+(`internal/server/render_spec.go`: `renderSpecPromptGuidance`, `sanitizeRenderBlock`) and
+drops a malformed block before persistence; a single shared front-end renderer
+(`renderRichAgentText` in `web/shared/app.js`) parses the fence and renders the blocks
+for the live stream, the thread re-render, and any future general chat. The raw JSON is
+hidden mid-stream and the rich blocks appear once the reply completes.
+
 Key files: `internal/orchestrator/orchestrator.go`, `internal/store/orchestrator.go`,
 `internal/server/server.go` (`runOrchestrator`), `internal/server/api_agents.go`
 (push model + abandonment guard), `cmd/tk/cmd_orchestrator.go`. History event types:

--- a/internal/server/refinement_ws.go
+++ b/internal/server/refinement_ws.go
@@ -302,6 +302,9 @@ func handleRefinementMessage(db *sql.DB, ticketID, userID, text string, notify f
 	if u, uErr := store.GetUserByID(ctx, db, refinerID); uErr == nil {
 		refinerName = u.Username
 	}
+	// Drop a malformed render block before persistence so the transcript never keeps
+	// raw broken JSON; a valid block is left intact for the front-end renderer.
+	full = sanitizeRenderBlock(full)
 	proposal := store.ParseRefinementProposal(full)
 	if err := store.ApplyLiveRefinerReply(ctx, db, ticketID, refinerName, refinerID, proposal); err != nil {
 		sharedRefinementHub.broadcast(ticketID, mustJSON(map[string]any{"type": "refinement_error", "error": err.Error()}))
@@ -449,6 +452,7 @@ func buildServerRefinementPrompt(ticket store.Ticket, comments []store.Comment) 
 	b.WriteString("- When the idea is too big and should be split, end with:\n")
 	b.WriteString("    PROPOSE_BREAKDOWN\n    STORY: <title> | <one-line description>\n    STORY: <title> | <one-line description>\n")
 	b.WriteString("- Otherwise just ask your questions and stop (no marker).\n\n")
+	b.WriteString(renderSpecPromptGuidance())
 	b.WriteString(fmt.Sprintf("Idea: %s — %s\n", ticket.ID, strings.TrimSpace(ticket.Title)))
 	if strings.TrimSpace(ticket.Description) != "" {
 		b.WriteString("Description:\n" + strings.TrimSpace(ticket.Description) + "\n")

--- a/internal/server/render_spec.go
+++ b/internal/server/render_spec.go
@@ -1,0 +1,132 @@
+package server
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Structured chat rendering (TK-177). A chat/refiner LLM may append a single fenced
+// ```render code block containing a JSON render-spec that tells the browser how to
+// present its answer (markdown text, a list, a table, or a bar/line chart). The spec
+// rides inside the persisted reply text so it survives thread reloads, and a single
+// shared front-end renderer (web/shared/app.js) parses the fence out of any agent
+// message. The server's only jobs are (a) to instruct the model how to emit the block
+// via renderSpecPromptGuidance, and (b) to drop a malformed block before persistence so
+// a human never sees raw broken JSON in the transcript (sanitizeRenderBlock).
+
+// renderSpecFenceTag is the info-string that marks a render-spec fenced block.
+const renderSpecFenceTag = "render"
+
+// allowedRenderBlockTypes is the whitelist of block types the front-end renderer knows.
+var allowedRenderBlockTypes = map[string]bool{
+	"text":  true,
+	"list":  true,
+	"table": true,
+	"chart": true,
+}
+
+// renderSpecPromptGuidance returns the prompt fragment that teaches the model when and
+// how to emit a render block. It is appended to chat/refiner system prompts so the
+// capability is described identically wherever it is used.
+func renderSpecPromptGuidance() string {
+	var b strings.Builder
+	b.WriteString("Rich rendering (optional):\n")
+	b.WriteString("- When a table, list, or chart would present your answer more clearly than prose, " +
+		"you MAY include exactly ONE fenced code block tagged `render` holding a JSON object.\n")
+	b.WriteString("- Order your reply: short prose answer FIRST, then the ```render block, then any " +
+		"PROPOSE_* marker LAST. Omit the block entirely when plain prose is enough.\n")
+	b.WriteString("- Shape: {\"blocks\":[ ... ]} where each block is one of:\n")
+	b.WriteString("    {\"type\":\"text\",\"content\":\"<markdown>\"}\n")
+	b.WriteString("    {\"type\":\"list\",\"ordered\":false,\"items\":[\"a\",\"b\"]}\n")
+	b.WriteString("    {\"type\":\"table\",\"columns\":[\"A\",\"B\"],\"rows\":[[\"1\",\"2\"]]}\n")
+	b.WriteString("    {\"type\":\"chart\",\"chartType\":\"bar\",\"labels\":[\"Q1\",\"Q2\"]," +
+		"\"series\":[{\"name\":\"x\",\"data\":[1,2]}]}\n")
+	b.WriteString("- chartType is \"bar\" or \"line\". Keep all cell/label/series values short. " +
+		"Emit valid JSON only inside the block.\n\n")
+	return b.String()
+}
+
+// renderBlockEnvelope mirrors the minimal shape the front-end renderer expects so the
+// server can validate a candidate render block.
+type renderBlockEnvelope struct {
+	Blocks []struct {
+		Type string `json:"type"`
+	} `json:"blocks"`
+}
+
+// validRenderSpec reports whether jsonText is a well-formed render-spec: a JSON object
+// with a non-empty "blocks" array whose every entry carries a known block type.
+func validRenderSpec(jsonText string) bool {
+	var env renderBlockEnvelope
+	if err := json.Unmarshal([]byte(strings.TrimSpace(jsonText)), &env); err != nil {
+		return false
+	}
+	if len(env.Blocks) == 0 {
+		return false
+	}
+	for _, blk := range env.Blocks {
+		if !allowedRenderBlockTypes[strings.ToLower(strings.TrimSpace(blk.Type))] {
+			return false
+		}
+	}
+	return true
+}
+
+// sanitizeRenderBlock returns full unchanged when it carries no render block or a valid
+// one, and with the render fence removed when the block is malformed — so a broken
+// render-spec degrades to the surrounding prose instead of leaking raw JSON into the
+// persisted transcript. Only the first render fence is considered.
+func sanitizeRenderBlock(full string) string {
+	start, inner, end, ok := findRenderFence(full)
+	if !ok || validRenderSpec(inner) {
+		return full
+	}
+	cleaned := full[:start] + full[end:]
+	// Collapse the blank gap the removed block may leave behind.
+	return strings.TrimRight(cleaned, " \t\n") + "\n"
+}
+
+// findRenderFence locates the first ```render fenced block in s. It returns the byte
+// offset of the fence opener, the inner JSON text, the offset just past the closing
+// fence, and whether a complete block was found.
+func findRenderFence(s string) (start int, inner string, end int, ok bool) {
+	lines := strings.Split(s, "\n")
+	offset := 0
+	openLine := -1
+	openOffset := 0
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if openLine < 0 {
+			if isRenderFenceOpener(trimmed) {
+				openLine = i
+				openOffset = offset
+			}
+		} else if trimmed == "```" || trimmed == "~~~" {
+			innerStart := openOffset + len(lines[openLine]) + 1
+			closeStart := offset
+			end := offset + len(line)
+			if end < len(s) && s[end] == '\n' {
+				end++
+			}
+			innerText := ""
+			if closeStart > innerStart {
+				innerText = s[innerStart : closeStart-1]
+			}
+			return openOffset, innerText, end, true
+		}
+		offset += len(line) + 1
+	}
+	return 0, "", 0, false
+}
+
+// isRenderFenceOpener reports whether a trimmed line opens a ```render (or ~~~render)
+// fenced block.
+func isRenderFenceOpener(trimmed string) bool {
+	for _, fence := range []string{"```", "~~~"} {
+		if strings.HasPrefix(trimmed, fence) {
+			info := strings.TrimSpace(trimmed[len(fence):])
+			return strings.EqualFold(info, renderSpecFenceTag)
+		}
+	}
+	return false
+}

--- a/internal/server/render_spec_test.go
+++ b/internal/server/render_spec_test.go
@@ -1,0 +1,78 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderSpecPromptGuidanceDescribesAllBlockTypes(t *testing.T) {
+	guidance := renderSpecPromptGuidance()
+	for _, want := range []string{"render", "\"text\"", "\"list\"", "\"table\"", "\"chart\"", "chartType"} {
+		if !strings.Contains(guidance, want) {
+			t.Errorf("prompt guidance missing %q\n---\n%s", want, guidance)
+		}
+	}
+}
+
+func TestValidRenderSpec(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+		want bool
+	}{
+		{"table", `{"blocks":[{"type":"table","columns":["A"],"rows":[["1"]]}]}`, true},
+		{"chart", `{"blocks":[{"type":"chart","chartType":"bar","labels":["Q1"],"series":[{"name":"x","data":[1]}]}]}`, true},
+		{"mixed", `{"blocks":[{"type":"text","content":"hi"},{"type":"list","items":["a"]}]}`, true},
+		{"unknown type", `{"blocks":[{"type":"pie"}]}`, false},
+		{"empty blocks", `{"blocks":[]}`, false},
+		{"no blocks key", `{"foo":1}`, false},
+		{"broken json", `{"blocks":[{`, false},
+	}
+	for _, tc := range cases {
+		if got := validRenderSpec(tc.json); got != tc.want {
+			t.Errorf("%s: validRenderSpec=%v want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestSanitizeRenderBlockKeepsValidStripsInvalid(t *testing.T) {
+	valid := "Here is the data.\n\n```render\n{\"blocks\":[{\"type\":\"list\",\"items\":[\"a\",\"b\"]}]}\n```\n"
+	if got := sanitizeRenderBlock(valid); got != valid {
+		t.Errorf("valid block should be preserved:\nwant %q\ngot  %q", valid, got)
+	}
+
+	invalid := "Here is the data.\n\n```render\n{not json at all\n```\n"
+	got := sanitizeRenderBlock(invalid)
+	if strings.Contains(got, "render") || strings.Contains(got, "not json") {
+		t.Errorf("invalid render block should be stripped, got %q", got)
+	}
+	if !strings.Contains(got, "Here is the data.") {
+		t.Errorf("prose should survive stripping, got %q", got)
+	}
+
+	plain := "Just a normal answer with no block.\n"
+	if got := sanitizeRenderBlock(plain); got != plain {
+		t.Errorf("plain text should be untouched, got %q", got)
+	}
+}
+
+func TestFindRenderFence(t *testing.T) {
+	s := "prose line\n```render\n{\"blocks\":[]}\n```\ntrailing"
+	start, inner, end, ok := findRenderFence(s)
+	if !ok {
+		t.Fatalf("expected to find a render fence")
+	}
+	if strings.TrimSpace(inner) != `{"blocks":[]}` {
+		t.Errorf("inner=%q", inner)
+	}
+	if s[:start] != "prose line\n" {
+		t.Errorf("prefix=%q", s[:start])
+	}
+	if !strings.HasPrefix(s[end:], "trailing") {
+		t.Errorf("suffix=%q", s[end:])
+	}
+
+	if _, _, _, ok := findRenderFence("no fence here at all"); ok {
+		t.Errorf("did not expect a fence")
+	}
+}

--- a/internal/server/room_agent.go
+++ b/internal/server/room_agent.go
@@ -141,6 +141,9 @@ func postAgentReply(ctx context.Context, db *sql.DB, room store.Room, agent stor
 		return false
 	}
 	reply = strings.TrimSpace(reply)
+	// Drop a malformed render block before persistence so the transcript never keeps
+	// raw broken JSON; a valid block is left intact for the front-end renderer (TK-177).
+	reply = strings.TrimSpace(sanitizeRenderBlock(reply))
 	if reply == "" {
 		log.Printf("server: room agent %s returned an empty reply", agent.Username)
 		postAgentNotice(ctx, db, room, agent, "returned an empty reply (the model produced no output).", hub)
@@ -265,6 +268,7 @@ func buildRoomAgentPrompt(agentName, latest string, history []store.RoomMessage)
 			b.WriteString(m.SenderID + ": " + m.Body + "\n")
 		}
 	}
-	b.WriteString("\nRespond concisely to the latest message addressed to you: " + latest)
+	b.WriteString("\n" + renderSpecPromptGuidance())
+	b.WriteString("Respond concisely to the latest message addressed to you: " + latest)
 	return b.String()
 }

--- a/internal/server/room_agent_test.go
+++ b/internal/server/room_agent_test.go
@@ -151,6 +151,15 @@ func TestReplyAsAgentsIgnoresNonAgentAndNonMember(t *testing.T) {
 	}
 }
 
+func TestBuildRoomAgentPromptIncludesRenderGuidance(t *testing.T) {
+	prompt := buildRoomAgentPrompt("helper", "make a table of revenue", nil)
+	for _, want := range []string{"render", "\"table\"", "\"chart\"", "make a table of revenue"} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("room agent prompt missing %q\n---\n%s", want, prompt)
+		}
+	}
+}
+
 func TestDefaultRoomAgentReplyPromptPlaceholder(t *testing.T) {
 	ctx := context.Background()
 	// {prompt} placeholder: substituted as an argument (echo prints it back).

--- a/internal/server/room_agent_worker.go
+++ b/internal/server/room_agent_worker.go
@@ -115,6 +115,9 @@ func (s *Server) executeRoomAgentTask(db *sql.DB, hub *liveHub, task store.RoomA
 	}
 
 	reply = strings.TrimSpace(reply)
+	// Strip a malformed render block before persistence (TK-177); a valid one is kept
+	// for the front-end renderer.
+	reply = strings.TrimSpace(sanitizeRenderBlock(reply))
 	if reply != "" {
 		postAgentText(ctx, db, room, agent, reply, cfg.Model, hub)
 	}

--- a/tests/playwright/site2.spec.js
+++ b/tests/playwright/site2.spec.js
@@ -115,6 +115,26 @@ function installSite2Mock(page, seed = {}) {
       ],
       commentsByTicket: {
         "OPS-101": [{ author: "admin", text: "Initial note", date: "now" }],
+        // TK-177: a refiner reply carrying a render-spec (table + chart + list).
+        "OPS-200": [
+          {
+            author: "refiner",
+            date: "now",
+            text: [
+              "Here is the quarterly breakdown:",
+              "",
+              "```render",
+              JSON.stringify({
+                blocks: [
+                  { type: "table", columns: ["Quarter", "Revenue"], rows: [["Q1", "100"], ["Q2", "140"]] },
+                  { type: "chart", chartType: "bar", labels: ["Q1", "Q2"], series: [{ name: "Revenue", data: [100, 140] }] },
+                  { type: "list", ordered: false, items: ["Alpha", "Beta"] },
+                ],
+              }),
+              "```",
+            ].join("\n"),
+          },
+        ],
       },
       labels: [{ label_id: 51, project_id: 1, name: "backend", color: "#ff6600", created_at: "now" }],
       ticketLabelIDs: { "OPS-101": [51] },
@@ -1987,6 +2007,30 @@ test("reorders the proposed breakdown from the refinement panel", async ({ page 
       }),
     ]),
   );
+});
+
+test("renders a chat render-spec as table/list/chart in the refinement thread (TK-177)", async ({ page }) => {
+  await page.getByText("Refine me").click();
+  await page.locator("[data-ticket-tab='refinement']").click();
+  const thread = page.locator("#refinement-thread");
+
+  // Prose before the render block renders as markdown text, not raw JSON.
+  await expect(thread.locator(".render-prose")).toContainText("quarterly breakdown");
+  await expect(thread).not.toContainText("```render");
+  await expect(thread).not.toContainText("\"blocks\"");
+
+  // Table block.
+  await expect(thread.locator(".render-table th").first()).toHaveText("Quarter");
+  const firstRow = thread.locator(".render-table tbody tr").first();
+  await expect(firstRow).toContainText("Q1");
+  await expect(firstRow).toContainText("100");
+
+  // Chart block (inline SVG bars).
+  await expect(thread.locator(".render-chart svg rect").first()).toBeVisible();
+  await expect(thread.locator(".render-chart-legend")).toContainText("Revenue");
+
+  // List block.
+  await expect(thread.locator(".render-list li").first()).toHaveText("Alpha");
 });
 
 test("creates, updates, uploads, and deletes documents from the Documents view", async ({ page }) => {

--- a/tests/playwright/site2.spec.js
+++ b/tests/playwright/site2.spec.js
@@ -215,7 +215,33 @@ function installSite2Mock(page, seed = {}) {
       defaultPlanSlug: String(mockSeed.defaultPlanSlug || "starter"),
       rooms: [{ room_id: 1, slug: "general", name: "General", topic: "Everything", visibility: "public", project_id: null, ticket_id: "", archived: 0, created_by: "admin" }],
       roomMembers: [{ room_id: 1, member_id: "admin", role: "owner", joined_at: "now", last_read_at: "" }],
-      roomMessages: [{ message_id: 1, room_id: 1, sender_id: "u-9f3a", sender_name: "admin", kind: "text", body: "welcome to the room", created_at: "now" }],
+      roomMessages: [
+        { message_id: 1, room_id: 1, sender_id: "u-9f3a", sender_name: "admin", kind: "text", body: "welcome to the room", created_at: "now" },
+        // TK-177: an agent reply that answered with a plain markdown table (the common
+        // case) must still render as an HTML table, not raw pipes.
+        {
+          message_id: 2, room_id: 1, sender_id: "agent-1", sender_name: "claude", kind: "text",
+          attrs: { agent: true },
+          body: "Here is the breakdown:\n\n| Quarter | Revenue |\n| --- | --- |\n| Q1 | 100 |\n| Q2 | 140 |",
+          created_at: "now",
+        },
+        // TK-177: an agent reply that used a render-spec block (table + chart).
+        {
+          message_id: 3, room_id: 1, sender_id: "agent-1", sender_name: "claude", kind: "text",
+          attrs: { agent: true },
+          body: [
+            "Spec sample:",
+            "",
+            "```render",
+            JSON.stringify({ blocks: [
+              { type: "table", columns: ["A", "B"], rows: [["x", "y"]] },
+              { type: "chart", chartType: "line", labels: ["t0", "t1"], series: [{ name: "load", data: [3, 7] }] },
+            ] }),
+            "```",
+          ].join("\n"),
+          created_at: "now",
+        },
+      ],
       nextRoomID: 2,
       nextRoomMessageID: 2,
       agents: [{ user_id: "agent-1", enabled: true }],
@@ -2160,6 +2186,23 @@ test("chat: rooms list, messages, send, and create a room", async ({ page }) => 
   await page.locator("#dialog-input").fill("Engineering");
   await page.locator("#dialog-ok").click();
   await expect(page.locator("#chat-rooms-list")).toContainText("Engineering");
+});
+
+test("renders agent chat replies richly: markdown table + render-spec block (TK-177)", async ({ page }) => {
+  await page.locator('#main-nav button[data-view="chat"]').click();
+  await page.locator('.chat-room-item[data-room-id="1"]').click();
+  const box = page.locator("#chat-messages");
+
+  // A plain markdown table from the agent becomes an HTML table (the bug report).
+  await expect(box.locator(".chat-msg-body .render-table").first()).toBeVisible();
+  await expect(box.locator(".render-table th").first()).toHaveText("Quarter");
+  await expect(box).not.toContainText("| Quarter | Revenue |");
+
+  // A render-spec block renders its table + (line) chart; raw JSON is not shown.
+  await expect(box.locator(".render-chart svg").first()).toBeVisible();
+  await expect(box.locator(".render-chart-line").first()).toBeVisible();
+  await expect(box).not.toContainText("```render");
+  await expect(box).not.toContainText("\"blocks\"");
 });
 
 test("chat: breakout room from a ticket", async ({ page }) => {

--- a/web/default/site.css
+++ b/web/default/site.css
@@ -1818,6 +1818,84 @@ select {
     color: var(--fg-2);
     margin-top: 4px;
 }
+
+/* Rich chat rendering (TK-177): render-spec blocks inside an agent bubble. */
+.render-prose,
+.render-text {
+    white-space: normal;
+    word-break: break-word;
+}
+.render-blocks {
+    margin-top: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+.render-prose + .render-blocks {
+    margin-top: 10px;
+}
+.render-list {
+    margin: 0;
+    padding-left: 20px;
+}
+.render-list li {
+    margin: 2px 0;
+}
+.render-table-wrap {
+    overflow-x: auto;
+}
+.render-table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 0.85rem;
+}
+.render-table th,
+.render-table td {
+    border: 1px solid var(--border, #3a3a3a);
+    padding: 4px 8px;
+    text-align: left;
+    vertical-align: top;
+}
+.render-table thead th {
+    background: var(--bg-2, rgba(127, 127, 127, 0.12));
+    font-weight: 600;
+}
+.render-chart svg {
+    width: 100%;
+    height: auto;
+    max-width: 480px;
+    display: block;
+}
+.render-chart-axis {
+    stroke: var(--border, #555);
+    stroke-width: 1;
+}
+.render-chart-line {
+    stroke-width: 2;
+}
+.render-chart-label {
+    fill: var(--fg-2, #999);
+    font-size: 11px;
+}
+.render-chart-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 4px;
+    font-size: 0.75rem;
+    color: var(--fg-2);
+}
+.render-chart-key {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+.render-chart-swatch {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    display: inline-block;
+}
 .refinement-compose {
     display: flex;
     gap: 8px;

--- a/web/default/site.css
+++ b/web/default/site.css
@@ -1834,8 +1834,28 @@ select {
 .render-prose + .render-blocks {
     margin-top: 10px;
 }
+.render-prose .render-p,
+.render-text .render-p {
+    margin: 0 0 8px;
+}
+.render-prose .render-p:last-child,
+.render-text .render-p:last-child {
+    margin-bottom: 0;
+}
+.render-h {
+    margin: 8px 0 4px;
+    line-height: 1.2;
+}
+.render-code {
+    margin: 6px 0;
+    padding: 8px 10px;
+    overflow-x: auto;
+    border-radius: 6px;
+    background: var(--bg-2, rgba(127, 127, 127, 0.12));
+    font-size: 0.82rem;
+}
 .render-list {
-    margin: 0;
+    margin: 4px 0;
     padding-left: 20px;
 }
 .render-list li {

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -1195,23 +1195,109 @@
             return (m ? s.slice(0, m.index) : s);
         }
 
-        // renderMarkdownLite renders a conservative markdown subset to safe HTML: it
-        // escapes first, then re-introduces inline code, bold, italic, links and breaks.
-        function renderMarkdownLite(text) {
+        // renderInlineMd renders inline markdown (code, bold, italic, links) to safe
+        // HTML. It escapes first so untrusted text cannot inject markup.
+        function renderInlineMd(text) {
             let html = escapeHTML(text);
             html = html.replace(/`([^`]+)`/g, (_, c) => "<code>" + c + "</code>");
             html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
             html = html.replace(/(^|[^*])\*([^*\n]+)\*/g, "$1<em>$2</em>");
             html = html.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
                 (_, t, u) => "<a href=\"" + u + "\" target=\"_blank\" rel=\"noopener noreferrer\">" + t + "</a>");
-            return html.replace(/\n/g, "<br>");
+            return html;
+        }
+
+        // mdSplitRow splits a markdown table row ("| a | b |") into trimmed cells.
+        function mdSplitRow(line) {
+            let s = String(line).trim();
+            if (s.startsWith("|")) s = s.slice(1);
+            if (s.endsWith("|")) s = s.slice(0, -1);
+            return s.split("|").map((c) => c.trim());
+        }
+
+        // mdIsTableSeparator reports whether a line is a GitHub table header rule
+        // ("|---|:--:|"), which (with a preceding row) marks a markdown table.
+        function mdIsTableSeparator(line) {
+            const t = String(line || "").trim();
+            return t.indexOf("-") !== -1 && /^\|?[\s:|-]+\|?$/.test(t);
+        }
+
+        // renderMarkdownLite renders a conservative block-level markdown subset to safe
+        // HTML: headings, fenced code, GitHub tables, bullet/numbered lists, and
+        // paragraphs — with inline formatting inside. This is the prose fallback so a
+        // model that answers with a plain markdown table/list still renders richly even
+        // when it does not emit a render-spec block.
+        function renderMarkdownLite(text) {
+            const lines = String(text || "").replace(/\r\n/g, "\n").split("\n");
+            let html = "";
+            let i = 0;
+            const isSpecial = (ln) => /^(```|~~~|#{1,6}\s|[-*+]\s|\d+\.\s)/.test(ln.trim());
+            while (i < lines.length) {
+                const t = lines[i].trim();
+                if (t === "") { i++; continue; }
+                // Fenced code block.
+                if (/^(```|~~~)/.test(t)) {
+                    const fence = t.slice(0, 3);
+                    i++;
+                    const buf = [];
+                    while (i < lines.length && lines[i].trim().slice(0, 3) !== fence) { buf.push(lines[i]); i++; }
+                    if (i < lines.length) i++; // closing fence
+                    html += "<pre class=\"render-code\"><code>" + escapeHTML(buf.join("\n")) + "</code></pre>";
+                    continue;
+                }
+                // Heading.
+                const h = t.match(/^(#{1,6})\s+(.*)$/);
+                if (h) {
+                    const lvl = h[1].length;
+                    html += "<h" + lvl + " class=\"render-h\">" + renderInlineMd(h[2]) + "</h" + lvl + ">";
+                    i++;
+                    continue;
+                }
+                // GitHub table: a row with pipes followed by a separator rule.
+                if (t.indexOf("|") !== -1 && i + 1 < lines.length && mdIsTableSeparator(lines[i + 1])) {
+                    const header = mdSplitRow(t);
+                    i += 2;
+                    const rows = [];
+                    while (i < lines.length && lines[i].indexOf("|") !== -1 && lines[i].trim() !== "") {
+                        rows.push(mdSplitRow(lines[i])); i++;
+                    }
+                    html += renderTableBlockHTML({ columns: header, rows: rows });
+                    continue;
+                }
+                // Unordered list.
+                if (/^[-*+]\s+/.test(t)) {
+                    const items = [];
+                    while (i < lines.length && /^[-*+]\s+/.test(lines[i].trim())) {
+                        items.push(lines[i].trim().replace(/^[-*+]\s+/, "")); i++;
+                    }
+                    html += "<ul class=\"render-list\">" + items.map((it) => "<li>" + renderInlineMd(it) + "</li>").join("") + "</ul>";
+                    continue;
+                }
+                // Ordered list.
+                if (/^\d+\.\s+/.test(t)) {
+                    const items = [];
+                    while (i < lines.length && /^\d+\.\s+/.test(lines[i].trim())) {
+                        items.push(lines[i].trim().replace(/^\d+\.\s+/, "")); i++;
+                    }
+                    html += "<ol class=\"render-list\">" + items.map((it) => "<li>" + renderInlineMd(it) + "</li>").join("") + "</ol>";
+                    continue;
+                }
+                // Paragraph: gather consecutive plain lines.
+                const para = [];
+                while (i < lines.length && lines[i].trim() !== "" && !isSpecial(lines[i]) &&
+                    !(lines[i].indexOf("|") !== -1 && i + 1 < lines.length && mdIsTableSeparator(lines[i + 1]))) {
+                    para.push(lines[i]); i++;
+                }
+                html += "<p class=\"render-p\">" + para.map(renderInlineMd).join("<br>") + "</p>";
+            }
+            return html;
         }
 
         function renderListBlockHTML(block) {
             const items = Array.isArray(block.items) ? block.items : [];
             if (!items.length) return "";
             const tag = block.ordered ? "ol" : "ul";
-            const lis = items.map((it) => "<li>" + renderMarkdownLite(String(it)) + "</li>").join("");
+            const lis = items.map((it) => "<li>" + renderInlineMd(String(it)) + "</li>").join("");
             return "<" + tag + " class=\"render-list\">" + lis + "</" + tag + ">";
         }
 
@@ -2585,9 +2671,12 @@
                 ? "<span class=\"chat-avatar chat-avatar-agent\" title=\"agent\">🤖</span>"
                 : "<span class=\"chat-avatar chat-avatar-person\">" + initial + "</span>";
             const model = (isAgent && attrs.model) ? "<span class=\"chat-msg-model\">via " + escapeHTML(String(attrs.model)) + "</span>" : "";
+            // Agent replies may carry a render-spec (table/list/chart/markdown);
+            // render them richly. Human turns keep @mention/#label highlighting.
+            const bodyHTML = isAgent ? renderRichAgentText(m.body) : highlightRoomText(m.body);
             const bubble = "<div class=\"chat-bubble\">" +
                 (isSelf ? "" : "<div class=\"chat-msg-meta\">" + name + model + "</div>") +
-                "<div class=\"chat-msg-body\">" + highlightRoomText(m.body) + "</div></div>";
+                "<div class=\"chat-msg-body\">" + bodyHTML + "</div></div>";
             const side = isSelf ? "chat-msg-self" : "chat-msg-other";
             return "<div class=\"chat-msg chat-bubble-row " + side + "\" data-message-id=\"" + m.message_id + "\">" +
                 (isSelf ? bubble : bubble + avatar) + "</div>";

--- a/web/shared/app.js
+++ b/web/shared/app.js
@@ -1160,6 +1160,151 @@
                 .replace(/'/g, "&#39;");
         }
 
+        // ── Rich chat rendering (TK-177) ─────────────────────────────────────
+        // A chat/refiner reply may append a single fenced ```render block holding a
+        // JSON render-spec describing how to present the answer (markdown text, a
+        // list, a table, or a bar/line chart). renderRichAgentText is the single
+        // shared entry point used by the refinement thread, the live streaming
+        // bubble, and (later) a general chat view. Everything is escaped before
+        // insertion, so untrusted model output cannot inject markup.
+
+        // extractRenderSpec splits an agent reply into prose and an optional parsed
+        // render-spec. Only the first ```render (or ~~~render) fence is honoured; a
+        // malformed block is ignored and its text left in the prose.
+        function extractRenderSpec(raw) {
+            const text = String(raw || "");
+            const re = /(^|\n)[ \t]*(```|~~~)[ \t]*render[ \t]*\n([\s\S]*?)\n[ \t]*\2[ \t]*(?=\n|$)/i;
+            const m = text.match(re);
+            if (!m) return { prose: text.trim(), spec: null };
+            let spec = null;
+            try {
+                const parsed = JSON.parse(m[3]);
+                if (parsed && Array.isArray(parsed.blocks) && parsed.blocks.length) spec = parsed;
+            } catch (_) { spec = null; }
+            if (!spec) return { prose: text.trim(), spec: null };
+            const prose = (text.slice(0, m.index) + text.slice(m.index + m[0].length)).trim();
+            return { prose, spec };
+        }
+
+        // streamingProse returns the portion of an in-progress reply safe to show live —
+        // everything before a (possibly still-streaming) ```render fence — so the raw
+        // JSON never flashes in the bubble while the model is typing it.
+        function streamingProse(raw) {
+            const s = String(raw || "");
+            const m = s.match(/(^|\n)[ \t]*(```|~~~)[ \t]*render/i);
+            return (m ? s.slice(0, m.index) : s);
+        }
+
+        // renderMarkdownLite renders a conservative markdown subset to safe HTML: it
+        // escapes first, then re-introduces inline code, bold, italic, links and breaks.
+        function renderMarkdownLite(text) {
+            let html = escapeHTML(text);
+            html = html.replace(/`([^`]+)`/g, (_, c) => "<code>" + c + "</code>");
+            html = html.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+            html = html.replace(/(^|[^*])\*([^*\n]+)\*/g, "$1<em>$2</em>");
+            html = html.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+                (_, t, u) => "<a href=\"" + u + "\" target=\"_blank\" rel=\"noopener noreferrer\">" + t + "</a>");
+            return html.replace(/\n/g, "<br>");
+        }
+
+        function renderListBlockHTML(block) {
+            const items = Array.isArray(block.items) ? block.items : [];
+            if (!items.length) return "";
+            const tag = block.ordered ? "ol" : "ul";
+            const lis = items.map((it) => "<li>" + renderMarkdownLite(String(it)) + "</li>").join("");
+            return "<" + tag + " class=\"render-list\">" + lis + "</" + tag + ">";
+        }
+
+        function renderTableBlockHTML(block) {
+            const cols = Array.isArray(block.columns) ? block.columns : [];
+            const rows = Array.isArray(block.rows) ? block.rows : [];
+            if (!cols.length && !rows.length) return "";
+            let html = "<div class=\"render-table-wrap\"><table class=\"render-table\">";
+            if (cols.length) {
+                html += "<thead><tr>" + cols.map((c) => "<th>" + escapeHTML(String(c)) + "</th>").join("") + "</tr></thead>";
+            }
+            html += "<tbody>" + rows.map((r) => {
+                const cells = Array.isArray(r) ? r : [r];
+                return "<tr>" + cells.map((c) => "<td>" + escapeHTML(String(c)) + "</td>").join("") + "</tr>";
+            }).join("") + "</tbody></table></div>";
+            return html;
+        }
+
+        // renderChartBlockHTML draws a small inline-SVG bar or line chart (no external
+        // dependency) from labels + named series.
+        function renderChartBlockHTML(block) {
+            const labels = Array.isArray(block.labels) ? block.labels.map(String) : [];
+            const series = Array.isArray(block.series) ? block.series.filter((s) => s && Array.isArray(s.data)) : [];
+            if (!series.length) return "";
+            const type = String(block.chartType || "bar").toLowerCase() === "line" ? "line" : "bar";
+            const W = 480, H = 240, padL = 36, padR = 12, padT = 12, padB = 28;
+            const plotW = W - padL - padR, plotH = H - padT - padB;
+            let max = 0;
+            series.forEach((s) => s.data.forEach((v) => { const n = Number(v) || 0; if (n > max) max = n; }));
+            if (max <= 0) max = 1;
+            const n = Math.max(1, labels.length, Math.max.apply(null, series.map((s) => s.data.length)));
+            const colors = ["#4f8cff", "#ff7d4f", "#39c486", "#c879ff", "#ffc24f"];
+            const xLine = (i) => padL + (n <= 1 ? plotW / 2 : (plotW * i) / (n - 1));
+            const groupW = plotW / n;
+            const labelX = (i) => type === "line" ? xLine(i) : padL + i * groupW + groupW / 2;
+            const y = (v) => padT + plotH - (plotH * (Number(v) || 0)) / max;
+            const axisY = padT + plotH;
+            let body = "<line x1=\"" + padL + "\" y1=\"" + axisY + "\" x2=\"" + (W - padR) + "\" y2=\"" + axisY + "\" class=\"render-chart-axis\"/>" +
+                "<line x1=\"" + padL + "\" y1=\"" + padT + "\" x2=\"" + padL + "\" y2=\"" + axisY + "\" class=\"render-chart-axis\"/>";
+            if (type === "line") {
+                series.forEach((s, si) => {
+                    const pts = s.data.map((v, i) => xLine(i).toFixed(1) + "," + y(v).toFixed(1)).join(" ");
+                    body += "<polyline class=\"render-chart-line\" fill=\"none\" stroke=\"" + colors[si % colors.length] + "\" points=\"" + pts + "\"/>";
+                });
+            } else {
+                const barW = Math.max(2, (groupW * 0.7) / series.length);
+                series.forEach((s, si) => {
+                    s.data.forEach((v, i) => {
+                        const bx = padL + i * groupW + groupW * 0.15 + si * barW;
+                        const by = y(v);
+                        const bh = Math.max(0, axisY - by);
+                        body += "<rect x=\"" + bx.toFixed(1) + "\" y=\"" + by.toFixed(1) + "\" width=\"" + barW.toFixed(1) + "\" height=\"" + bh.toFixed(1) + "\" fill=\"" + colors[si % colors.length] + "\"/>";
+                    });
+                });
+            }
+            labels.forEach((lab, i) => {
+                body += "<text class=\"render-chart-label\" x=\"" + labelX(i).toFixed(1) + "\" y=\"" + (H - 8) + "\" text-anchor=\"middle\">" + escapeHTML(lab) + "</text>";
+            });
+            let legend = "";
+            if (series.length > 1 || (series[0] && series[0].name)) {
+                legend = "<div class=\"render-chart-legend\">" + series.map((s, si) =>
+                    "<span class=\"render-chart-key\"><span class=\"render-chart-swatch\" style=\"background:" + colors[si % colors.length] + "\"></span>" +
+                    escapeHTML(String(s.name || ("series " + (si + 1)))) + "</span>").join("") + "</div>";
+            }
+            return "<div class=\"render-chart\"><svg viewBox=\"0 0 " + W + " " + H + "\" preserveAspectRatio=\"xMidYMid meet\" role=\"img\">" + body + "</svg>" + legend + "</div>";
+        }
+
+        function renderSpecBlocksHTML(spec) {
+            if (!spec || !Array.isArray(spec.blocks)) return "";
+            return spec.blocks.map((block) => {
+                if (!block || typeof block !== "object") return "";
+                switch (String(block.type || "").toLowerCase()) {
+                    case "text": return "<div class=\"render-text\">" + renderMarkdownLite(String(block.content || "")) + "</div>";
+                    case "list": return renderListBlockHTML(block);
+                    case "table": return renderTableBlockHTML(block);
+                    case "chart": return renderChartBlockHTML(block);
+                    default: return "";
+                }
+            }).join("");
+        }
+
+        // renderRichAgentText returns safe HTML for an agent message: prose rendered as
+        // light markdown plus any render-spec blocks. Degrades to plain prose when no
+        // (or a malformed) render block is present.
+        function renderRichAgentText(raw) {
+            const parsed = extractRenderSpec(raw);
+            let html = "";
+            if (parsed.prose) html += "<div class=\"render-prose\">" + renderMarkdownLite(parsed.prose) + "</div>";
+            if (parsed.spec) html += "<div class=\"render-blocks\">" + renderSpecBlocksHTML(parsed.spec) + "</div>";
+            if (!html) html = "<div class=\"render-prose\">" + escapeHTML(String(raw || "")) + "</div>";
+            return html;
+        }
+
         // humanizeSince renders a coarse elapsed time since a stored UTC timestamp
         // ("2026-06-22 18:08:52"), mirroring the CLI/TUI helper (TK-90).
         function humanizeSince(ts) {
@@ -8295,9 +8440,13 @@
                     const author = item.author || "user";
                     const isAgent = agents.has(String(author).toLowerCase()) || /refin/i.test(author);
                     const side = isAgent ? "agent" : "human";
+                    const rawText = item.text || item.comment || "";
+                    // Agent replies may carry a render-spec — render rich (tables,
+                    // lists, charts, markdown). Human turns stay plain text.
+                    const bodyHTML = isAgent ? renderRichAgentText(rawText) : escapeHTML(rawText);
                     return "<div class=\"refinement-bubble refinement-bubble-" + side + "\">" +
                         "<div class=\"refinement-author\">" + escapeHTML(author) + "</div>" +
-                        "<div class=\"refinement-text\">" + escapeHTML(item.text || item.comment || "") + "</div>" +
+                        "<div class=\"refinement-text\">" + bodyHTML + "</div>" +
                         (item.date ? "<div class=\"refinement-date\">" + escapeHTML(item.date) + "</div>" : "") +
                         "</div>";
                 }).join("");
@@ -8671,13 +8820,21 @@
                     setRefinementStatus("Refiner is responding…", true);
                     const node = ensureRefinementStreamingBubble();
                     if (node) {
-                        // Clear the "thinking" dots once real output begins.
                         const bubble = node.closest(".refinement-bubble");
+                        // Clear the "thinking" dots once real output begins.
                         if (bubble && bubble.classList.contains("refinement-thinking")) {
                             bubble.classList.remove("refinement-thinking");
-                            node.textContent = "";
+                            if (bubble) bubble.dataset.raw = "";
                         }
-                        node.textContent += String(payload.text || "");
+                        // Accumulate the raw reply but only show the prose portion live —
+                        // a streaming ```render block is hidden until message_done re-
+                        // renders the persisted reply richly.
+                        if (bubble) {
+                            bubble.dataset.raw = (bubble.dataset.raw || "") + String(payload.text || "");
+                            node.textContent = streamingProse(bubble.dataset.raw);
+                        } else {
+                            node.textContent += String(payload.text || "");
+                        }
                         refinementScrollToBottom();
                     }
                     return;


### PR DESCRIPTION
## Summary
Adds a `claude -p`-style structured-output capability to the chat/refiner experience: the model may append a single fenced ```` ```render ```` block holding a JSON render-spec describing how the browser should present its answer, so a prompt like "make a table" renders as an HTML **table**, **list**, **markdown**, or **chart** instead of plain text.

Refs TK-177. Follow-up: TK-178 (wire the standalone general chat view to reuse the renderer).

## Design (no schema change)
- The render-spec rides **inside the persisted comment text** as a ```` ```render ```` fence, so it survives thread reloads.
- A **single shared front-end renderer** (`renderRichAgentText` in `web/shared/app.js`) parses the fence — used by the live stream, the thread re-render, and any future general chat (one code path).
- Streaming stays live (prose shown token-by-token); the raw JSON is hidden mid-stream and the rich blocks appear on completion.

Render-spec shape:
```json
{"blocks":[
  {"type":"text","content":"markdown"},
  {"type":"list","ordered":false,"items":["a","b"]},
  {"type":"table","columns":["A","B"],"rows":[["1","2"]]},
  {"type":"chart","chartType":"bar","labels":["Q1"],"series":[{"name":"x","data":[1]}]}
]}
```

## Changes
- **Server** `internal/server/render_spec.go` (new): `renderSpecPromptGuidance` (prompt fragment teaching the model the protocol) + `sanitizeRenderBlock` (drops a malformed block before persistence so raw broken JSON never lands in the transcript). Wired into `buildServerRefinementPrompt` and `handleRefinementMessage`.
- **Front-end** `web/shared/app.js`: shared `renderRichAgentText` (extract spec, markdown-lite prose, list/table/inline-SVG bar+line chart), all XSS-safe (escape-first). Wired into the refinement thread (agent bubbles) and the live streaming bubble (raw JSON hidden mid-stream via `streamingProse`).
- **CSS** `web/default/site.css`: styles for render tables/lists/charts.
- **Docs** `docs/DESIGN_ORCHESTRATOR.md`: render-spec section.

## Tests
- Go unit (`render_spec_test.go`): prompt guidance, spec validation, sanitize/strip, fence extraction.
- Playwright smoke: a refiner reply with a render-spec yields a table + chart + list (and no raw JSON) in the thread.
- `make test`, `make test-api`, `make test-browser` (47 passed; 1 unrelated flaky), `make lint` (0 issues) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)